### PR TITLE
fix: remove the tooltip with the full public key when the user has only one account

### DIFF
--- a/src/libs/ui/components/account-list/account-list.tsx
+++ b/src/libs/ui/components/account-list/account-list.tsx
@@ -133,6 +133,7 @@ export const AccountList = ({ closeModal }: AccountListProps) => {
                     value={account.publicKey}
                     variant={HashVariant.CaptionHash}
                     truncated
+                    withoutTooltip={accountListRows.length === 1}
                     withTag={account.imported}
                     placement={
                       index === accountListRows.length - 1


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

- removed the tooltip with the full public key when the user has only one account

## Linked tickets

[WALLET-197](https://make-software.atlassian.net/browse/WALLET-197)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [ ] Include a screenshot or recording if implementing significant UI or user flow change

- [ ] When this PR affects architecture changes wait for review from Dmytro before merging
