### PR TITLE
Casper Signer is referenced during onboarding

### DIFF
--- a/src/apps/onboarding/pages/confirm-secret-phrase-success/content.tsx
+++ b/src/apps/onboarding/pages/confirm-secret-phrase-success/content.tsx
@@ -19,7 +19,7 @@ export function ConfirmSecretPhraseSuccessPageContent() {
       key: 3,
       value: (
         <Trans>
-          Be careful of phishing! Casper Signer will{' '}
+          Be careful of phishing! Casper Wallet will{' '}
           <Underline>never</Underline> spontaneously ask for your secret phrase.
         </Trans>
       )
@@ -30,7 +30,7 @@ export function ConfirmSecretPhraseSuccessPageContent() {
         'If you need to back up your secret phrase again, you can find it in Settings.'
       )
     },
-    { key: 5, value: t('Casper Signer cannot recover your secret phrase.') }
+    { key: 5, value: t('Casper Wallet cannot recover your secret phrase.') }
   ];
 
   return (


### PR DESCRIPTION
#501 

Replaced "Casper Signer" with "Casper Wallet"

<img width="516" alt="Знімок екрана 2023-02-08 о 15 21 29" src="https://user-images.githubusercontent.com/44294945/217541822-4cb4daa0-4e91-4a81-ba77-346de4341109.png">

