### PR TITLE
feature: add account balance to account switcher and all accounts list

### DIFF
--- a/src/apps/import-account-with-file/pages/import-account-with-file-upload/hooks/use-secret-key-file-reader.ts
+++ b/src/apps/import-account-with-file/pages/import-account-with-file-upload/hooks/use-secret-key-file-reader.ts
@@ -67,7 +67,10 @@ export function useSecretKeyFileReader({
           name,
           publicKey: publicKeyHex,
           secretKey: secretKeyBase64,
-          hidden: false
+          hidden: false,
+          balance: {
+            liquidMotes: null
+          }
         });
       };
     },

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -69,6 +69,7 @@ import {
   accountImported,
   accountRemoved,
   accountRenamed,
+  accountsBalanceChanged,
   activeAccountChanged,
   anotherAccountConnected,
   deployPayloadReceived,
@@ -113,6 +114,7 @@ import { fetchErc20TokenActivity } from '@libs/services/account-activity-service
 import { fetchAccountInfo } from '@libs/services/account-info';
 import {
   fetchAccountBalance,
+  fetchAccountsBalance,
   fetchCurrencyRate
 } from '@libs/services/balance-service';
 import { fetchErc20Tokens } from '@libs/services/erc20-service';
@@ -569,6 +571,7 @@ runtime.onMessage.addListener(
           case getType(accountRemoved):
           case getType(accountRenamed):
           case getType(activeAccountChanged):
+          case getType(accountsBalanceChanged):
           case getType(hideAccountFromListChange):
           case getType(activeTimeoutDurationSettingChanged):
           case getType(activeNetworkSettingChanged):
@@ -648,6 +651,27 @@ runtime.onMessage.addListener(
                   accountData: accountData?.data || null,
                   currencyRate: rate?.data || null
                 })
+              );
+            } catch (error) {
+              console.error(error);
+            }
+
+            return;
+          }
+
+          case getType(serviceMessage.fetchAccountsBalanceRequest): {
+            const { casperWalletApiUrl } = selectApiConfigBasedOnActiveNetwork(
+              store.getState()
+            );
+
+            try {
+              const data = await fetchAccountsBalance({
+                accountHashes: action.payload.accountHashes,
+                casperWalletApiUrl
+              });
+
+              return sendResponse(
+                serviceMessage.fetchAccountsBalanceResponse(data)
               );
             } catch (error) {
               console.error(error);

--- a/src/background/redux/sagas/onboarding-sagas.ts
+++ b/src/background/redux/sagas/onboarding-sagas.ts
@@ -105,7 +105,8 @@ function* initVaultSaga(action: ReturnType<typeof initVault>) {
     const account = {
       ...keyPair,
       name: 'Account 1',
-      hidden: false
+      hidden: false,
+      balance: { liquidMotes: null }
     };
 
     yield put(secretPhraseCreated(secretPhrase));

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -319,7 +319,10 @@ function* createAccountSaga(action: ReturnType<typeof createAccount>) {
     const account = {
       ...keyPair,
       name,
-      hidden: false
+      hidden: false,
+      balance: {
+        liquidMotes: null
+      }
     };
 
     yield put(accountAdded(account));

--- a/src/background/redux/vault/actions.ts
+++ b/src/background/redux/vault/actions.ts
@@ -23,6 +23,10 @@ export const accountRenamed = createAction('ACCOUNT_RENAMED')<{
   newName: string;
 }>();
 
+export const accountsBalanceChanged = createAction('ACCOUNTS_BALANCE_CHANGED')<
+  Account[]
+>();
+
 export const siteConnected = createAction('SITE_CONNECTED')<{
   siteOrigin: string;
   accountNames: string[];

--- a/src/background/redux/vault/reducer.ts
+++ b/src/background/redux/vault/reducer.ts
@@ -6,6 +6,7 @@ import {
   accountImported,
   accountRemoved,
   accountRenamed,
+  accountsBalanceChanged,
   activeAccountChanged,
   anotherAccountConnected,
   deployPayloadReceived,
@@ -159,6 +160,13 @@ export const reducer = createReducer(initialState)
         accountNamesByOriginDict: newAccountNamesByOriginDict
       };
     }
+  )
+  .handleAction(
+    accountsBalanceChanged,
+    (state, action: ReturnType<typeof accountsBalanceChanged>) => ({
+      ...state,
+      accounts: action.payload
+    })
   )
   .handleAction(
     siteConnected,

--- a/src/background/service-message.ts
+++ b/src/background/service-message.ts
@@ -6,7 +6,10 @@ import {
   TransferResult
 } from '@libs/services/account-activity-service/types';
 import { AccountInfo } from '@libs/services/account-info/types';
-import { FetchBalanceResponse } from '@libs/services/balance-service/types';
+import {
+  AccountData,
+  FetchBalanceResponse
+} from '@libs/services/balance-service/types';
 import { ContractPackageWithBalance } from '@libs/services/erc20-service/types';
 import { NFTTokenResult } from '@libs/services/nft-service/types';
 import { ErrorResponse, PaginatedResponse } from '@libs/services/types';
@@ -24,6 +27,14 @@ export const serviceMessage = {
   >(),
   fetchBalanceResponse: createAction('FETCH_ACCOUNT_BALANCE_RESPONSE')<
     FetchBalanceResponse,
+    Meta
+  >(),
+  fetchAccountsBalanceRequest: createAction('FETCH_ACCOUNTS_BALANCE')<
+    { accountHashes: string },
+    Meta
+  >(),
+  fetchAccountsBalanceResponse: createAction('FETCH_ACCOUNTS_BALANCE_RESPONSE')<
+    PaginatedResponse<AccountData> | ErrorResponse,
     Meta
   >(),
   fetchAccountInfoRequest: createAction('FETCH_ACCOUNT_INFO')<

--- a/src/fixtures/initial-state-for-popup-tests.ts
+++ b/src/fixtures/initial-state-for-popup-tests.ts
@@ -55,14 +55,20 @@ export const initialStateForPopupTests: RootState = {
           '0202b1943511b8c23b1b2b8ed7ddcedffcc7be70d9366a5005c7beab08a81b7ae633',
         secretKey: 'Go8sSp3u/hSaDFCjFK6wdM4VZuWjqxEaNB38RaZHLA0=',
         name: 'Account 1',
-        hidden: false
+        hidden: false,
+        balance: {
+          liquidMotes: null
+        }
       },
       {
         publicKey:
           '0203b2e05f074452f5e69ba512310deceaca152ebd3394eadcec26c6e68e91aa7724',
         secretKey: 'TCDeehVWtWeWP2PM/UKh2gQ6hgUpZ6v1D6lzmonYpm4=',
         name: 'Account 2',
-        hidden: false
+        hidden: false,
+        balance: {
+          liquidMotes: null
+        }
       }
     ],
     accountNamesByOriginDict: {},

--- a/src/hooks/use-fetch-accounts-balance.ts
+++ b/src/hooks/use-fetch-accounts-balance.ts
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
+
+import { BALANCE_REFRESH_RATE } from '@src/constants';
+
+import { useForceUpdate } from '@popup/hooks/use-force-update';
+
+import { selectApiConfigBasedOnActiveNetwork } from '@background/redux/settings/selectors';
+import { dispatchToMainStore } from '@background/redux/utils';
+import { accountsBalanceChanged } from '@background/redux/vault/actions';
+import { selectVaultAccounts } from '@background/redux/vault/selectors';
+
+import { getAccountHashFromPublicKey } from '@libs/entities/Account';
+import { dispatchFetchAccountsBalance } from '@libs/services/balance-service';
+import { Account } from '@libs/types/account';
+
+export const useFetchAccountsBalance = () => {
+  const effectTimeoutRef = useRef<NodeJS.Timeout>();
+  const forceUpdate = useForceUpdate();
+  const { t } = useTranslation();
+
+  const { casperClarityApiUrl } = useSelector(
+    selectApiConfigBasedOnActiveNetwork
+  );
+  const accounts = useSelector(selectVaultAccounts);
+
+  useEffect(() => {
+    const hashes = accounts.reduce(
+      (previousValue, currentValue, currentIndex) => {
+        const hash = getAccountHashFromPublicKey(currentValue.publicKey);
+
+        return accounts.length === currentIndex + 1
+          ? previousValue + `${hash}`
+          : previousValue + `${hash},`;
+      },
+      ''
+    );
+
+    dispatchFetchAccountsBalance(hashes)
+      .then(({ payload }) => {
+        if ('data' in payload) {
+          const accountsWithBalance: Account[] = accounts.map(account => {
+            const accountWithBalance = payload.data.find(
+              ac => ac.public_key === account.publicKey
+            );
+
+            return {
+              ...account,
+              balance: {
+                liquidMotes: String(accountWithBalance?.balance || '0')
+              }
+            };
+          });
+
+          dispatchToMainStore(accountsBalanceChanged(accountsWithBalance));
+        } else {
+          const accountsWithoutBalance: Account[] = accounts.map(account => {
+            return {
+              ...account,
+              balance: {
+                liquidMotes: null
+              }
+            };
+          });
+
+          dispatchToMainStore(accountsBalanceChanged(accountsWithoutBalance));
+        }
+      })
+      .catch(error => {
+        console.error(t('Failed to fetch accounts balance'), error);
+      });
+
+    // will cause effect to run again after timeout
+    effectTimeoutRef.current = setTimeout(() => {
+      forceUpdate();
+    }, BALANCE_REFRESH_RATE + 1);
+
+    return () => {
+      clearTimeout(effectTimeoutRef.current);
+    };
+  }, [casperClarityApiUrl, forceUpdate, accounts.length]);
+};

--- a/src/libs/layout/header/header-data-updater.tsx
+++ b/src/libs/layout/header/header-data-updater.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 
+import { useFetchAccountsBalance } from '@hooks/use-fetch-accounts-balance';
 import { useFetchActiveAccountBalance } from '@hooks/use-fetch-active-account-balance';
 import { useFetchErc20Tokens } from '@hooks/use-fetch-erc20-tokens';
 
 export const HeaderDataUpdater: React.FC = () => {
   useFetchActiveAccountBalance();
   useFetchErc20Tokens();
+  useFetchAccountsBalance();
 
   return null;
 };

--- a/src/libs/services/balance-service/balance-service.ts
+++ b/src/libs/services/balance-service/balance-service.ts
@@ -3,11 +3,20 @@ import { BALANCE_REFRESH_RATE, CURRENCY_REFRESH_RATE } from '@src/constants';
 import { dispatchToMainStore } from '@background/redux/utils';
 import { serviceMessage } from '@background/service-message';
 
-import { DataResponse, Payload } from '@libs/services/types';
+import {
+  DataResponse,
+  ErrorResponse,
+  PaginatedResponse,
+  Payload
+} from '@libs/services/types';
 
 import { queryClient } from '../query-client';
 import { handleError, toJson } from '../utils';
-import { getAccountBalanceUrl, getCurrencyRateUrl } from './constants';
+import {
+  getAccountBalanceUrl,
+  getAccountsBalanceUrl,
+  getCurrencyRateUrl
+} from './constants';
 import {
   AccountData,
   FetchBalanceResponse,
@@ -48,10 +57,28 @@ export const accountBalanceRequest = (
     .catch(handleError);
 };
 
+export const accountsBalanceRequest = (
+  accountHashes: string,
+  casperWalletApiUrl: string,
+  signal?: AbortSignal
+): Promise<PaginatedResponse<AccountData> | ErrorResponse> =>
+  fetch(getAccountsBalanceUrl({ accountHashes, casperWalletApiUrl }), {
+    signal
+  })
+    .then(toJson)
+    .catch(handleError);
+
 export const dispatchFetchActiveAccountBalance = (
   accountHash = ''
 ): Promise<Payload<FetchBalanceResponse>> =>
   dispatchToMainStore(serviceMessage.fetchBalanceRequest({ accountHash }));
+
+export const dispatchFetchAccountsBalance = (
+  accountHashes = ''
+): Promise<Payload<PaginatedResponse<AccountData> | ErrorResponse>> =>
+  dispatchToMainStore(
+    serviceMessage.fetchAccountsBalanceRequest({ accountHashes })
+  );
 
 export const fetchAccountBalance = ({
   accountHash,
@@ -79,5 +106,21 @@ export const fetchCurrencyRate = ({
     ({ signal }) => currencyRateRequest(casperClarityApiUrl, signal),
     {
       staleTime: CURRENCY_REFRESH_RATE
+    }
+  );
+
+export const fetchAccountsBalance = ({
+  accountHashes,
+  casperWalletApiUrl
+}: {
+  accountHashes: string;
+  casperWalletApiUrl: string;
+}) =>
+  queryClient.fetchQuery(
+    ['getAccountsBalanceRequest', accountHashes, casperWalletApiUrl],
+    ({ signal }) =>
+      accountsBalanceRequest(accountHashes, casperWalletApiUrl, signal),
+    {
+      staleTime: BALANCE_REFRESH_RATE
     }
   );

--- a/src/libs/services/balance-service/constants.ts
+++ b/src/libs/services/balance-service/constants.ts
@@ -3,6 +3,11 @@ interface GetAccountBalanceUrl {
   casperWalletApiUrl: string;
 }
 
+interface GetAccountsBalanceUrl {
+  accountHashes: string;
+  casperWalletApiUrl: string;
+}
+
 export const getCurrencyRateUrl = (casperClarityApiUrl: string) =>
   `${casperClarityApiUrl}/rates/1/amount`;
 
@@ -11,3 +16,9 @@ export const getAccountBalanceUrl = ({
   casperWalletApiUrl
 }: GetAccountBalanceUrl) =>
   `${casperWalletApiUrl}/accounts/${accountHash}?includes=delegated_balance,undelegating_balance`;
+
+export const getAccountsBalanceUrl = ({
+  accountHashes,
+  casperWalletApiUrl
+}: GetAccountsBalanceUrl) =>
+  `${casperWalletApiUrl}/accounts?account_hash=${accountHashes}&page=1&page_size=100&includes=delegated_balance,undelegating_balance`;

--- a/src/libs/services/types.ts
+++ b/src/libs/services/types.ts
@@ -16,5 +16,7 @@ export interface DataResponse<T> {
 export interface ErrorResponse {
   error: {
     message: string;
+    description: string;
+    code: string;
   };
 }

--- a/src/libs/types/account.ts
+++ b/src/libs/types/account.ts
@@ -6,6 +6,9 @@ export interface Account extends KeyPair {
   name: string;
   imported?: boolean;
   hidden: boolean;
+  balance: {
+    liquidMotes: string | null;
+  };
 }
 
 export interface AccountListRows extends Account {

--- a/src/libs/ui/components/account-list/account-list-item.tsx
+++ b/src/libs/ui/components/account-list/account-list-item.tsx
@@ -2,10 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 
 import {
-  AlignedFlexRow,
   AlignedSpaceBetweenFlexRow,
   FlexColumn,
-  LeftAlignedFlexColumn,
   SpacingSize
 } from '@libs/layout';
 import { AccountListRows } from '@libs/types/account';
@@ -16,6 +14,7 @@ import {
   HashVariant,
   Typography
 } from '@libs/ui/components';
+import { formatNumber, motesToCSPR } from '@libs/ui/utils';
 
 const ListItemContainer = styled(FlexColumn)`
   min-height: 68px;
@@ -24,9 +23,21 @@ const ListItemContainer = styled(FlexColumn)`
   padding: 16px 8px 16px 16px;
 `;
 
-const ListItemClickableContainer = styled(AlignedFlexRow)`
+const ClickableContainer = styled(FlexColumn)`
+  flex-grow: 1;
+
   cursor: ${({ onClick }) => (onClick ? 'pointer' : 'default')};
-  width: ${({ onClick }) => (onClick ? '100%' : 'auto')};
+`;
+
+const Balance = styled(Typography)`
+  min-width: 0;
+  flex-grow: 1;
+  flex-basis: auto;
+  text-align: right;
+`;
+
+const AccountName = styled(Typography)`
+  flex-shrink: 0;
 `;
 
 interface AccountListItemProps {
@@ -48,19 +59,17 @@ export const AccountListItem = ({
   isConnected,
   showHideAccountItem,
   closeModal
-}: AccountListItemProps) => (
-  <ListItemContainer key={account.name}>
-    <AlignedSpaceBetweenFlexRow>
-      <ListItemClickableContainer
-        gap={SpacingSize.Medium}
-        onClick={
-          onClick
-            ? event => {
-                onClick(event, account.name);
-              }
-            : undefined
-        }
-      >
+}: AccountListItemProps) => {
+  const accountBalance =
+    account.balance?.liquidMotes != null
+      ? formatNumber(motesToCSPR(account.balance.liquidMotes), {
+          precision: { max: 0 }
+        })
+      : '-';
+
+  return (
+    <ListItemContainer key={account.name}>
+      <AlignedSpaceBetweenFlexRow gap={SpacingSize.Small}>
         <Avatar
           size={38}
           publicKey={account.publicKey}
@@ -69,24 +78,46 @@ export const AccountListItem = ({
           displayContext="accountList"
           isActiveAccount={isActiveAccount}
         />
-        <LeftAlignedFlexColumn>
-          <Typography type={isActiveAccount ? 'bodySemiBold' : 'body'}>
-            {account.name}
-          </Typography>
-          <Hash
-            value={account.publicKey}
-            variant={HashVariant.CaptionHash}
-            truncated
-            withoutTooltip
-            withTag={account.imported}
-          />
-        </LeftAlignedFlexColumn>
-      </ListItemClickableContainer>
-      <AccountActionsMenuPopover
-        account={account}
-        showHideAccountItem={showHideAccountItem}
-        onClick={closeModal}
-      />
-    </AlignedSpaceBetweenFlexRow>
-  </ListItemContainer>
-);
+        <ClickableContainer
+          onClick={
+            onClick
+              ? event => {
+                  onClick(event, account.name);
+                }
+              : undefined
+          }
+        >
+          <AlignedSpaceBetweenFlexRow gap={SpacingSize.Small}>
+            <AccountName type={isActiveAccount ? 'bodySemiBold' : 'body'}>
+              {account.name}
+            </AccountName>
+            <Balance
+              type="bodyHash"
+              ellipsis
+              loading={!account.balance && account.balance !== 0}
+            >
+              {accountBalance}
+            </Balance>
+          </AlignedSpaceBetweenFlexRow>
+          <AlignedSpaceBetweenFlexRow>
+            <Hash
+              value={account.publicKey}
+              variant={HashVariant.CaptionHash}
+              truncated
+              withoutTooltip
+              withTag={account.imported}
+            />
+            <Typography type="captionHash" color="contentSecondary">
+              CSPR
+            </Typography>
+          </AlignedSpaceBetweenFlexRow>
+        </ClickableContainer>
+        <AccountActionsMenuPopover
+          account={account}
+          showHideAccountItem={showHideAccountItem}
+          onClick={closeModal}
+        />
+      </AlignedSpaceBetweenFlexRow>
+    </ListItemContainer>
+  );
+};

--- a/src/libs/ui/components/account-list/account-list.tsx
+++ b/src/libs/ui/components/account-list/account-list.tsx
@@ -59,7 +59,6 @@ export const AccountList = ({ closeModal }: AccountListProps) => {
 
     setAccountListRows(accountListRows);
     // We need to sort the account list only on the component mount and when new accounts are added
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visibleAccounts]);
 
   return (

--- a/src/libs/ui/components/account-list/utils.test.ts
+++ b/src/libs/ui/components/account-list/utils.test.ts
@@ -7,35 +7,50 @@ describe('sortAccount()', () => {
       publicKey:
         '02026360f7ea7ce2ab573c732252e166bff086fe69d5d892b31f22fb80d910bde63b',
       secretKey: 'FXYT1tqA5j89+P4Aw/VMDRZSrH5byyBvcan2CRLMnEE=',
-      hidden: false
+      hidden: false,
+      balance: {
+        liquidMotes: null
+      }
     },
     {
       name: 'Test user 2',
       publicKey:
         '01f9631111f51219ac0b96ce69ffd9f8fc274a744a8e3e77cd7b18f8b5d4bcf39a',
       secretKey: '0Z4EkL1TStnELE1QL2IgtjiOem3mjMp4WHOX91Er6Lc=',
-      hidden: false
+      hidden: false,
+      balance: {
+        liquidMotes: null
+      }
     },
     {
       name: 'Test user 3',
       publicKey:
         '020373098cf279f55b501a16642e18ecfe4691ce795213060f28c86bf485f16528da',
       secretKey: 'nWbsCkonqeWOeT1S9clhyFlb5HfN5blktdZbJCmK5qE=',
-      hidden: false
+      hidden: false,
+      balance: {
+        liquidMotes: null
+      }
     },
     {
       name: 'Test user 4',
       publicKey:
         '01d302c4a8e9687f0ed0ffa5f9cd29cb5109af526cd72da5a0db9c321fc990bee0',
       secretKey: '09+B7ceHs72J8YdNxCPzxuo3g6MJPTVZcr30PiSZoPE=',
-      hidden: false
+      hidden: false,
+      balance: {
+        liquidMotes: null
+      }
     },
     {
       name: 'Test user 5',
       publicKey:
         '01f33224e945e601fec597b711abe1966abeddb41881954d281c99634df2698a7b',
       secretKey: 'KrwMFnKWZ4ASavxhzJ59g/+6KkZHXatLl6G3DzJ6uLA=',
-      hidden: false
+      hidden: false,
+      balance: {
+        liquidMotes: null
+      }
     }
   ];
 
@@ -48,35 +63,50 @@ describe('sortAccount()', () => {
       publicKey:
         '020373098cf279f55b501a16642e18ecfe4691ce795213060f28c86bf485f16528da',
       secretKey: 'nWbsCkonqeWOeT1S9clhyFlb5HfN5blktdZbJCmK5qE=',
-      hidden: false
+      hidden: false,
+      balance: {
+        liquidMotes: null
+      }
     },
     {
       name: 'Test user 1',
       publicKey:
         '02026360f7ea7ce2ab573c732252e166bff086fe69d5d892b31f22fb80d910bde63b',
       secretKey: 'FXYT1tqA5j89+P4Aw/VMDRZSrH5byyBvcan2CRLMnEE=',
-      hidden: false
+      hidden: false,
+      balance: {
+        liquidMotes: null
+      }
     },
     {
       name: 'Test user 5',
       publicKey:
         '01f33224e945e601fec597b711abe1966abeddb41881954d281c99634df2698a7b',
       secretKey: 'KrwMFnKWZ4ASavxhzJ59g/+6KkZHXatLl6G3DzJ6uLA=',
-      hidden: false
+      hidden: false,
+      balance: {
+        liquidMotes: null
+      }
     },
     {
       name: 'Test user 2',
       publicKey:
         '01f9631111f51219ac0b96ce69ffd9f8fc274a744a8e3e77cd7b18f8b5d4bcf39a',
       secretKey: '0Z4EkL1TStnELE1QL2IgtjiOem3mjMp4WHOX91Er6Lc=',
-      hidden: false
+      hidden: false,
+      balance: {
+        liquidMotes: null
+      }
     },
     {
       name: 'Test user 4',
       publicKey:
         '01d302c4a8e9687f0ed0ffa5f9cd29cb5109af526cd72da5a0db9c321fc990bee0',
       secretKey: '09+B7ceHs72J8YdNxCPzxuo3g6MJPTVZcr30PiSZoPE=',
-      hidden: false
+      hidden: false,
+      balance: {
+        liquidMotes: null
+      }
     }
   ];
 


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

- add account balance to account switcher and all accounts list
- create a hook that fetches balance for all accounts and sets them to the store
- expand the Account type by adding a balance field

## Linked tickets

[WALLET-312](https://make-software.atlassian.net/browse/WALLET-312)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [ ] Include a screenshot or recording if implementing significant UI or user flow change

- [x] When this PR affects architecture changes wait for review from Dmytro before merging
