### PR TITLE
fix: add handle for large fiat amount 

### DIFF
--- a/src/apps/popup/pages/activity-details/content.tsx
+++ b/src/apps/popup/pages/activity-details/content.tsx
@@ -171,7 +171,7 @@ export const ActivityDetailsPageContent = ({
     precision: { min: 5 }
   });
   const costAmountInUSD = formatCurrency(
-    deployInfo.currencyCost || '0',
+    String(deployInfo.currencyCost) || '0',
     'USD',
     {
       precision: 5

--- a/src/libs/ui/utils/formatters.ts
+++ b/src/libs/ui/utils/formatters.ts
@@ -179,9 +179,8 @@ export const motesToCurrency = (
   const billion = new Big(10).pow(9);
 
   if (amount.gte(billion)) {
-    // If the value is greater than or equal to 10^9, return empty string.
-    // TODO: Clarify future behavior for large fiat amount
-    return '';
+    // If the value is greater than or equal to 10^9, return one billion string.
+    return '1000000000';
   }
 
   return amount.toString();
@@ -200,7 +199,7 @@ export function capitalizeString(str: string): string {
 }
 
 export const formatCurrency = (
-  value: number | string,
+  value: string,
   code: string,
   {
     precision
@@ -208,12 +207,16 @@ export const formatCurrency = (
     precision?: number;
   } = {}
 ): string => {
-  return intl.formatNumber(value as number, {
+  const formattedValue = intl.formatNumber(Number(value), {
     style: 'currency',
     currency: code,
     minimumFractionDigits: precision,
     maximumFractionDigits: precision
   });
+  // Check if the original value is '1000000000'
+  // If yes, append a '+' sign to the end of the formatted value
+  // Otherwise, return the formatted value as is
+  return value === '1000000000' ? `${formattedValue}+` : formattedValue;
 };
 
 export const formatFiatAmount = (

--- a/src/libs/ui/utils/formatters.ts
+++ b/src/libs/ui/utils/formatters.ts
@@ -174,10 +174,17 @@ export const motesToCurrency = (
     throw new Error('motesToCurrency: the CSPR rate cannot be zero');
   }
 
-  return Big(motes)
-    .div(MOTES_PER_CSPR_RATE)
-    .mul(currencyPerCsprRate)
-    .toString();
+  const amount = Big(motes).div(MOTES_PER_CSPR_RATE).mul(currencyPerCsprRate);
+
+  const billion = new Big(10).pow(9);
+
+  if (amount.gte(billion)) {
+    // If the value is greater than or equal to 10^9, return empty string.
+    // TODO: Clarify future behavior for large fiat amount
+    return '';
+  }
+
+  return amount.toString();
 };
 
 export function snakeAndKebabToCamel(str: string): string {


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

Modified the formatters utility to now handle values greater than or equal to one billion, which were previously returned as an empty string. The formatCurrency function was updated to convert the value to a number and added a check to append a '+' sign if the value is '1000000000'. Changed input parameter type to 'string' in formatCurrency function for consistency

## Linked tickets

[WALLET-298](https://make-software.atlassian.net/browse/WALLET-298)

## Checklist

- [ ] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [ ] Include a screenshot or recording if implementing significant UI or user flow change

- [ ] When this PR affects architecture changes wait for review from Dmytro before merging
