### PR TITLE
fix: fix tooltip placement for deploy status

### DIFF
--- a/src/apps/popup/pages/deploy-details/content.tsx
+++ b/src/apps/popup/pages/deploy-details/content.tsx
@@ -70,10 +70,6 @@ export const DeployDetailsPageContent = ({
   const { t } = useTranslation();
 
   const activeAccount = useSelector(selectVaultActiveAccount);
-  // const activeAccount = {
-  //   publicKey:
-  //     '0203b9b4cd6085590b68bfccaf7ea1744766e5225928beba99155a1bd79870f7a984'
-  // };
 
   useEffect(() => {
     setSingleDeploy(deploy);
@@ -109,6 +105,7 @@ export const DeployDetailsPageContent = ({
               status: singleDeploy.status,
               errorMessage: singleDeploy.errorMessage
             }}
+            placement="bottomRight"
           />
         </TitleContainer>
       </ParagraphContainer>

--- a/src/libs/ui/components/deploy-status/deploy-status.tsx
+++ b/src/libs/ui/components/deploy-status/deploy-status.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { AlignedFlexRow, SpacingSize } from '@libs/layout';
-import { SvgIcon, Tooltip, Typography } from '@libs/ui/components';
+import { Placement, SvgIcon, Tooltip, Typography } from '@libs/ui/components';
 import { ContentColor } from '@libs/ui/utils';
 
 export enum Status {
@@ -69,6 +69,7 @@ export interface DeployStatusProps {
     | null
     | undefined;
   textWithIcon?: boolean;
+  placement?: Placement;
 }
 
 const StatusContainer = styled(AlignedFlexRow)<{ status: Status }>(
@@ -80,11 +81,10 @@ const StatusContainer = styled(AlignedFlexRow)<{ status: Status }>(
   })
 );
 
-export const isPendingStatus = (status: string) => status === Status.Pending;
-
 export const DeployStatus = ({
   deployResult,
-  textWithIcon
+  textWithIcon,
+  placement = 'topRight'
 }: DeployStatusProps) => {
   const { t } = useTranslation();
 
@@ -102,7 +102,7 @@ export const DeployStatus = ({
 
   if (textWithIcon) {
     return (
-      <Tooltip title={message} placement="topRight">
+      <Tooltip title={message} placement={placement}>
         <StatusContainer status={status} gap={SpacingSize.Small}>
           <SvgIcon
             src={StatusIcons[status]}


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

- The tooltip placement for deploy status in the deploy details page was fixed

## Linked tickets

[WALLET-424](https://make-software.atlassian.net/browse/WALLET-424)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [x] Include a screenshot or recording if implementing significant UI or user flow change

- [ ] When this PR affects architecture changes wait for review from Dmytro before merging

<img width="364" alt="image" src="https://github.com/user-attachments/assets/69f8863e-c4f3-442f-97df-4aa133864969">
