### PR TITLE
Typo on 'wrong secret phrase' error screen

### DIFF
--- a/src/apps/onboarding/pages/confirm-secret-phrase/index.tsx
+++ b/src/apps/onboarding/pages/confirm-secret-phrase/index.tsx
@@ -50,7 +50,7 @@ export function ConfirmSecretPhrasePage({
       navigate(
         ErrorPath,
         createErrorLocationState({
-          errorHeaderText: t("That's not the correct word order."),
+          errorHeaderText: t("That's not the correct word order"),
           errorContentText: t(
             'Please start over. Make sure you save your secret phrase as a text file or write it down somewhere.'
           ),


### PR DESCRIPTION
Changed text on an error page #421 

<img width="663" alt="image" src="https://user-images.githubusercontent.com/44294945/208238655-274a3e23-d535-4eeb-ab0a-fe6175572d7b.png">
