### PR TITLE
fix: add handle text overflow in deploy-value component

### DIFF
--- a/src/apps/signature-request/pages/sign-deploy/deploy-value.tsx
+++ b/src/apps/signature-request/pages/sign-deploy/deploy-value.tsx
@@ -59,7 +59,12 @@ export function DeployValue({
       return <Typography type="body">{formatDate(value)}</Typography>;
     }
 
-    return <Typography type="body">{value}</Typography>;
+    return (
+      // Temporary solution. We will change it when we have the new design
+      <Typography type="body" style={{ overflowWrap: 'anywhere' }}>
+        {value}
+      </Typography>
+    );
   } else {
     // cl value args
     const { parsedValue } = getDeployParsedValue(value);
@@ -96,6 +101,11 @@ export function DeployValue({
       );
     }
 
-    return <Typography type="body">{parsedValue}</Typography>;
+    return (
+      // Temporary solution. We will change it when we have the new design
+      <Typography type="body" style={{ overflowWrap: 'anywhere' }}>
+        {parsedValue}
+      </Typography>
+    );
   }
 }

--- a/src/apps/signature-request/pages/sign-deploy/sign-deploy-content.tsx
+++ b/src/apps/signature-request/pages/sign-deploy/sign-deploy-content.tsx
@@ -183,7 +183,7 @@ export function SignDeployContent({
                   }
 
                   return (
-                    <AccordionItem key={key}>
+                    <AccordionItem key={key} gap={SpacingSize.Small}>
                       <Typography type="body" color="contentSecondary">
                         {label}
                       </Typography>


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

- Added overflowWrap style to Typography component in deploy-value.tsx to handle long texts. Temporarily addressed design limitations until the new design is applied. 
- Updated AccordionItem in sign-deploy-content.tsx to include gap property for better spacing.

## Linked tickets

[WALLET-445](https://make-software.atlassian.net/browse/WALLET-445)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [ ] Include a screenshot or recording if implementing significant UI or user flow change

- [ ] When this PR affects architecture changes wait for review from Dmytro before merging
