### PR TITLE
fix: fix sending deploys for Safari

### DIFF
--- a/src/apps/popup/pages/stakes/index.tsx
+++ b/src/apps/popup/pages/stakes/index.tsx
@@ -34,7 +34,10 @@ import {
   createErrorLocationState
 } from '@libs/layout';
 import { dispatchFetchExtendedDeploysInfo } from '@libs/services/account-activity-service';
-import { makeAuctionManagerDeployAndSing } from '@libs/services/deployer-service';
+import {
+  makeAuctionManagerDeployAndSing,
+  sendSignDeploy
+} from '@libs/services/deployer-service';
 import {
   dispatchFetchAuctionValidatorsRequest,
   dispatchFetchValidatorsDetailsDataRequest
@@ -240,9 +243,8 @@ export const StakesPage = () => {
         [KEYS]
       );
 
-      signDeploy
-        .send(nodeUrl)
-        .then((deployHash: string) => {
+      sendSignDeploy(signDeploy, nodeUrl)
+        .then(({ result: { deploy_hash: deployHash } }) => {
           if (deployHash) {
             let triesLeft = 10;
             const interval = setInterval(async () => {

--- a/src/apps/popup/pages/transfer-nft/index.tsx
+++ b/src/apps/popup/pages/transfer-nft/index.tsx
@@ -41,7 +41,10 @@ import {
   createErrorLocationState
 } from '@libs/layout';
 import { dispatchFetchExtendedDeploysInfo } from '@libs/services/account-activity-service';
-import { makeNFTDeployAndSign } from '@libs/services/deployer-service';
+import {
+  makeNFTDeployAndSign,
+  sendSignDeploy
+} from '@libs/services/deployer-service';
 import {
   Button,
   HomePageTabsId,
@@ -149,9 +152,8 @@ export const TransferNftPage = () => {
         [KEYS]
       );
 
-      signDeploy
-        .send(nodeUrl)
-        .then((deployHash: string) => {
+      sendSignDeploy(signDeploy, nodeUrl)
+        .then(({ result: { deploy_hash: deployHash } }) => {
           dispatchToMainStore(recipientPublicKeyAdded(recipientPublicKey));
 
           if (deployHash) {

--- a/src/apps/popup/pages/transfer/index.tsx
+++ b/src/apps/popup/pages/transfer/index.tsx
@@ -38,7 +38,8 @@ import {
 import { dispatchFetchExtendedDeploysInfo } from '@libs/services/account-activity-service';
 import {
   makeCep18TransferDeployAndSign,
-  makeNativeTransferDeployAndSign
+  makeNativeTransferDeployAndSign,
+  sendSignDeploy
 } from '@libs/services/deployer-service';
 import { Button, HomePageTabsId, Typography } from '@libs/ui/components';
 import { calculateSubmitButtonDisabled } from '@libs/ui/forms/get-submit-button-state-from-validation';
@@ -176,9 +177,8 @@ export const TransferPage = () => {
   }, [isSubmitButtonDisable, transferStep]);
 
   const sendDeploy = (signDeploy: DeployUtil.Deploy) => {
-    signDeploy
-      .send(nodeUrl)
-      .then((deployHash: string) => {
+    sendSignDeploy(signDeploy, nodeUrl)
+      .then(({ result: { deploy_hash: deployHash } }) => {
         dispatchToMainStore(recipientPublicKeyAdded(recipientPublicKey));
 
         if (deployHash) {

--- a/src/apps/popup/pages/transfer/index.tsx
+++ b/src/apps/popup/pages/transfer/index.tsx
@@ -9,11 +9,11 @@ import {
   TRANSFER_COST_MOTES
 } from '@src/constants';
 import { useActiveAccountErc20Tokens } from '@src/hooks/use-active-account-erc20-tokens';
+import { fetchAndDispatchExtendedDeployInfo } from '@src/utils';
 
 import { TransferPageContent } from '@popup/pages/transfer/content';
 import { RouterPath, useTypedLocation, useTypedNavigate } from '@popup/router';
 
-import { accountPendingTransactionsChanged } from '@background/redux/account-info/actions';
 import { selectAccountBalance } from '@background/redux/account-info/selectors';
 import { selectAllPublicKeys } from '@background/redux/contacts/selectors';
 import {
@@ -35,7 +35,6 @@ import {
   SpaceBetweenFlexRow,
   createErrorLocationState
 } from '@libs/layout';
-import { dispatchFetchExtendedDeploysInfo } from '@libs/services/account-activity-service';
 import {
   makeCep18TransferDeployAndSign,
   makeNativeTransferDeployAndSign,
@@ -178,28 +177,27 @@ export const TransferPage = () => {
 
   const sendDeploy = (signDeploy: DeployUtil.Deploy) => {
     sendSignDeploy(signDeploy, nodeUrl)
-      .then(({ result: { deploy_hash: deployHash } }) => {
+      .then(resp => {
         dispatchToMainStore(recipientPublicKeyAdded(recipientPublicKey));
 
-        if (deployHash) {
-          let triesLeft = 10;
-          const interval = setInterval(async () => {
-            const { payload: extendedDeployInfo } =
-              await dispatchFetchExtendedDeploysInfo(deployHash);
-            if (extendedDeployInfo) {
-              dispatchToMainStore(
-                accountPendingTransactionsChanged(extendedDeployInfo)
-              );
-              clearInterval(interval);
-            } else if (triesLeft === 0) {
-              clearInterval(interval);
-            }
-
-            triesLeft--;
-            //   Note: this timeout is needed because the deploy is not immediately visible in the explorer
-          }, 2000);
+        if ('result' in resp) {
+          fetchAndDispatchExtendedDeployInfo(resp.result.deploy_hash);
 
           setTransferStep(TransactionSteps.Success);
+        } else {
+          navigate(
+            ErrorPath,
+            createErrorLocationState({
+              errorHeaderText: resp.error.message || t('Something went wrong'),
+              errorContentText:
+                resp.error.data ||
+                t(
+                  'Please check browser console for error details, this will be a valuable for our team to fix the issue.'
+                ),
+              errorPrimaryButtonLabel: t('Close'),
+              errorRedirectPath: RouterPath.Home
+            })
+          );
         }
       })
       .catch(error => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -80,6 +80,8 @@ export enum CasperNodeUrl {
   TestnetUrl = 'https://node.testnet.cspr.cloud/rpc'
 }
 
+export const ReferrerUrl = 'https://casperwallet.io';
+
 export enum NetworkName {
   Mainnet = 'casper',
   Testnet = 'casper-test'

--- a/src/libs/services/deployer-service/index.ts
+++ b/src/libs/services/deployer-service/index.ts
@@ -13,6 +13,7 @@ import {
   AuctionManagerEntryPoint,
   CasperNodeUrl,
   NetworkName,
+  ReferrerUrl,
   STAKE_COST_MOTES,
   TRANSFER_COST_MOTES
 } from '@src/constants';
@@ -22,7 +23,10 @@ import { toJson } from '@libs/services/utils';
 import { Account } from '@libs/types/account';
 import { CSPRtoMotes, multiplyErc20Balance } from '@libs/ui/utils';
 
-import { ICasperNodeStatusResponse } from './types';
+import {
+  ICasperNetworkSendDeployResponse,
+  ICasperNodeStatusResponse
+} from './types';
 
 export const getAuctionManagerDeployCost = (
   entryPoint: AuctionManagerEntryPoint
@@ -43,7 +47,10 @@ export const getDateForDeploy = async (nodeUrl: CasperNodeUrl) => {
 
   try {
     const casperNodeTimestamp: ICasperNodeStatusResponse = await fetch(
-      `${nodeUrl}/info_get_status`
+      `${nodeUrl}/info_get_status`,
+      {
+        referrer: ReferrerUrl
+      }
     ).then(toJson);
 
     return casperNodeTimestamp?.last_progress
@@ -228,4 +235,29 @@ export const makeNFTDeployAndSign = async (
   const deploy = DeployUtil.makeDeploy(deployParams, session, payment);
 
   return deploy.sign(keys);
+};
+
+export const sendSignDeploy = (
+  deploy: DeployUtil.Deploy,
+  nodeUrl: CasperNodeUrl
+): Promise<ICasperNetworkSendDeployResponse> => {
+  const oneMegaByte = 1048576;
+  const size = DeployUtil.deploySizeInBytes(deploy);
+
+  if (size > oneMegaByte) {
+    throw new Error(
+      `Deploy can not be send, because it's too large: ${size} bytes. Max size is 1 megabyte.`
+    );
+  }
+
+  return fetch(nodeUrl, {
+    method: 'POST',
+    referrer: ReferrerUrl,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'account_put_deploy',
+      params: [DeployUtil.deployToJson(deploy).deploy],
+      id: new Date().getTime()
+    })
+  }).then(toJson);
 };

--- a/src/libs/services/deployer-service/index.ts
+++ b/src/libs/services/deployer-service/index.ts
@@ -24,6 +24,7 @@ import { Account } from '@libs/types/account';
 import { CSPRtoMotes, multiplyErc20Balance } from '@libs/ui/utils';
 
 import {
+  ICasperNetworkSendDeployErrorResponse,
   ICasperNetworkSendDeployResponse,
   ICasperNodeStatusResponse
 } from './types';
@@ -240,7 +241,9 @@ export const makeNFTDeployAndSign = async (
 export const sendSignDeploy = (
   deploy: DeployUtil.Deploy,
   nodeUrl: CasperNodeUrl
-): Promise<ICasperNetworkSendDeployResponse> => {
+): Promise<
+  ICasperNetworkSendDeployResponse | ICasperNetworkSendDeployErrorResponse
+> => {
   const oneMegaByte = 1048576;
   const size = DeployUtil.deploySizeInBytes(deploy);
 

--- a/src/libs/services/deployer-service/types.ts
+++ b/src/libs/services/deployer-service/types.ts
@@ -12,3 +12,12 @@ export interface RPCErrorResponse {
 export interface ICasperNodeStatusResponse {
   last_progress: string;
 }
+
+export interface ICasperNetworkSendDeployResponse {
+  jsonrpc: '2.0';
+  id: number;
+  result: {
+    api_version: string;
+    deploy_hash: string;
+  };
+}

--- a/src/libs/services/deployer-service/types.ts
+++ b/src/libs/services/deployer-service/types.ts
@@ -21,3 +21,13 @@ export interface ICasperNetworkSendDeployResponse {
     deploy_hash: string;
   };
 }
+
+export interface ICasperNetworkSendDeployErrorResponse {
+  error: {
+    code: number;
+    data: string;
+    message: string;
+  };
+  id: number;
+  jsonrpc: string;
+}

--- a/src/manifest.v2.safari.json
+++ b/src/manifest.v2.safari.json
@@ -15,7 +15,9 @@
     "https://image-proxy-cdn.make.services/*",
     "https://api.testnet.casperwallet.io/*",
     "https://api.mainnet.casperwallet.io/*",
-    "https://onramp-api.cspr.click/api/*"
+    "https://onramp-api.cspr.click/api/*",
+    "https://node.testnet.cspr.cloud/*",
+    "https://node.cspr.cloud/*"
   ],
   "declarative_net_request": {
     "rule_resources": [


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

- updated manifest for Safari
- used custom sending deploy function
- updated error handling
- the routine to fetch and dispatch extended deploy information has been refactored into a utility function for reuse in all deploy-sending instances

## Linked tickets

[WALLET-327](https://make-software.atlassian.net/browse/WALLET-327)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [ ] Include a screenshot or recording if implementing significant UI or user flow change

- [x] When this PR affects architecture changes wait for review from Dmytro before merging
