### PR TITLE
fix: Disable Redux devtools in development mode

### DIFF
--- a/src/background/redux/index.ts
+++ b/src/background/redux/index.ts
@@ -1,4 +1,3 @@
-import { composeWithDevTools } from '@redux-devtools/remote';
 import {
   applyMiddleware, // TODO: Move to actual `createStore`
   compose,
@@ -7,31 +6,30 @@ import {
 import createSagaMiddleware from 'redux-saga';
 import { RootState } from 'typesafe-actions';
 
-import { isChromeBuild } from '@src/utils';
-
 import reduxAction from './redux-action';
 import rootReducer from './root-reducer';
 import rootSaga from './root-saga';
 
-// export const composeEnhancers = compose;
-export const composeEnhancers =
-  process.env.NODE_ENV === 'development' && isChromeBuild
-    ? composeWithDevTools({
-        name: 'Casper Wallet',
-        hostname: 'localhost',
-        port: 8000
-      })
-    : compose;
+// Disabled redux devtools
+// until we find a solution to fix the issue with an infinite number of times to connect to the WebSocket server
+
+// import { composeWithDevTools } from '@redux-devtools/remote';
+// export const composeEnhancers =
+//   process.env.NODE_ENV === 'development' && isChromeBuild
+//     ? composeWithDevTools({
+//         name: 'Casper Wallet',
+//         hostname: 'localhost',
+//         port: 8000
+//       })
+//     : compose;
 
 export const createStore = (initialState: Partial<RootState>) => {
   const sagaMiddleware = createSagaMiddleware();
   // configure middlewares
   const middlewares = [sagaMiddleware];
   // compose enhancers
-  // @ts-ignore
-  const enhancer = composeEnhancers(applyMiddleware(...middlewares));
+  const enhancer = compose(applyMiddleware(...middlewares));
   // create store
-  // @ts-ignore
   const store = createStoreRedux(rootReducer, initialState, enhancer);
   // run sagas
   sagaMiddleware.run(rootSaga);


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

The Redux devtools have been temporarily disabled in development mode due to a persisting issue causing repeated attempts to connect to the WebSocket server. The current commit removes the code enabling these devtools and leaves a comment for ease of reimplementation once a solution is found.

## Linked tickets

[WALLET-330](https://make-software.atlassian.net/browse/WALLET-330)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [ ] Include a screenshot or recording if implementing significant UI or user flow change

- [ ] When this PR affects architecture changes wait for review from Dmytro before merging
