### PR TITLE
feature: add private key download disabled message for Safari

### DIFF
--- a/src/apps/import-account-with-file/pages/import-account-with-file/content.tsx
+++ b/src/apps/import-account-with-file/pages/import-account-with-file/content.tsx
@@ -8,6 +8,7 @@ import {
   SpacingSize
 } from '@src/libs/layout';
 import { SvgIcon, Tag, Typography } from '@libs/ui';
+import { isSafariBrowser } from '@src/utils';
 
 export function ImportAccountWithFileContentPage() {
   const { t } = useTranslation();
@@ -35,6 +36,18 @@ export function ImportAccountWithFileContentPage() {
           </Trans>
         </Typography>
       </ParagraphContainer>
+      {/* https://github.com/make-software/casper-wallet/issues/611 */}
+      {isSafariBrowser && (
+        <ParagraphContainer top={SpacingSize.Small}>
+          <Typography type="body" color="contentSecondary">
+            <Trans t={t}>
+              Important: After importing, private key files cannot be downloaded
+              from Casper Wallet. Make sure to store a copy of your secret key
+              file in a safe place.
+            </Trans>
+          </Typography>
+        </ParagraphContainer>
+      )}
     </ContentContainer>
   );
 }

--- a/src/apps/popup/pages/navigation-menu/index.tsx
+++ b/src/apps/popup/pages/navigation-menu/index.tsx
@@ -24,14 +24,17 @@ import { selectTimeoutDurationSetting } from '@src/background/redux/settings/sel
 import { dispatchToMainStore } from '@src/background/redux/utils';
 import { lockVault } from '@src/background/redux/sagas/actions';
 import { TimeoutDurationSetting } from '@popup/constants';
+import { isSafariBrowser } from '@src/utils';
 
 interface ListItemClickableContainerProps {
   disabled: boolean;
+  hide?: boolean;
 }
 
 const ListItemClickableContainer = styled(
   BaseListItemClickableContainer
 )<ListItemClickableContainerProps>`
+  display: ${({ hide }) => hide && 'none'};
   align-items: center;
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
 
@@ -53,6 +56,7 @@ interface MenuItem {
   disabled: boolean;
   currentValue?: string | number;
   handleOnClick?: () => void;
+  hide?: boolean;
 }
 
 interface MenuGroup {
@@ -161,6 +165,8 @@ export function NavigationMenuPageContent() {
             description: t('For all accounts imported via file'),
             iconPath: 'assets/icons/download.svg',
             disabled: !vaultHasImportedAccount,
+            // https://github.com/make-software/casper-wallet/issues/611
+            hide: isSafariBrowser,
             handleOnClick: () => {
               closeNavigationMenu();
               navigate(RouterPath.DownloadSecretKeys);
@@ -215,6 +221,7 @@ export function NavigationMenuPageContent() {
               href={groupItem.href ? groupItem.href : undefined}
               target={groupItem.href ? '_blank' : undefined}
               onClick={groupItem.disabled ? undefined : groupItem.handleOnClick}
+              hide={groupItem.hide}
             >
               <SvgIcon
                 src={groupItem.iconPath}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,12 @@ export enum CasperApiUrl {
 }
 
 export enum NetworkSetting {
-  'Mainnet' = 'Mainnet',
-  'Testnet' = 'Testnet'
+  Mainnet = 'Mainnet',
+  Testnet = 'Testnet'
+}
+
+export enum Browser {
+  Safari = 'safari',
+  Chrome = 'chrome',
+  Firefox = 'firefox'
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { Browser } from '@src/constants';
+
 const httpPrefixRegex = /^https?:\/\//;
 
 export const hasHttpPrefix = (url: string) => httpPrefixRegex.test(url);
@@ -8,3 +10,5 @@ export const getUrlOrigin = (url: string) => {
   }
   return new URL(url).origin;
 };
+
+export const isSafariBrowser = process.env.BROWSER === Browser.Safari;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -164,7 +164,8 @@ const options = {
     // expose and write the allowed env vars on the compiled bundle
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-      'process.env.MOCK_STATE': JSON.stringify(process.env.MOCK_STATE)
+      'process.env.MOCK_STATE': JSON.stringify(process.env.MOCK_STATE),
+      'process.env.BROWSER': JSON.stringify(process.env.BROWSER)
     }),
     // manifest file generation
     new CopyWebpackPlugin({


### PR DESCRIPTION
## Description

- Added warning message
- Hidden the "Download secret key file" for Safari

## Linked tickets

#611 

## Checklist

- [X] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [X] Include a screenshot or recording if implementing significant UI or user flow change

- [ ] When this PR affects architecture changes wait for review from Piotr before merging


<img width="375" alt="Знімок екрана 2023-04-06 о 13 15 42" src="https://user-images.githubusercontent.com/44294945/230371504-66da312f-be87-4652-80bc-c592b6b1fe64.png">
<img width="358" alt="Знімок екрана 2023-04-06 о 13 16 00" src="https://user-images.githubusercontent.com/44294945/230371528-1b5ca8f3-e937-4dbf-a78a-8d522582bfaa.png">

