### PR TITLE
feature: add display full recipient hash in the send tokens flow

### DIFF
--- a/src/apps/popup/pages/transfer/confirm-step.tsx
+++ b/src/apps/popup/pages/transfer/confirm-step.tsx
@@ -10,12 +10,11 @@ import {
   SpacingSize,
   TransferInputContainer
 } from '@libs/layout';
-import { Input, List, Typography } from '@libs/ui';
+import { FormField, List, TextArea, Typography } from '@libs/ui';
 import {
   AmountContainer,
   SenderDetails
 } from '@popup/pages/transfer/sender-details';
-import { truncateKey } from '@libs/ui/components/hash/utils';
 import {
   formatFiatAmount,
   formatNumber,
@@ -84,12 +83,13 @@ export const ConfirmStep = ({
       </ParagraphContainer>
       <SenderDetails />
       <TransferInputContainer>
-        <Input
-          monotype
-          readOnly
-          label={recipientLabel}
-          value={truncateKey(recipientPublicKey, { size: 'max' })}
-        />
+        <FormField label={recipientLabel}>
+          <TextArea
+            value={recipientPublicKey}
+            readOnly
+            style={{ minHeight: '78px' }}
+          />
+        </FormField>
       </TransferInputContainer>
       <List
         contentTop={SpacingSize.XXXL}


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

- added display of the full recipient hash in the Recipient field

## Linked tickets

[WALLET-102](https://make-software.atlassian.net/browse/WALLET-102)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [x] Include a screenshot or recording if implementing significant UI or user flow change

- [ ] When this PR affects architecture changes wait for review from Piotr before merging


<img width="348" alt="image" src="https://github.com/make-software/casper-wallet/assets/44294945/0cd7d09c-b427-4e2e-b018-802c2699f47d">


[WALLET-102]: https://make-software.atlassian.net/browse/WALLET-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ