### PR TITLE
Added fixed width to popup layout container

### DIFF
--- a/src/libs/layout/popup-layout.tsx
+++ b/src/libs/layout/popup-layout.tsx
@@ -24,6 +24,7 @@ const Container = styled(FlexColumn)`
   height: 100%;
   height: -webkit-fill-available;
   min-height: 600px;
+  width: 360px;
 `;
 
 const PageHeader = styled.header``;


### PR DESCRIPTION
Fixed bug with extension screen size on Firefox

<img width="366" alt="image" src="https://user-images.githubusercontent.com/44294945/208456313-079d5c68-20f9-46bc-a6ea-b0c862b6c936.png">
<img width="366" alt="image" src="https://user-images.githubusercontent.com/44294945/208456362-310e7831-6cf3-41ce-be9a-a9e3adaa5286.png">
