### PR TITLE
fix: stop opening terms links in the same window on Safari

### DIFF
--- a/src/apps/import-account-with-file/pages/import-account-with-file/content.tsx
+++ b/src/apps/import-account-with-file/pages/import-account-with-file/content.tsx
@@ -8,7 +8,7 @@ import {
   SpacingSize
 } from '@src/libs/layout';
 import { SvgIcon, Tag, Typography } from '@libs/ui';
-import { isSafariBrowser } from '@src/utils';
+import { isSafariBuild } from '@src/utils';
 
 export function ImportAccountWithFileContentPage() {
   const { t } = useTranslation();
@@ -37,7 +37,7 @@ export function ImportAccountWithFileContentPage() {
         </Typography>
       </ParagraphContainer>
       {/* https://github.com/make-software/casper-wallet/issues/611 */}
-      {isSafariBrowser && (
+      {isSafariBuild && (
         <ParagraphContainer top={SpacingSize.Small}>
           <Typography type="body" color="contentSecondary">
             <Trans t={t}>

--- a/src/apps/onboarding/pages/create-vault-password/index.tsx
+++ b/src/apps/onboarding/pages/create-vault-password/index.tsx
@@ -20,6 +20,7 @@ import { useTypedNavigate } from '@src/apps/onboarding/router/use-typed-navigate
 import { selectPasswordHash } from '@src/background/redux/keys/selectors';
 import { initKeys } from '@src/background/redux/sagas/actions';
 import { dispatchToMainStore } from '@background/redux/utils';
+import { TermsLink } from '@src/constants';
 
 import { CreateVaultPasswordPageContent } from './content';
 
@@ -54,10 +55,10 @@ export function CreateVaultPasswordPage({
       <Link
         onClick={event => {
           event.stopPropagation();
+          event.preventDefault();
+          window.open(TermsLink.Tos, '_blank');
         }}
         color="fillBlue"
-        target="_blank"
-        href="https://www.casperwallet.io/tos"
       >
         Casper Wallet Terms of Service
       </Link>{' '}
@@ -65,10 +66,10 @@ export function CreateVaultPasswordPage({
       <Link
         onClick={event => {
           event.stopPropagation();
+          event.preventDefault();
+          window.open(TermsLink.Privacy, '_blank');
         }}
         color="fillBlue"
-        target="_blank"
-        href="https://www.casperwallet.io/privacy"
       >
         Privacy Policy
       </Link>

--- a/src/apps/popup/pages/navigation-menu/index.tsx
+++ b/src/apps/popup/pages/navigation-menu/index.tsx
@@ -24,7 +24,7 @@ import { selectTimeoutDurationSetting } from '@src/background/redux/settings/sel
 import { dispatchToMainStore } from '@src/background/redux/utils';
 import { lockVault } from '@src/background/redux/sagas/actions';
 import { TimeoutDurationSetting } from '@popup/constants';
-import { isSafariBrowser } from '@src/utils';
+import { isSafariBuild } from '@src/utils';
 
 interface ListItemClickableContainerProps {
   disabled: boolean;
@@ -166,7 +166,7 @@ export function NavigationMenuPageContent() {
             iconPath: 'assets/icons/download.svg',
             disabled: !vaultHasImportedAccount,
             // https://github.com/make-software/casper-wallet/issues/611
-            hide: isSafariBrowser,
+            hide: isSafariBuild,
             handleOnClick: () => {
               closeNavigationMenu();
               navigate(RouterPath.DownloadSecretKeys);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,3 +30,8 @@ export enum Browser {
   Chrome = 'chrome',
   Firefox = 'firefox'
 }
+
+export enum TermsLink {
+  Tos = 'https://www.casperwallet.io/tos',
+  Privacy = 'https://www.casperwallet.io/privacy'
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,4 +11,4 @@ export const getUrlOrigin = (url: string) => {
   return new URL(url).origin;
 };
 
-export const isSafariBrowser = process.env.BROWSER === Browser.Safari;
+export const isSafariBuild = process.env.BROWSER === Browser.Safari;


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

- fixed terms links opening
- renamed `isSafariBrowser` to `isSafariBuild`

## Linked tickets

#624 

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [ ] Include a screenshot or recording if implementing significant UI or user flow change

- [ ] When this PR affects architecture changes wait for review from Piotr before merging
