### PR TITLE
feature: update 'Sign:Response' with additional error handling

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -9,7 +9,11 @@ import {
   windows
 } from 'webextension-polyfill';
 
-import { getUrlOrigin, hasHttpPrefix } from '@src/utils';
+import {
+  getUrlOrigin,
+  hasHttpPrefix,
+  isEqualCaseInsensitive
+} from '@src/utils';
 
 import { CasperDeploy } from '@signature-request/pages/sign-deploy/deploy-types';
 
@@ -359,8 +363,7 @@ runtime.onMessage.addListener(
 
             const isDeployAlreadySigningWithThisAccount = deploy.approvals.some(
               approvals =>
-                approvals.signer.toLowerCase() ===
-                signingPublicKeyHex.toLowerCase()
+                isEqualCaseInsensitive(approvals.signer, signingPublicKeyHex)
             );
 
             if (isDeployAlreadySigningWithThisAccount) {

--- a/src/content/sdk-method.ts
+++ b/src/content/sdk-method.ts
@@ -41,8 +41,7 @@ export const sdkMethod = {
     Meta
   >(),
   signResponse: createAction('CasperWalletProvider:Sign:Response')<
-    | { cancelled: true }
-    | { cancelled: true; message: string }
+    | { cancelled: true; message?: string }
     | { cancelled: false; signatureHex: string },
     Meta
   >(),

--- a/src/content/sdk.ts
+++ b/src/content/sdk.ts
@@ -11,6 +11,7 @@ import {
 export type SignatureResponse =
   | {
       cancelled: true; // if sign was cancelled
+      message?: string;
     }
   | {
       cancelled: false; // if sign was successfull

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -312,7 +312,7 @@ export const findMediaPreview = (metadata: NFTTokenMetadataEntry): boolean => {
   return hasImageExtension || knownImageKey;
 };
 
-const isEqualCaseInsensitive = (key1: string, key2: string) => {
+export const isEqualCaseInsensitive = (key1: string, key2: string) => {
   return key1.toLowerCase() === key2.toLowerCase();
 };
 


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

Modified 'Sign:Response' so that it now includes a 'cancelled' scenario where an optional error message can be attached. Also, a utility function has been added to the background that checks if a deploy was signed with a particular account already. This will be helpful in scenarios where duplicate signatures have to be prevented from the same account while signing a deploy.

## Linked tickets

[WALLET-280](https://make-software.atlassian.net/browse/WALLET-280)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [ ] Include a screenshot or recording if implementing significant UI or user flow change

- [x] When this PR affects architecture changes wait for review from Dmytro before merging


[WALLET-280]: https://make-software.atlassian.net/browse/WALLET-280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ