### PR TITLE
feature: add e2e tests for buying CSPR and make minor code adjustments

### DIFF
--- a/e2e-tests/popup/buy-cspr/buy-cspr.spec.ts
+++ b/e2e-tests/popup/buy-cspr/buy-cspr.spec.ts
@@ -1,0 +1,138 @@
+import { popup, popupExpect } from '../../fixtures';
+
+popup.describe('Popup UI: buy cspr', () => {
+  popup(
+    'should redirect to Topper provider page',
+    async ({ popupPage, unlockVault, context }) => {
+      await unlockVault();
+
+      await popupPage.getByTestId('network-switcher').click();
+      await popupPage.getByText('Mainnet').click();
+
+      await popupPage.getByText('Buy').click();
+
+      await popupExpect(
+        popupPage.getByRole('heading', { name: 'Pick country' })
+      ).toBeVisible();
+
+      await popupPage.getByRole('button', { name: 'Next' }).click();
+
+      await popupExpect(
+        popupPage.getByRole('heading', { name: 'Enter amount' })
+      ).toBeVisible();
+      await popupPage.getByRole('button', { name: 'Next' }).click();
+
+      await popupExpect(
+        popupPage.getByRole('heading', { name: 'Pick provider' })
+      ).toBeVisible();
+
+      await popupExpect(
+        popupPage.getByRole('button', { name: 'Confirm' })
+      ).toBeDisabled();
+
+      await popupPage.getByText('Topper by Uphold').click();
+
+      await popupExpect(
+        popupPage.getByRole('button', { name: 'Confirm' })
+      ).not.toBeDisabled();
+
+      const [torusPage] = await Promise.all([
+        context.waitForEvent('page'),
+        popupPage.getByRole('button', { name: 'Confirm' }).click()
+      ]);
+
+      await new Promise(r => setTimeout(r, 2000));
+
+      console.log(torusPage.url());
+      popupExpect(torusPage.url()).toContain('https://app.topperpay.com/');
+    }
+  );
+
+  popup(
+    'should redirect to Ramp provider page',
+    async ({ popupPage, unlockVault, context }) => {
+      await unlockVault();
+
+      await popupPage.getByTestId('network-switcher').click();
+      await popupPage.getByText('Mainnet').click();
+
+      await popupPage.getByText('Buy').click();
+
+      await popupExpect(
+        popupPage.getByRole('heading', { name: 'Pick country' })
+      ).toBeVisible();
+
+      await popupPage.getByRole('button', { name: 'Next' }).click();
+
+      await popupExpect(
+        popupPage.getByRole('heading', { name: 'Enter amount' })
+      ).toBeVisible();
+      await popupPage.getByRole('button', { name: 'Next' }).click();
+
+      await popupExpect(
+        popupPage.getByRole('heading', { name: 'Pick provider' })
+      ).toBeVisible();
+
+      await popupExpect(
+        popupPage.getByRole('button', { name: 'Confirm' })
+      ).toBeDisabled();
+
+      await popupPage.getByText('Ramp').click();
+
+      await popupExpect(
+        popupPage.getByRole('button', { name: 'Confirm' })
+      ).not.toBeDisabled();
+
+      const [rampPage] = await Promise.all([
+        context.waitForEvent('page'),
+        popupPage.getByRole('button', { name: 'Confirm' }).click()
+      ]);
+
+      await new Promise(r => setTimeout(r, 2000));
+
+      console.log(rampPage.url());
+      popupExpect(rampPage.url()).toContain('https://app.ramp.network/');
+    }
+  );
+
+  popup(
+    'should display and empty provider page when no available provider',
+    async ({ popupPage, unlockVault }) => {
+      await unlockVault();
+
+      await popupPage.getByTestId('network-switcher').click();
+      await popupPage.getByText('Mainnet').click();
+
+      await popupPage.getByText('Buy').click();
+
+      await popupExpect(
+        popupPage.getByRole('heading', { name: 'Pick country' })
+      ).toBeVisible();
+
+      await popupPage.getByTestId('country-row').click();
+
+      await popupPage
+        .getByPlaceholder('Search', { exact: true })
+        .fill('Ukraine');
+
+      await popupPage.getByText('Ukraine').click();
+
+      await popupPage.getByRole('button', { name: 'Next' }).click();
+
+      await popupExpect(
+        popupPage.getByRole('heading', { name: 'Enter amount' })
+      ).toBeVisible();
+      await popupPage.getByTestId('currency-row').click();
+
+      await popupPage.getByPlaceholder('Search', { exact: true }).fill('UAH');
+
+      await popupPage.getByText('UAH').click();
+
+      await popupPage.getByRole('button', { name: 'Next' }).click();
+
+      await popupExpect(
+        popupPage.getByRole('heading', { name: 'No available provider' })
+      ).toBeVisible();
+    }
+  );
+});

--- a/e2e-tests/popup/common/wallet.spec.ts
+++ b/e2e-tests/popup/common/wallet.spec.ts
@@ -1,5 +1,5 @@
-import { popup, popupExpect } from '../../fixtures';
 import { ACCOUNT_NAMES } from '../../constants';
+import { popup, popupExpect } from '../../fixtures';
 
 popup.describe('Popup UI: lock/unlock/reset wallet', () => {
   popup(

--- a/e2e-tests/popup/contacts/contacts.spec.ts
+++ b/e2e-tests/popup/contacts/contacts.spec.ts
@@ -1,9 +1,9 @@
-import { popup, popupExpect } from '../../fixtures';
 import {
   DEFAULT_FIRST_ACCOUNT,
   DEFAULT_SECOND_ACCOUNT,
   vaultPassword
 } from '../../constants';
+import { popup, popupExpect } from '../../fixtures';
 
 popup.describe('Popup UI: contacts', () => {
   popup(

--- a/e2e-tests/popup/create-account/create-account.spec.ts
+++ b/e2e-tests/popup/create-account/create-account.spec.ts
@@ -1,5 +1,5 @@
-import { popup, popupExpect } from '../../fixtures';
 import { ACCOUNT_NAMES } from '../../constants';
+import { popup, popupExpect } from '../../fixtures';
 
 popup.describe('Popup UI: create account', () => {
   popup.beforeEach(async ({ unlockVault, popupPage }) => {

--- a/e2e-tests/popup/disconnect-account/disconnect-account.spec.ts
+++ b/e2e-tests/popup/disconnect-account/disconnect-account.spec.ts
@@ -1,5 +1,5 @@
-import { popup, popupExpect } from '../../fixtures';
 import { ACCOUNT_NAMES, PLAYGROUND_URL } from '../../constants';
+import { popup, popupExpect } from '../../fixtures';
 
 popup.describe('Popup UI: disconnect account', () => {
   popup.beforeEach(async ({ connectAccounts }) => {

--- a/e2e-tests/popup/rename-account/rename-account.spec.ts
+++ b/e2e-tests/popup/rename-account/rename-account.spec.ts
@@ -1,5 +1,5 @@
-import { popup, popupExpect } from '../../fixtures';
 import { ACCOUNT_NAMES } from '../../constants';
+import { popup, popupExpect } from '../../fixtures';
 
 popup.describe('Popup UI: rename account', () => {
   popup(

--- a/e2e-tests/popup/signature-request-scenarios/signature-request-scenarios.spec.ts
+++ b/e2e-tests/popup/signature-request-scenarios/signature-request-scenarios.spec.ts
@@ -1,10 +1,10 @@
-import { popup, popupExpect } from '../../fixtures';
 import {
   DEFAULT_FIRST_ACCOUNT,
   NEW_VALIDATOR,
   PLAYGROUND_URL,
   VALIDATOR
 } from '../../constants';
+import { popup, popupExpect } from '../../fixtures';
 
 popup.describe('Popup UI: signature request scenarios', () => {
   popup.beforeEach(async ({ connectAccounts, page }) => {

--- a/src/apps/popup/pages/buy-cspr/components/country-row.tsx
+++ b/src/apps/popup/pages/buy-cspr/components/country-row.tsx
@@ -60,7 +60,11 @@ export const CountryRow = ({ country, onClick }: CountryRowProps) => {
               height="18"
               onError={handleError}
             />
-            <Typography type="body" loading={!country.name}>
+            <Typography
+              type="body"
+              loading={!country.name}
+              dataTestId="country-row"
+            >
               {country.name}
             </Typography>
           </AlignedFlexRow>

--- a/src/apps/popup/pages/buy-cspr/components/currency-row.tsx
+++ b/src/apps/popup/pages/buy-cspr/components/currency-row.tsx
@@ -28,7 +28,11 @@ export const CurrencyRow = ({
       </Typography>
       <Tile borderRadius="base">
         <Container>
-          <Typography type="bodySemiBold" color="contentAction">
+          <Typography
+            type="bodySemiBold"
+            color="contentAction"
+            dataTestId="currency-row"
+          >
             {selectedCurrency.code}
           </Typography>
         </Container>

--- a/src/libs/layout/header/header-network-switcher.tsx
+++ b/src/libs/layout/header/header-network-switcher.tsx
@@ -107,6 +107,7 @@ export const HeaderNetworkSwitcher = () => {
             src="assets/icons/network.svg"
             size={16}
             color="contentOnFill"
+            dataTestId="network-switcher"
           />
           <Typography type="listSubtext" color="contentOnFill">
             {activeNetwork}


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

A new end-to-end test scenario file has been added to verify the purchasing of CSPR from different providers and handling various cases, such as no available provider for a certain country or currency. The order of import statements in several files was reshuffled for consistency and an identifier was attached to elements in `header-network-switcher.tsx`, `country-row.tsx`, and `currency-row.tsx` for easier testing.

## Linked tickets

[WALLET-329](https://make-software.atlassian.net/browse/WALLET-329)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [ ] Include a screenshot or recording if implementing significant UI or user flow change

- [x] When this PR affects architecture changes wait for review from Dmytro before merging
