### PR TITLE
fix: add missing UI for transfer flow

### DIFF
--- a/src/apps/popup/pages/transfer/amount-step.tsx
+++ b/src/apps/popup/pages/transfer/amount-step.tsx
@@ -52,6 +52,7 @@ export const AmountStep = ({
   setIsAmountFormButtonDisabled
 }: AmountStepProps) => {
   const [disabled, setDisabled] = useState(false);
+  const [maxAmountMotes, setMaxAmountMotes] = useState('0');
 
   const { t } = useTranslation();
 
@@ -83,6 +84,7 @@ export const AmountStep = ({
 
     const hasEnoughBalance = Big(maxAmountMotes).gte(TRANSFER_MIN_AMOUNT_MOTES);
 
+    setMaxAmountMotes(maxAmountMotes);
     setDisabled(!hasEnoughBalance);
   }, [csprBalance.liquidMotes]);
 
@@ -92,7 +94,7 @@ export const AmountStep = ({
     }
   }, [isErc20Transfer, setAmount]);
 
-  const { register, formState, control, trigger } = amountForm;
+  const { register, formState, control, trigger, setValue } = amountForm;
 
   const { errors } = formState;
 
@@ -178,6 +180,24 @@ export const AmountStep = ({
           validationText={errors?.amount?.message}
         />
       </VerticalSpaceContainer>
+
+      {!isErc20Transfer && (
+        <ParagraphContainer top={SpacingSize.Small}>
+          <Typography
+            type="captionRegular"
+            color="contentAction"
+            style={{ cursor: 'pointer' }}
+            onClick={() => {
+              setAmount(motesToCSPR(maxAmountMotes));
+              setValue('amount', motesToCSPR(maxAmountMotes));
+
+              trigger('amount');
+            }}
+          >
+            <Trans t={t}>Send max</Trans>
+          </Typography>
+        </ParagraphContainer>
+      )}
 
       {/** transferIdMemo is only relevant for CSPR */}
       <VerticalSpaceContainer top={SpacingSize.XL}>

--- a/src/apps/popup/pages/transfer/index.tsx
+++ b/src/apps/popup/pages/transfer/index.tsx
@@ -2,6 +2,7 @@ import { DeployUtil } from 'casper-js-sdk';
 import React, { useEffect, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
+import styled from 'styled-components';
 
 import { ERC20_PAYMENT_AMOUNT_AVERAGE_MOTES } from '@src/constants';
 import { fetchAndDispatchExtendedDeployInfo } from '@src/utils';
@@ -32,15 +33,16 @@ import { useSubmitButton } from '@hooks/use-submit-button';
 import { createAsymmetricKey } from '@libs/crypto/create-asymmetric-key';
 import {
   AlignedFlexRow,
+  CenteredFlexRow,
   ErrorPath,
   FooterButtonsContainer,
   HeaderPopup,
   HeaderSubmenuBarNavLink,
   PopupLayout,
   SpacingSize,
+  VerticalSpaceContainer,
   createErrorLocationState
 } from '@libs/layout';
-import { HeaderSubmenuBarBuyCSPRLink } from '@libs/layout/header/header-submenu-bar-buy-cspr-link';
 import {
   makeCep18TransferDeploy,
   makeNativeTransferDeploy,
@@ -54,6 +56,7 @@ import {
   LedgerEventView,
   SvgIcon,
   TransferSuccessScreen,
+  Typography,
   renderLedgerFooter
 } from '@libs/ui/components';
 import { CSPRtoMotes, motesToCSPR } from '@libs/ui/utils';
@@ -63,6 +66,23 @@ import { ConfirmStep } from './confirm-step';
 import { RecipientStep } from './recipient-step';
 import { TokenStep } from './token-step';
 import { TransactionSteps } from './utils';
+
+const ScrollContainer = styled(VerticalSpaceContainer)<{
+  isHidden: boolean;
+}>`
+  opacity: ${({ isHidden }) => (isHidden ? '0' : '1')};
+  height: ${({ isHidden }) => (isHidden ? '0' : '24px')};
+  transition:
+    opacity 0.2s ease-in-out,
+    height 0.5s ease-in-out;
+`;
+
+const ConfirmButtonContainer = styled(FooterButtonsContainer)<{
+  isHidden: boolean;
+}>`
+  gap: ${({ isHidden }) => (isHidden ? '0' : '16px')};
+  transition: gap 0.5s ease-in-out;
+`;
 
 export const TransferPage = () => {
   const { t } = useTranslation();
@@ -321,37 +341,27 @@ export const TransferPage = () => {
 
   const headerButtons = {
     [TransactionSteps.Token]: (
-      <>
-        <HeaderSubmenuBarNavLink linkType="back" />
-        <HeaderSubmenuBarBuyCSPRLink />
-      </>
+      <HeaderSubmenuBarNavLink linkType="back" backTypeWithBalance />
     ),
     [TransactionSteps.Recipient]: (
-      <>
-        <HeaderSubmenuBarNavLink
-          linkType="back"
-          onClick={() => setTransferStep(TransactionSteps.Token)}
-        />
-        <HeaderSubmenuBarBuyCSPRLink />
-      </>
+      <HeaderSubmenuBarNavLink
+        linkType="back"
+        backTypeWithBalance
+        onClick={() => setTransferStep(TransactionSteps.Token)}
+      />
     ),
     [TransactionSteps.Amount]: (
-      <>
-        <HeaderSubmenuBarNavLink
-          linkType="back"
-          onClick={() => setTransferStep(TransactionSteps.Recipient)}
-        />
-        <HeaderSubmenuBarBuyCSPRLink />
-      </>
+      <HeaderSubmenuBarNavLink
+        linkType="back"
+        backTypeWithBalance
+        onClick={() => setTransferStep(TransactionSteps.Recipient)}
+      />
     ),
     [TransactionSteps.Confirm]: (
-      <>
-        <HeaderSubmenuBarNavLink
-          linkType="back"
-          onClick={() => setTransferStep(TransactionSteps.Amount)}
-        />
-        <HeaderSubmenuBarBuyCSPRLink />
-      </>
+      <HeaderSubmenuBarNavLink
+        linkType="back"
+        onClick={() => setTransferStep(TransactionSteps.Amount)}
+      />
     ),
     [TransactionSteps.ConfirmWithLedger]: (
       <HeaderSubmenuBarNavLink
@@ -417,7 +427,14 @@ export const TransferPage = () => {
       <></>
     ),
     [TransactionSteps.Confirm]: (
-      <FooterButtonsContainer>
+      <ConfirmButtonContainer isHidden={!isSubmitButtonDisable}>
+        <ScrollContainer isHidden={!isSubmitButtonDisable}>
+          <CenteredFlexRow>
+            <Typography type="captionRegular">
+              <Trans t={t}>Scroll down to check all details</Trans>
+            </Typography>
+          </CenteredFlexRow>
+        </ScrollContainer>
         <Button
           color="primaryBlue"
           type="button"
@@ -441,7 +458,7 @@ export const TransferPage = () => {
             <Trans t={t}>Confirm send</Trans>
           )}
         </Button>
-      </FooterButtonsContainer>
+      </ConfirmButtonContainer>
     ),
     [TransactionSteps.Success]: (
       <FooterButtonsContainer>

--- a/src/libs/ui/components/recipient-tabs/components/contacts-list.tsx
+++ b/src/libs/ui/components/recipient-tabs/components/contacts-list.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { selectAllContacts } from '@background/redux/contacts/selectors';
 import { ContactWithId } from '@background/redux/contacts/types';
+import { selectVaultActiveAccount } from '@background/redux/vault/selectors';
 
 import { SpacingSize, TileContainer } from '@libs/layout';
 import { List, RecipientPlate, Tile, Typography } from '@libs/ui/components';
@@ -15,15 +16,18 @@ export const ContactsList = ({ handleSelectRecipient }: ContactsListProps) => {
   const [contactsWithId, setContactsWithId] = useState<ContactWithId[]>([]);
 
   const contacts = useSelector(selectAllContacts);
+  const activeAccount = useSelector(selectVaultActiveAccount);
 
   useEffect(() => {
-    const contactsWithId = contacts.map(contact => ({
-      ...contact,
-      id: contact.name
-    }));
+    const contactsWithId = contacts
+      .map(contact => ({
+        ...contact,
+        id: contact.name
+      }))
+      .filter(account => account.publicKey !== activeAccount?.publicKey);
 
     setContactsWithId(contactsWithId);
-  }, [contacts]);
+  }, [contacts, activeAccount]);
 
   if (contactsWithId.length === 0) {
     return (

--- a/src/libs/ui/components/recipient-tabs/components/my-accounts-list.tsx
+++ b/src/libs/ui/components/recipient-tabs/components/my-accounts-list.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
-import { selectVaultAccountsWithBalances } from '@background/redux/vault/selectors';
+import {
+  selectVaultAccountsWithBalances,
+  selectVaultActiveAccount
+} from '@background/redux/vault/selectors';
 
 import { SpacingSize } from '@libs/layout';
 import { AccountListRows } from '@libs/types/account';
@@ -17,15 +20,18 @@ export const MyAccountsList = ({
   const [accountsWithIds, setAccountsWithIds] = useState<AccountListRows[]>([]);
 
   const accounts = useSelector(selectVaultAccountsWithBalances);
+  const activeAccount = useSelector(selectVaultActiveAccount);
 
   useEffect(() => {
-    const accountsWithIds = accounts.map(account => ({
-      ...account,
-      id: account.name
-    }));
+    const accountsWithIds = accounts
+      .map(account => ({
+        ...account,
+        id: account.name
+      }))
+      .filter(account => account.publicKey !== activeAccount?.publicKey);
 
     setAccountsWithIds(accountsWithIds);
-  }, [accounts, setAccountsWithIds]);
+  }, [accounts, setAccountsWithIds, activeAccount]);
 
   return (
     <List

--- a/src/libs/ui/components/recipient-tabs/components/recent-list.tsx
+++ b/src/libs/ui/components/recipient-tabs/components/recent-list.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { selectAllContacts } from '@background/redux/contacts/selectors';
 import { selectRecentRecipientPublicKeys } from '@background/redux/recent-recipient-public-keys/selectors';
+import { selectVaultActiveAccount } from '@background/redux/vault/selectors';
 
 import { SpacingSize, TileContainer } from '@libs/layout';
 import { List, RecipientPlate, Tile, Typography } from '@libs/ui/components';
@@ -24,26 +25,31 @@ export const RecentList = ({ handleSelectRecipient }: MyAccountsListProps) => {
     selectRecentRecipientPublicKeys
   );
   const contacts = useSelector(selectAllContacts);
+  const activeAccount = useSelector(selectVaultActiveAccount);
 
   useEffect(() => {
-    const recentRecipient = recentRecipientPublicKeys.map(publicKey => {
-      const contact = contacts.find(contact => contact.publicKey === publicKey);
-      if (contact) {
+    const recentRecipient = recentRecipientPublicKeys
+      .map(publicKey => {
+        const contact = contacts.find(
+          contact => contact.publicKey === publicKey
+        );
+        if (contact) {
+          return {
+            name: contact.name,
+            publicKey: publicKey,
+            id: publicKey
+          };
+        }
         return {
-          name: contact.name,
+          name: '',
           publicKey: publicKey,
           id: publicKey
         };
-      }
-      return {
-        name: '',
-        publicKey: publicKey,
-        id: publicKey
-      };
-    });
+      })
+      .filter(account => account.publicKey !== activeAccount?.publicKey);
 
     setAccountsWithIds(recentRecipient);
-  }, [contacts, recentRecipientPublicKeys, setAccountsWithIds]);
+  }, [contacts, recentRecipientPublicKeys, setAccountsWithIds, activeAccount]);
 
   if (!accountsWithIds.length) {
     return (


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

- added Casper balance to the header sub-menu bar
- added `Send max` button for native transfer
- added text `Scroll down to check all details` for confirmation button container
- added filter for recipient tabs to remove the active account from the list

## Linked tickets

[WALLET-365](https://make-software.atlassian.net/browse/WALLET-365)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [x] Include a screenshot or recording if implementing significant UI or user flow change

- [x] When this PR affects architecture changes wait for review from Dmytro before merging
