### PR TITLE
fix: fix token balance displaying

### DIFF
--- a/src/apps/popup/pages/activity-details/content.tsx
+++ b/src/apps/popup/pages/activity-details/content.tsx
@@ -113,7 +113,7 @@ export const ActivityDetailsPageContent = ({
 
   const transferAmount =
     deployInfo.amount != null
-      ? decimals
+      ? Number.isInteger(decimals) && decimals != null
         ? divideErc20Balance(deployInfo?.amount, decimals)
         : motesToCSPR(deployInfo.amount)
       : '-';

--- a/src/hooks/use-casper-token/use-casper-token.ts
+++ b/src/hooks/use-casper-token/use-casper-token.ts
@@ -24,7 +24,9 @@ export const useCasperToken = () => {
   const amount =
     balance?.amountMotes == null
       ? '-'
-      : formatNumber(motesToCSPR(balance.amountMotes));
+      : formatNumber(motesToCSPR(balance.amountMotes), {
+          precision: { max: 5 }
+        });
 
   useEffect(() => {
     setCasperToken({

--- a/src/libs/ui/components/account-activity-plate/account-activity-plate.tsx
+++ b/src/libs/ui/components/account-activity-plate/account-activity-plate.tsx
@@ -87,8 +87,8 @@ export const AccountActivityPlate = forwardRef<Ref, AccountActivityPlateProps>(
     const activeAccount = useSelector(selectVaultActiveAccount);
 
     const { deployHash, callerPublicKey, timestamp, args } = transactionInfo;
-    let decimals = null;
-    let symbol = null;
+    let decimals: number | undefined;
+    let symbol: string | undefined;
     let toAccountPublicKey = '';
     let toAccountHash = '';
 
@@ -109,9 +109,10 @@ export const AccountActivityPlate = forwardRef<Ref, AccountActivityPlateProps>(
 
     const parsedAmount = (args.amount?.parsed as string) || '';
 
-    const amount = decimals
-      ? divideErc20Balance(parsedAmount, decimals)
-      : motesToCSPR(parsedAmount);
+    const amount =
+      Number.isInteger(decimals) && decimals != null
+        ? divideErc20Balance(parsedAmount, decimals)
+        : motesToCSPR(parsedAmount);
 
     const formattedAmount = formatNumber(amount || '', {
       precision: { min: 5 }


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

- removed the Casper token rounded balance from the Tokens tab
- fixed displaying tokens balance in the activity plate and activity details when a decimal is equal to 0

## Linked tickets

[WALLET-91](https://make-software.atlassian.net/browse/WALLET-91)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [ ] Include a screenshot or recording if implementing significant UI or user flow change

- [ ] When this PR affects architecture changes wait for review from Piotr before merging

<img width="1160" alt="image" src="https://github.com/make-software/casper-wallet/assets/44294945/445c5fe2-325d-4f2e-82be-00cb3a095684">
<img width="323" alt="image" src="https://github.com/make-software/casper-wallet/assets/44294945/1b7c6d91-35fa-4ea3-abc9-b7bb00a79ab5">
<img width="323" alt="image" src="https://github.com/make-software/casper-wallet/assets/44294945/f67bbf9f-8c8c-4ea2-a081-dcb82d639b77">


[WALLET-91]: https://make-software.atlassian.net/browse/WALLET-91?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ