### PR TITLE
feature: update secret phrase validation and recovery for 12 and 24 words

### DIFF
--- a/e2e-tests/constants.ts
+++ b/e2e-tests/constants.ts
@@ -1,8 +1,10 @@
 import path from 'path';
 
 export const vaultPassword = '3hQqzYn4C7Y8rEZTVEZb';
-export const recoverSecretPhrase =
+export const twentyFourWordsSecretPhrase =
   'hold matrix spider subway bottom jazz charge fire lawn valley stay coil moral hospital dream cycle multiply december agree huge major tower devote old';
+export const twelveWordsSecretPhrase =
+  'small vendor member cry motion lava hurdle gravity cry sentence medal seminar';
 export const secretKeyPath = path.join(__dirname, './account_secret_key.pem');
 
 export const ACCOUNT_NAMES = {
@@ -37,6 +39,13 @@ export const DEFAULT_SECOND_ACCOUNT = {
     '0203b2e05f074452f5e69ba512310deceaca152ebd3394eadcec26c6e68e91aa7724',
   truncatedPublicKey: '0203b...a7724',
   mediumTruncatedPublicKey: '0203b2e05f...8e91aa7724'
+};
+
+export const RECOVER_ACCOUNT_FROM_TWELVE_WORDS = {
+  accountName: 'Account 1',
+  publicKey:
+    '0202b869dbed03ef2cc6a76e54e1a5c588fbe6198f80937994f9a2c1fd3aff4adc1b',
+  truncatedPublicKey: '0202b...adc1b'
 };
 
 export const VALIDATOR = {

--- a/e2e-tests/onboarding-flow/recover-secret-phrase-flow.spec.ts
+++ b/e2e-tests/onboarding-flow/recover-secret-phrase-flow.spec.ts
@@ -1,9 +1,14 @@
-import { onboardingExpect, onboarding } from '../fixtures';
-import { DEFAULT_FIRST_ACCOUNT, recoverSecretPhrase } from '../constants';
+import {
+  DEFAULT_FIRST_ACCOUNT,
+  RECOVER_ACCOUNT_FROM_TWELVE_WORDS,
+  twelveWordsSecretPhrase,
+  twentyFourWordsSecretPhrase
+} from '../constants';
+import { onboarding, onboardingExpect } from '../fixtures';
 
 onboarding.describe('Onboarding UI: recover secret phrase flow', () => {
   onboarding(
-    'should recover account via secret phrase',
+    'should recover account via 24 words secret phrase',
     async ({ page, createOnboardingPassword, extensionId }) => {
       await createOnboardingPassword();
 
@@ -19,7 +24,7 @@ onboarding.describe('Onboarding UI: recover secret phrase flow', () => {
 
       await page
         .getByPlaceholder('e.g. Bobcat Lemon Blanket…')
-        .fill(recoverSecretPhrase);
+        .fill(twentyFourWordsSecretPhrase);
 
       await page.getByRole('button', { name: 'Recover my wallet' }).click();
 
@@ -30,6 +35,39 @@ onboarding.describe('Onboarding UI: recover secret phrase flow', () => {
       ).toBeVisible();
       await onboardingExpect(
         page.getByText(DEFAULT_FIRST_ACCOUNT.truncatedPublicKey).nth(0)
+      ).toBeVisible();
+    }
+  );
+  onboarding(
+    'should recover account via 12 words secret phrase',
+    async ({ page, createOnboardingPassword, extensionId }) => {
+      await createOnboardingPassword();
+
+      await page
+        .getByRole('button', {
+          name: 'Import an existing secret recovery phrase'
+        })
+        .click();
+
+      await onboardingExpect(
+        page.getByText('Please enter your secret recovery phrase')
+      ).toBeVisible();
+
+      await page
+        .getByPlaceholder('e.g. Bobcat Lemon Blanket…')
+        .fill(twelveWordsSecretPhrase);
+
+      await page.getByRole('button', { name: 'Recover my wallet' }).click();
+
+      await page.goto(`chrome-extension://${extensionId}/popup.html`);
+
+      await onboardingExpect(
+        page.getByText(RECOVER_ACCOUNT_FROM_TWELVE_WORDS.accountName)
+      ).toBeVisible();
+      await onboardingExpect(
+        page
+          .getByText(RECOVER_ACCOUNT_FROM_TWELVE_WORDS.truncatedPublicKey)
+          .nth(0)
       ).toBeVisible();
     }
   );

--- a/src/apps/onboarding/pages/recover-from-secret-phrase/content.tsx
+++ b/src/apps/onboarding/pages/recover-from-secret-phrase/content.tsx
@@ -34,8 +34,8 @@ export function RecoverFromSecretPhrasePageContent({
       <TabTextContainer>
         <Typography type="body" color="contentSecondary">
           <Trans t={t}>
-            Recover your wallet by entering each word of your 24-word secret
-            recovery phrase, separated by spaces.
+            Recover your wallet by entering each word of your 12-word or 24-word
+            secret recovery phrase, separated by spaces.
           </Trans>
         </Typography>
       </TabTextContainer>

--- a/src/apps/popup/index.html
+++ b/src/apps/popup/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'; script-src 'self'; style-src 'unsafe-inline'; img-src https: data:; media-src https: data:; connect-src https://event-store-api-clarity-testnet.make.services https://event-store-api-clarity-mainnet.make.services https://casper-assets.s3.amazonaws.com/ https://image-proxy-cdn.make.services/ https://casper-testnet-node-proxy.make.services/rpc https://casper-node-proxy.make.services/rpc"
+      content="default-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'; script-src 'self'; style-src 'unsafe-inline'; img-src https: data:; media-src https: data:; connect-src https://event-store-api-clarity-testnet.make.services https://event-store-api-clarity-mainnet.make.services https://casper-assets.s3.amazonaws.com/ https://image-proxy-cdn.make.services/ https://casper-testnet-node-proxy.make.services/rpc https://casper-node-proxy.make.services/rpc https://cspr-wallet-api.dev.make.services/ https://api.casperwallet.io/"
     />
 
     <link rel="stylesheet" href="/assets/fonts/fonts.css" />

--- a/src/libs/ui/forms/form-validation-rules.ts
+++ b/src/libs/ui/forms/form-validation-rules.ts
@@ -79,10 +79,16 @@ export function useRepeatPasswordRule(inputName: string) {
 
 export function useValidSecretPhraseRule() {
   const { t } = useTranslation();
-  const errorMessage = t('There should be 24 words in a valid secret phrase.');
+  const errorMessage = t(
+    'There should be 12 or 24 words in a valid secret phrase.'
+  );
 
   return Yup.string().test('unique', errorMessage, value => {
-    return value != null && value.trim().split(' ').length === 24;
+    return (
+      value != null &&
+      (value.trim().split(' ').length === 24 ||
+        value.trim().split(' ').length === 12)
+    );
   });
 }
 

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "content_security_policy": "default-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'unsafe-inline'; img-src https: data:; media-src https: data:; connect-src https://event-store-api-clarity-testnet.make.services https://event-store-api-clarity-mainnet.make.services https://casper-assets.s3.amazonaws.com/ https://image-proxy-cdn.make.services/ https://casper-testnet-node-proxy.make.services/rpc https://casper-node-proxy.make.services/rpc",
+  "content_security_policy": "default-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'unsafe-inline'; img-src https: data:; media-src https: data:; connect-src https://event-store-api-clarity-testnet.make.services https://event-store-api-clarity-mainnet.make.services https://casper-assets.s3.amazonaws.com/ https://image-proxy-cdn.make.services/ https://casper-testnet-node-proxy.make.services/rpc https://casper-node-proxy.make.services/rpc https://cspr-wallet-api.dev.make.services/ https://api.casperwallet.io/",
   "icons": {
     "16": "logo16.png",
     "64": "logo64.png",

--- a/src/manifest.v3.json
+++ b/src/manifest.v3.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "content_security_policy": {
-    "extension_pages": "default-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'unsafe-inline'; img-src https: data:; media-src https: data:; connect-src https://event-store-api-clarity-testnet.make.services https://event-store-api-clarity-mainnet.make.services https://casper-assets.s3.amazonaws.com/ https://image-proxy-cdn.make.services/ https://casper-testnet-node-proxy.make.services/rpc https://casper-node-proxy.make.services/rpc"
+    "extension_pages": "default-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'unsafe-inline'; img-src https: data:; media-src https: data:; connect-src https://event-store-api-clarity-testnet.make.services https://event-store-api-clarity-mainnet.make.services https://casper-assets.s3.amazonaws.com/ https://image-proxy-cdn.make.services/ https://casper-testnet-node-proxy.make.services/rpc https://casper-node-proxy.make.services/rpc https://cspr-wallet-api.dev.make.services/ https://api.casperwallet.io/"
   },
   "icons": {
     "16": "logo16.png",


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

- Updated secret phrase validation and recovery process to accept both 12-word and 24-word phrases.
- End-to-end tests have been updated to account for the new 12-word phrase recovery method.
- Updated CORS to fix issue with staked balance for Firefox

## Linked tickets

[WALLET-259](https://make-software.atlassian.net/browse/WALLET-259)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [ ] Include a screenshot or recording if implementing significant UI or user flow change

- [ ] When this PR affects architecture changes wait for review from Dmytro before merging
