### PR TITLE
fix: improve handling of onboarding URL navigation

### DIFF
--- a/src/background/open-onboarding-flow.ts
+++ b/src/background/open-onboarding-flow.ts
@@ -24,6 +24,7 @@ export async function enableOnboardingFlow() {
 export async function openOnboardingUi() {
   const { tabId, windowId } = await loadState();
   let tabExist = false;
+
   if (tabId != null && windowId != null) {
     try {
       const tab = await tabs.get(tabId);
@@ -38,7 +39,19 @@ export async function openOnboardingUi() {
     }
   }
 
-  if (!tabExist) {
+  // this needed for case when the user goes to another url from onboarding
+  // and then click on Casper Wallet from the extension menu
+  const tab =
+    tabId != null &&
+    (await tabs.get(tabId).catch(() => {
+      // catch error if the tab does not exist
+    }));
+  // check if the tab URL is the onboarding URL
+  const isOnboardingUrl = tab && tab.url?.includes('onboarding.html');
+
+  // create a tab if it does not exist or if it's not an onboarding URL
+  if (!tabExist || !isOnboardingUrl) {
+    console.log(123);
     tabs
       .create({ url: 'onboarding.html', active: true })
       .then(tab => {


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

This update improves the way we handle the use case where a user navigates away from the onboarding page and then clicks on the extension menu. The changes ensure that if the tab for onboarding does not exist or is not on the onboarding URL, a new onboarding tab will be created.

## Linked tickets

[WALLET-306](https://make-software.atlassian.net/browse/WALLET-306)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [ ] Include a screenshot or recording if implementing significant UI or user flow change

- [x] When this PR affects architecture changes wait for review from Dmytro before merging
