### PR TITLE
fix: fix wallet setup kick-off automatically in the Reset Wallet flow

### DIFF
--- a/src/background/close-window-by-reload-extension.ts
+++ b/src/background/close-window-by-reload-extension.ts
@@ -1,10 +1,22 @@
 import browser from 'webextension-polyfill';
 
+import { isFirefoxBuild, isSafariBuild } from '@src/utils';
+
 // It's hacky for Safari browser => browser.runtime.reload();
 // window.close() method can only be called on windows that were opened by a script using the Window.open() method.
 // If the window was > not opened by a script, an error similar to this one appears in the console:
 // Scripts may not close windows that were not opened by script
 // WARNING: IT WILL RELOAD ENTIRE EXTENSION
 export function closeWindowByReloadExtension() {
-  browser.runtime.reload();
+  if (isSafariBuild) {
+    browser.tabs.create({ url: 'onboarding.html', active: true });
+    browser.runtime.reload();
+    return;
+  }
+  if (isFirefoxBuild) {
+    browser.runtime.reload();
+    return;
+  }
+  window.close();
+  browser.tabs.create({ url: 'onboarding.html', active: true });
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,6 +27,7 @@ export const getUrlOrigin = (url: string | undefined) => {
 };
 
 export const isSafariBuild = process.env.BROWSER === Browser.Safari;
+export const isFirefoxBuild = process.env.BROWSER === Browser.Firefox;
 
 export const isValidU64 = (value?: string): boolean => {
   if (!value) {


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

- fixed issue with auto launching onboarding after wallet reset

## Linked tickets

[WALLET-220](https://make-software.atlassian.net/browse/WALLET-220)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [ ] Include a screenshot or recording if implementing significant UI or user flow change

- [ ] When this PR affects architecture changes wait for review from Dmytro before merging
