### PR TITLE
feature: show already connected accounts in the list with preselected and disabled state

### DIFF
--- a/src/apps/connect-to-app/pages/select-account/content.tsx
+++ b/src/apps/connect-to-app/pages/select-account/content.tsx
@@ -80,7 +80,7 @@ export function SelectAccountContent({
       : { caption: captionSelectAll, onClick: handleSelectAll };
   }, [t, areAllAccountsSelected, handleSelectAll, handleUnselectAll]);
 
-  const accountsListItems = notConnectedAccounts.map(account => ({
+  const accountsListItems = accounts.map(account => ({
     ...account,
     id: account.name
   }));
@@ -102,45 +102,59 @@ export function SelectAccountContent({
           rows={accountsListItems}
           headerLabelTop={SpacingSize.Large}
           contentTop={SpacingSize.Small}
-          renderRow={(account, index) => (
-            <ListItemClickableContainer
-              onClick={() =>
-                setSelectedAccountNames(selectedAccountNames =>
-                  selectedAccountNames.includes(account.name)
-                    ? selectedAccountNames.filter(
-                        accountName => accountName !== account.name
-                      )
-                    : [...selectedAccountNames, account.name]
-                )
-              }
-            >
-              <Checkbox
-                variant="square"
-                checked={selectedAccountNames.includes(account.name)}
-              />
-              <AccountNameWithHashListItemContainer>
-                <Typography
-                  type={
-                    activeAccount && activeAccount.name === account.name
-                      ? 'bodySemiBold'
-                      : 'body'
-                  }
-                >
-                  {account.name}
-                </Typography>
-                <Hash
-                  value={account.publicKey}
-                  variant={HashVariant.CaptionHash}
-                  truncated
-                  placement={
-                    index === accountsListItems.length - 1
-                      ? 'topRight'
-                      : 'bottomRight'
-                  }
+          renderRow={(account, index) => {
+            const isAccountAlreadyConnected = !!connectedAccountNames?.includes(
+              account.name
+            );
+            const isAccountSelected = selectedAccountNames.includes(
+              account.name
+            );
+
+            return (
+              <ListItemClickableContainer
+                onClick={
+                  isAccountAlreadyConnected
+                    ? undefined
+                    : () =>
+                        setSelectedAccountNames(selectedAccountNames =>
+                          isAccountSelected
+                            ? selectedAccountNames.filter(
+                                accountName => accountName !== account.name
+                              )
+                            : [...selectedAccountNames, account.name]
+                        )
+                }
+                isDisabled={isAccountAlreadyConnected}
+              >
+                <Checkbox
+                  variant="square"
+                  checked={isAccountSelected || isAccountAlreadyConnected}
+                  disabled={isAccountAlreadyConnected}
                 />
-              </AccountNameWithHashListItemContainer>
-            </ListItemClickableContainer>
-          )}
+                <AccountNameWithHashListItemContainer>
+                  <Typography
+                    type={
+                      activeAccount && activeAccount.name === account.name
+                        ? 'bodySemiBold'
+                        : 'body'
+                    }
+                  >
+                    {account.name}
+                  </Typography>
+                  <Hash
+                    value={account.publicKey}
+                    variant={HashVariant.CaptionHash}
+                    truncated
+                    placement={
+                      index === accountsListItems.length - 1
+                        ? 'topRight'
+                        : 'bottomRight'
+                    }
+                  />
+                </AccountNameWithHashListItemContainer>
+              </ListItemClickableContainer>
+            );
+          }}
           marginLeftForItemSeparatorLine={60}
         />
       </ContentContainer>

--- a/src/libs/layout/containers.ts
+++ b/src/libs/layout/containers.ts
@@ -195,8 +195,10 @@ export const FooterButtonsContainer = styled(SpaceBetweenFlexRow)<Props>`
   background-color: ${({ theme }) => theme.color.backgroundPrimary};
 `;
 
-export const ListItemClickableContainer = styled(SpaceBetweenFlexRow)`
-  cursor: pointer;
+export const ListItemClickableContainer = styled(SpaceBetweenFlexRow)<{
+  isDisabled?: boolean;
+}>`
+  cursor: ${({ isDisabled }) => (isDisabled ? 'default' : 'pointer')};
 
   width: 100%;
   padding: 14px 18px;


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

Updated the clickable container and checkbox components to respect account connection status. Disabled interaction and visual states for accounts that are already connected to prevent unintended actions. Simplified account list processing by removing the filtering of connected accounts earlier in the pipeline.

## Linked tickets

[WALLET-287](https://make-software.atlassian.net/browse/WALLET-287)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [ ] Include a screenshot or recording if implementing significant UI or user flow change

- [ ] When this PR affects architecture changes wait for review from Dmytro before merging
