### PR TITLE
fix: fix account hash hint is overlapped by loading animation of stakes balance

### DIFF
--- a/src/libs/ui/components/tooltip/tooltip.tsx
+++ b/src/libs/ui/components/tooltip/tooltip.tsx
@@ -27,7 +27,7 @@ const TooltipTip = styled.div<{ placement: Placement }>(
   ({ theme, placement }) => ({
     position: 'absolute',
 
-    zIndex: 1,
+    zIndex: 2,
 
     ...(placement === 'topCenter' && {
       left: '50%',


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

- fix account hash hint is overlapped by loading animation of stakes balance

## Linked tickets

[WALLET-272](https://make-software.atlassian.net/browse/WALLET-272)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [ ] Include a screenshot or recording if implementing significant UI or user flow change

- [ ] When this PR affects architecture changes wait for review from Dmytro before merging
