### PR TITLE
fix: fix issue with broken `delegate max` button

### DIFF
--- a/src/apps/popup/pages/stakes/amount-step.tsx
+++ b/src/apps/popup/pages/stakes/amount-step.tsx
@@ -32,7 +32,7 @@ const StakeMaxButton = styled(AlignedFlexRow)<{ disabled?: boolean }>`
 interface AmountStepProps {
   amountForm: UseFormReturn<StakeAmountFormValues>;
   stakeType: AuctionManagerEntryPoint;
-  stakeAmountMotes: string;
+  maxAmountMotesForStaking: string;
   amountStepText: string;
   amountStepMaxAmountValue: string | null;
 }
@@ -40,7 +40,7 @@ interface AmountStepProps {
 export const AmountStep = ({
   amountForm,
   stakeType,
-  stakeAmountMotes,
+  maxAmountMotesForStaking,
   amountStepText,
   amountStepMaxAmountValue
 }: AmountStepProps) => {
@@ -76,10 +76,10 @@ export const AmountStep = ({
           Big(accountBalance.liquidBalance).gte(STAKE_COST_MOTES);
 
         setDisabled(!hasEnoughBalance);
-        setMaxAmountMotes(stakeAmountMotes);
+        setMaxAmountMotes(maxAmountMotesForStaking);
       }
     }
-  }, [accountBalance.liquidBalance, stakeAmountMotes, stakeType]);
+  }, [accountBalance.liquidBalance, maxAmountMotesForStaking, stakeType]);
 
   const {
     register,

--- a/src/apps/popup/pages/stakes/index.tsx
+++ b/src/apps/popup/pages/stakes/index.tsx
@@ -109,7 +109,7 @@ export const StakesPage = () => {
   const [inputAmountCSPR, setInputAmountCSPR] = useState('');
   const [validator, setValidator] = useState<ValidatorDto | null>(null);
   const [newValidator, setNewValidator] = useState<ValidatorDto | null>(null);
-  const [stakeAmountMotes, setStakeAmountMotes] = useState('');
+  const [maxAmountMotesForStaking, setMaxAmountMotesForStaking] = useState('');
   const isCasper2Network = useSelector(selectIsCasper2Network);
   const casperNetworkApiVersion = useSelector(selectCasperNetworkApiVersion);
 
@@ -141,7 +141,7 @@ export const StakesPage = () => {
   const { amountForm, validatorForm, newValidatorForm } = useStakesForm(
     accountBalance.liquidBalance,
     stakeType,
-    stakeAmountMotes,
+    maxAmountMotesForStaking,
     validator,
     newValidator,
     inputAmountCSPR,
@@ -263,7 +263,7 @@ export const StakesPage = () => {
     confirmStepText,
     amountStepText,
     amountStepMaxAmountValue
-  } = useStakeActionTexts(stakeType, stakeAmountMotes);
+  } = useStakeActionTexts(stakeType, maxAmountMotesForStaking);
 
   const confirmButtonText = useConfirmationButtonText(stakeType);
 
@@ -279,7 +279,7 @@ export const StakesPage = () => {
           }
           validator={validator}
           setValidator={setValidator}
-          setStakeAmount={setStakeAmountMotes}
+          setMaxAmountMotesForStaking={setMaxAmountMotesForStaking}
           stakeType={stakeType}
           loading={loading}
         />
@@ -290,7 +290,7 @@ export const StakesPage = () => {
         <AmountStep
           amountForm={amountForm}
           stakeType={stakeType}
-          stakeAmountMotes={stakeAmountMotes}
+          maxAmountMotesForStaking={maxAmountMotesForStaking}
           amountStepText={amountStepText}
           amountStepMaxAmountValue={amountStepMaxAmountValue}
         />

--- a/src/apps/popup/pages/stakes/index.tsx
+++ b/src/apps/popup/pages/stakes/index.tsx
@@ -311,7 +311,6 @@ export const StakesPage = () => {
           validatorList={validatorList}
           validator={newValidator}
           setValidator={setNewValidator}
-          setStakeAmount={setStakeAmountMotes}
         />
       </Step>
     ),

--- a/src/apps/popup/pages/stakes/redelegate-validator-dropdown-input.tsx
+++ b/src/apps/popup/pages/stakes/redelegate-validator-dropdown-input.tsx
@@ -21,15 +21,13 @@ interface ValidatorDropdownInputProps {
   validatorList: ValidatorDto[] | null;
   validator: ValidatorDto | null;
   setValidator: React.Dispatch<React.SetStateAction<ValidatorDto | null>>;
-  setStakeAmount: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export const RedelegateValidatorDropdownInput = ({
   newValidatorForm,
   validatorList,
   validator,
-  setValidator,
-  setStakeAmount
+  setValidator
 }: ValidatorDropdownInputProps) => {
   const [isOpenValidatorPublicKeysList, setIsOpenValidatorPublicKeysList] =
     useState(true);
@@ -58,7 +56,6 @@ export const RedelegateValidatorDropdownInput = ({
         if (inputValue !== '') {
           setShowValidatorPlate(true);
           setValue('newValidatorPublicKey', validator.publicKey);
-          setStakeAmount(validator.stake!);
           await resetAndTriggerPublicKey(validator.publicKey);
         } else {
           setShowValidatorPlate(false);
@@ -90,7 +87,6 @@ export const RedelegateValidatorDropdownInput = ({
 
   const handleValidatorClick = (validator: ValidatorDto) => {
     setValue('newValidatorPublicKey', validator.publicKey);
-    setStakeAmount(validator.stake!);
 
     setValidator(validator);
 

--- a/src/apps/popup/pages/stakes/utils.ts
+++ b/src/apps/popup/pages/stakes/utils.ts
@@ -78,7 +78,7 @@ export const useFilteredValidators = (
 
 export const useStakeActionTexts = (
   stakeType: AuctionManagerEntryPoint,
-  stakeAmountMotes?: string
+  maxAmountMotesForStaking?: string
 ) => {
   const [state, setState] = useState<StakeTexts>({
     ...stakeActionsTextMap[stakeType],
@@ -87,8 +87,10 @@ export const useStakeActionTexts = (
 
   useEffect(() => {
     const formattedAmountCSPR =
-      stakeAmountMotes &&
-      formatNumber(motesToCSPR(stakeAmountMotes), { precision: { max: 4 } });
+      maxAmountMotesForStaking &&
+      formatNumber(motesToCSPR(maxAmountMotesForStaking), {
+        precision: { max: 4 }
+      });
 
     setState({
       ...stakeActionsTextMap[stakeType],
@@ -97,7 +99,7 @@ export const useStakeActionTexts = (
           ? `${formattedAmountCSPR} CSPR`
           : null
     });
-  }, [stakeAmountMotes, stakeType]);
+  }, [maxAmountMotesForStaking, stakeType]);
 
   return state;
 };

--- a/src/apps/popup/pages/stakes/validator-dropdown-input.tsx
+++ b/src/apps/popup/pages/stakes/validator-dropdown-input.tsx
@@ -23,7 +23,7 @@ interface ValidatorDropdownInputProps {
   validatorList: ValidatorDto[] | null;
   validator: ValidatorDto | null;
   setValidator: React.Dispatch<React.SetStateAction<ValidatorDto | null>>;
-  setStakeAmount: React.Dispatch<React.SetStateAction<string>>;
+  setMaxAmountMotesForStaking: React.Dispatch<React.SetStateAction<string>>;
   stakeType: AuctionManagerEntryPoint;
   loading: boolean;
 }
@@ -33,7 +33,7 @@ export const ValidatorDropdownInput = ({
   validatorList,
   validator,
   setValidator,
-  setStakeAmount,
+  setMaxAmountMotesForStaking,
   stakeType,
   loading
 }: ValidatorDropdownInputProps) => {
@@ -65,7 +65,7 @@ export const ValidatorDropdownInput = ({
         if (inputValue !== '') {
           setShowValidatorPlate(true);
           setValue('validatorPublicKey', validator.publicKey);
-          setStakeAmount(validator.stake!);
+          setMaxAmountMotesForStaking(validator.stake!);
           await resetAndTriggerPublicKey(validator.publicKey);
         } else {
           setShowValidatorPlate(false);
@@ -111,7 +111,7 @@ export const ValidatorDropdownInput = ({
 
   const handleValidatorClick = (validator: ValidatorDto) => {
     setValue('validatorPublicKey', validator.publicKey);
-    setStakeAmount(validator.stake!);
+    setMaxAmountMotesForStaking(validator.stake!);
 
     setValidator(validator);
 

--- a/src/libs/ui/forms/form-validation-rules.ts
+++ b/src/libs/ui/forms/form-validation-rules.ts
@@ -321,7 +321,7 @@ export const usePaymentAmountRule = (csprBalance: string | undefined) => {
 export const useCSPRStakeAmountRule = (
   amountMotes: string | undefined,
   mode: AuctionManagerEntryPoint,
-  stakeAmountMotes: string,
+  maxAmountMotesForStaking: string,
   validatorMinAmount: string,
   validatorMaxAmount: string
 ) => {
@@ -403,12 +403,14 @@ export const useCSPRStakeAmountRule = (
           switch (mode) {
             case AuctionManagerEntryPoint.undelegate: {
               return Big(CSPRtoMotes(csprAmountInputValue)).lte(
-                Big(stakeAmountMotes).sub(getStakeMinAmountMotes()).toFixed()
+                Big(maxAmountMotesForStaking)
+                  .sub(getStakeMinAmountMotes())
+                  .toFixed()
               );
             }
             case AuctionManagerEntryPoint.redelegate: {
               return Big(CSPRtoMotes(csprAmountInputValue)).lte(
-                Big(stakeAmountMotes).toFixed()
+                Big(maxAmountMotesForStaking).toFixed()
               );
             }
             case AuctionManagerEntryPoint.delegate:

--- a/src/libs/ui/forms/stakes-form.ts
+++ b/src/libs/ui/forms/stakes-form.ts
@@ -30,7 +30,7 @@ export type StakeAmountFormValues = {
 export const useStakesForm = (
   amountMotes: string | undefined,
   stakeType: AuctionManagerEntryPoint,
-  stakeAmountMotes: string,
+  maxAmountMotesForStaking: string,
   validator: IValidator | null,
   newValidator: IValidator | null,
   inputAmountCspr: string,
@@ -87,7 +87,7 @@ export const useStakesForm = (
     amount: useCSPRStakeAmountRule(
       amountMotes,
       stakeType,
-      stakeAmountMotes,
+      maxAmountMotesForStaking,
       minAmount,
       maxAmount
     )


### PR DESCRIPTION
_**Make sure to fill in all the below sections.**_

## Description

Updated variable names across components to better reflect their purpose, replacing `stakeAmountMotes` with `maxAmountMotesForStaking`. This improves clarity regarding the maximum amount available for staking and ensures consistency throughout the codebase.
Removed `maxAmountMotesForStaking` from redelegate validator dropdown input.

## Linked tickets

[WALLET-XXX](https://make-software.atlassian.net/browse/WALLET-XXX)

## Checklist

- [ ] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [ ] If the PR adds any new text to the UI, make sure they are localized

- [ ] Include a screenshot or recording if implementing significant UI or user flow change

- [ ] When this PR affects architecture changes wait for review from Dmytro before merging
