### PR TITLE
fix: double reveal password button on Edge

### DIFF
--- a/src/libs/ui/components/input/input.tsx
+++ b/src/libs/ui/components/input/input.tsx
@@ -72,6 +72,11 @@ const StyledInput = styled('input')<InputProps>(({ theme }) => ({
   },
   '::placeholder': {
     color: theme.color.contentSecondary
+  },
+  // Hiding the password reveal button in the MS Edge
+  // https://github.com/make-software/casper-wallet/issues/547
+  '::-ms-reveal': {
+    display: 'none'
   }
 }));
 


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

- Hid the password reveal button in the MS Edge

## Linked tickets

#547 

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [ ] Include a screenshot or recording if implementing significant UI or user flow change

- [ ] When this PR affects architecture changes wait for review from Piotr before merging
