### PR TITLE
fix/SIGN2-148: removed default scrollbars and used `mac-scrollbar` for `connect-to-app` app

### DIFF
--- a/src/apps/connect-to-app/index.html
+++ b/src/apps/connect-to-app/index.html
@@ -10,7 +10,6 @@
 
   <style>
     div#connect-to-app-app-container {
-        overflow-y: auto;
         height: 100%;
     }
   </style>

--- a/src/apps/connect-to-app/layout/index.tsx
+++ b/src/apps/connect-to-app/layout/index.tsx
@@ -7,7 +7,6 @@ interface Props {
 }
 
 const Container = styled.div`
-  overflow-y: auto;
   height: 100%;
 `;
 


### PR DESCRIPTION
[Task #148]
There was an issue due to which standard scrollbars were displayed instead of `mac-scrollbar`.