### PR TITLE
Refactored. Used `selectVaultCountOfAccounts` in background

### DIFF
--- a/src/apps/popup/pages/home/index.tsx
+++ b/src/apps/popup/pages/home/index.tsx
@@ -28,7 +28,7 @@ import {
   selectConnectedAccountsWithOrigin,
   selectVaultActiveAccount,
   selectVaultActiveOrigin,
-  selectCountOfAccounts
+  selectVaultCountOfAccounts
 } from '@src/background/redux/vault/selectors';
 import { useAccountManager } from '@src/apps/popup/hooks/use-account-actions-with-events';
 
@@ -180,7 +180,7 @@ export function HomePageHeaderSubmenuItems({
   linkType
 }: HomePageHeaderSubmenuItemsProps) {
   const { t } = useTranslation();
-  const countOfAccounts = useSelector(selectCountOfAccounts);
+  const countOfAccounts = useSelector(selectVaultCountOfAccounts);
 
   return (
     <>

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -27,9 +27,9 @@ import {
   vaultUnlocked
 } from '@src/background/redux/vault/actions';
 import {
+  selectVaultCountOfAccounts,
   selectIsActiveAccountConnectedWithOrigin,
   selectIsAnyAccountConnectedWithOrigin,
-  selectVaultAccounts,
   selectVaultAccountsNames,
   selectVaultAccountsSecretKeysBase64,
   selectVaultActiveAccount,
@@ -70,8 +70,10 @@ browser.runtime.onMessage.addListener(
         switch (action.type) {
           case getType(sdkMessage.connectRequest): {
             let success = false;
-            const accounts = selectVaultAccounts(store.getState());
-            if (accounts.length > 0) {
+            const countOfAccounts = selectVaultCountOfAccounts(
+              store.getState()
+            );
+            if (countOfAccounts > 0) {
               openWindow({
                 purposeForOpening: PurposeForOpening.ConnectToApp,
                 query: { origin: action.payload }

--- a/src/background/redux/vault/selectors.ts
+++ b/src/background/redux/vault/selectors.ts
@@ -126,7 +126,7 @@ export const selectCountOfConnectedAccounts = createSelector(
   connectedAccounts => connectedAccounts.length
 );
 
-export const selectCountOfAccounts = createSelector(
+export const selectVaultCountOfAccounts = createSelector(
   selectVaultAccounts,
   accounts => accounts.length
 );


### PR DESCRIPTION
Used `selectVaultCountOfAccounts` selector instead of `selectVaultAccounts` and `accounts.length`