### PR TITLE
feature: show staked balance in list of stakes on "undelegate" page

### DIFF
--- a/src/libs/ui/components/validator-dropdown-input/validator-dropdown-input.tsx
+++ b/src/libs/ui/components/validator-dropdown-input/validator-dropdown-input.tsx
@@ -8,7 +8,7 @@ import {
   SpacingSize,
   VerticalSpaceContainer
 } from '@src/libs/layout';
-import { SvgIcon, Input, List, ValidatorPlate, Typography } from '@libs/ui';
+import { Input, List, SvgIcon, Typography, ValidatorPlate } from '@libs/ui';
 import { StakeValidatorFormValues } from '@libs/ui/forms/stakes-form';
 import { useClickAway } from '@libs/ui/hooks/use-click-away';
 import { ValidatorResultWithId } from '@libs/services/validators-service/types';
@@ -152,7 +152,12 @@ export const ValidatorDropdownInput = ({
         fee={validator.fee}
         name={validator?.account_info?.info?.owner?.name}
         logo={validator?.account_info?.info?.owner?.branding?.logo?.svg}
-        totalStake={validator.total_stake}
+        // TODO: remove user_stake after we merge recipient and amount steps for undelegation
+        totalStake={
+          stakesType === AuctionManagerEntryPoint.undelegate
+            ? validator.user_stake
+            : validator.total_stake
+        }
         delegatorsNumber={validator?.delegators_number}
         validatorLabel={label}
         error={errors?.validatorPublicKey}
@@ -209,7 +214,12 @@ export const ValidatorDropdownInput = ({
               fee={validator.fee}
               name={validator?.account_info?.info?.owner?.name}
               logo={validator?.account_info?.info?.owner?.branding?.logo?.svg}
-              totalStake={validator.total_stake}
+              // TODO: remove user_stake after we merge recipient and amount steps for undelegation
+              totalStake={
+                stakesType === AuctionManagerEntryPoint.undelegate
+                  ? validator.user_stake
+                  : validator.total_stake
+              }
               delegatorsNumber={validator?.delegators_number}
               handleClick={async () => {
                 setValue('validatorPublicKey', validator.public_key);


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

- showed user stake amount for validator on undelegate page

## Linked tickets

[WALLET-237](https://make-software.atlassian.net/browse/WALLET-237)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [x] Include a screenshot or recording if implementing significant UI or user flow change

- [x] When this PR affects architecture changes wait for review from Dmytro before merging


<img width="347" alt="image" src="https://github.com/make-software/casper-wallet/assets/44294945/c0110b99-a2c4-4dd6-a220-a7fff67c6e58">