### PR TITLE
fix: show account balance when the currency rate service is down

### DIFF
--- a/src/apps/popup/pages/home/index.tsx
+++ b/src/apps/popup/pages/home/index.tsx
@@ -139,7 +139,7 @@ export function HomePageContent() {
               ? formatCurrency(motesToCurrency(balance, currencyRate), 'USD', {
                   precision: 2
                 })
-              : '-';
+              : t('Currency service is offline...');
 
           setBalance({ amount, fiatAmount });
         }


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

removed dependency on the account balance to the currency rate

## Linked tickets

#605 

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [x] Include a screenshot or recording if implementing significant UI or user flow change

- [ ] When this PR affects architecture changes wait for review from Piotr before merging

<img width="360" alt="Знімок екрана 2023-03-30 о 11 24 26" src="https://user-images.githubusercontent.com/44294945/228775789-f96aefb0-d417-4bbe-9997-72416c711729.png">

