### PR TITLE
fix: fix null checks for accessing csprName properties.

### DIFF
--- a/src/apps/connect-to-app/pages/switch-account/content.tsx
+++ b/src/apps/connect-to-app/pages/switch-account/content.tsx
@@ -134,7 +134,7 @@ export function SwitchAccountContent({ requestId }: SwitchAccountContentProps) {
               rows={connectedAccountsListItems}
               renderRow={(account, index) => {
                 const csprName =
-                  accountsInfo && accountsInfo[account.accountHash].csprName;
+                  accountsInfo && accountsInfo[account.accountHash]?.csprName;
 
                 return (
                   <ListItemContainer key={account.name}>

--- a/src/apps/connect-to-app/pages/switch-account/unconnected-accounts-list.tsx
+++ b/src/apps/connect-to-app/pages/switch-account/unconnected-accounts-list.tsx
@@ -69,7 +69,7 @@ export const UnconnectedAccountsList = ({
         renderRow={(unconnectedAccount, index) => {
           const csprName =
             accountsInfo &&
-            accountsInfo[unconnectedAccount.accountHash].csprName;
+            accountsInfo[unconnectedAccount.accountHash]?.csprName;
 
           return (
             <ListItemContainer key={unconnectedAccount.name}>

--- a/src/apps/popup/pages/connected-sites/index.tsx
+++ b/src/apps/popup/pages/connected-sites/index.tsx
@@ -97,7 +97,7 @@ export function ConnectedSitesPage() {
               const accountHash = getAccountHashFromPublicKey(publicKey);
 
               const csprName =
-                accountsInfo && accountsInfo[accountHash].csprName;
+                accountsInfo && accountsInfo[accountHash]?.csprName;
 
               return (
                 <SiteGroupItem


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

- Updated the code to include optional chaining when accessing csprName from accountsInfo. This change prevents potential errors in scenarios where accountHash does not exist in accountsInfo.

## Linked tickets

[WALLET-450](https://make-software.atlassian.net/browse/WALLET-450)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [ ] Include a screenshot or recording if implementing significant UI or user flow change

- [ ] When this PR affects architecture changes wait for review from Dmytro before merging
