### PR TITLE
"Switch Account" has different behaviours

### DIFF
--- a/src/apps/connect-to-app/pages/switch-account/content.tsx
+++ b/src/apps/connect-to-app/pages/switch-account/content.tsx
@@ -125,7 +125,7 @@ export function SwitchAccountContent() {
               )}
               marginLeftForItemSeparatorLine={60}
             />
-            {!!unconnectedAccountsList.length && (
+            {unconnectedAccountsList.length > 0 && (
               <List
                 headerLabel={t('Connect another account')}
                 rows={unconnectedAccountsList}

--- a/src/background/redux/vault/selectors.ts
+++ b/src/background/redux/vault/selectors.ts
@@ -51,8 +51,13 @@ export const selectVaultActiveAccountName = (state: RootState) =>
 export const selectVaultActiveAccount = createSelector(
   selectVaultAccounts,
   selectVaultActiveAccountName,
-  (accounts, activeAccountName) =>
-    accounts.find(account => account.name === activeAccountName)
+  (accounts, activeAccountName) => {
+    const activeAccount = accounts.find(
+      account => account.name === activeAccountName
+    );
+
+    return activeAccount;
+  }
 );
 
 export const selectVaultAccountNamesByOriginDict = (state: RootState) =>


### PR DESCRIPTION
#463 

- added list of unconnected accounts to the switch account page
- added possibility to connect unconnected accounts at  the switch account page

Also, I didn't change the logic when only one account is connected. It still shows the message `Only the active account is connected...`

<img width="375" alt="Знімок екрана 2023-02-01 о 16 48 41" src="https://user-images.githubusercontent.com/44294945/216077519-95c1206c-f4c2-4988-a81e-beaded92f8b4.png">
