### PR TITLE
chore(deps): bump casper-wallet-core — EIP-712 chain name dedup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "base64-loader": "1.0.0",
         "big.js": "^6.2.1",
         "casper-js-sdk": "5.0.12",
-        "casper-wallet-core": "https://github.com/make-software/casper-wallet-core.git#442723023778ee0bbfce3ca886015d1372a883e2",
+        "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#a833509b62534197165212d4742e49159325771c",
         "date-fns": "^4.1.0",
         "dotenv-webpack": "^8.1.0",
         "i18next": "^23.11.0",
@@ -9218,6 +9218,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/addons-linter/node_modules/node-fetch": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/addons-linter/node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -9263,6 +9286,37 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/addons-linter/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/addons-linter/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/addons-linter/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/addons-moz-compare": {
@@ -11010,8 +11064,9 @@
     "node_modules/casper-wallet-core": {
       "name": "CasperWalletCore",
       "version": "1.3.0",
-      "resolved": "git+ssh://git@github.com/make-software/casper-wallet-core.git#442723023778ee0bbfce3ca886015d1372a883e2",
-      "integrity": "sha512-Df4r1A1uFidPoEnUMVBXHD+ccKSiJstFq9OUkWQPKWrBz6vuBaIcpe2nyhnHIHKcTrBu2vteM/A0FG0p9OrelQ==",
+      "resolved": "git+ssh://git@github.com/make-software/casper-wallet-core.git#a833509b62534197165212d4742e49159325771c",
+      "integrity": "sha512-Kmbi4Ax0htVRYVPNkfmu1CCFpYJgE0SsxNpWTtM7pzQ5R6ngrSgLOAm0ry2dwR0Q0CY+usSh1ZrwYG4FSFmaaQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@casper-ecosystem/casper-eip-712": "1.2.1",
         "@noble/hashes": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "base64-loader": "1.0.0",
     "big.js": "^6.2.1",
     "casper-js-sdk": "5.0.12",
-    "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#442723023778ee0bbfce3ca886015d1372a883e2",
+    "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#a833509b62534197165212d4742e49159325771c",
     "date-fns": "^4.1.0",
     "dotenv-webpack": "^8.1.0",
     "i18next": "^23.11.0",


### PR DESCRIPTION
## What

Bumps `casper-wallet-core` from `4427230` to [`a833509`](https://github.com/make-software/casper-wallet-core/commit/a833509b62534197165212d4742e49159325771c).

This picks up the core change that removes the duplicated **Chain Name** row from the **Domain** section of EIP-712 signature requests.

## Why

On the EIP-712 signature request screen, the Domain section showed the same chain value twice:

- a synthetic **Network** row, built in the wallet from `signatureRequest.chainName`, and
- a **Chain Name** row coming from `signatureRequest.domainRows`.

Both rendered `typedData.domain.chain_name`. The root of the duplication was in core: `EIP712SignatureRequestDto` promotes `chain_name` into the dedicated `chainName` field but still left it in the generic `domainRows`.

The core fix excludes `chain_name` from `domainRows` (it remains available as the dedicated `chainName` field that feeds the Network row), so the Domain section now shows a single **Network** row and no duplicate **Chain Name** row.

## Scope

- Wallet side: dependency bump only — no `.ts`/`.tsx` changes. The synthetic Network row is unchanged.
- Core side: change shipped in casper-wallet-core (`buildTypedDataDisplayModel` gained an `excludeDomainKeys` parameter; the DTO passes `['chain_name']`). `buildDisplayModel()` is unaffected.

## Testing

- `npm run tsc` — passes against the new core version.
- Core unit tests cover the new behavior (display-model + DTO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)