### PR TITLE
refactor(eip712): align signTypedData onto signTypedDataEIP712 convention

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "base64-loader": "1.0.0",
         "big.js": "^6.2.1",
         "casper-js-sdk": "5.0.12",
-        "casper-wallet-core": "https://github.com/make-software/casper-wallet-core.git#442723023778ee0bbfce3ca886015d1372a883e2",
+        "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#ac71d1f4546d28a121de9494eb7a8896c65fc6de",
         "date-fns": "^4.1.0",
         "dotenv-webpack": "^8.1.0",
         "i18next": "^23.11.0",
@@ -9218,6 +9218,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/addons-linter/node_modules/node-fetch": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/addons-linter/node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -9263,6 +9285,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/addons-linter/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/addons-linter/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/addons-linter/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/addons-moz-compare": {
@@ -11010,8 +11060,8 @@
     "node_modules/casper-wallet-core": {
       "name": "CasperWalletCore",
       "version": "1.3.0",
-      "resolved": "git+ssh://git@github.com/make-software/casper-wallet-core.git#442723023778ee0bbfce3ca886015d1372a883e2",
-      "integrity": "sha512-Df4r1A1uFidPoEnUMVBXHD+ccKSiJstFq9OUkWQPKWrBz6vuBaIcpe2nyhnHIHKcTrBu2vteM/A0FG0p9OrelQ==",
+      "resolved": "git+ssh://git@github.com/make-software/casper-wallet-core.git#ac71d1f4546d28a121de9494eb7a8896c65fc6de",
+      "integrity": "sha512-R1pJMC9IkHfX9+f5jVVCabVwQyrvbyBy8Zoxv/U2Ca1eq4Atbb8vh68bwTlDXHmCzV6aBeWyeUMjyw4XB9hiPA==",
       "dependencies": {
         "@casper-ecosystem/casper-eip-712": "1.2.1",
         "@noble/hashes": "^1.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "base64-loader": "1.0.0",
         "big.js": "^6.2.1",
         "casper-js-sdk": "5.0.12",
-        "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#ac71d1f4546d28a121de9494eb7a8896c65fc6de",
+        "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#68f5b58a868d6bea9f3d7811a52a3a4719534b39",
         "date-fns": "^4.1.0",
         "dotenv-webpack": "^8.1.0",
         "i18next": "^23.11.0",
@@ -11060,8 +11060,8 @@
     "node_modules/casper-wallet-core": {
       "name": "CasperWalletCore",
       "version": "1.3.0",
-      "resolved": "git+ssh://git@github.com/make-software/casper-wallet-core.git#ac71d1f4546d28a121de9494eb7a8896c65fc6de",
-      "integrity": "sha512-R1pJMC9IkHfX9+f5jVVCabVwQyrvbyBy8Zoxv/U2Ca1eq4Atbb8vh68bwTlDXHmCzV6aBeWyeUMjyw4XB9hiPA==",
+      "resolved": "git+ssh://git@github.com/make-software/casper-wallet-core.git#68f5b58a868d6bea9f3d7811a52a3a4719534b39",
+      "integrity": "sha512-/j1lHw0F3OZmO28DAMYR/hsZRH9uyzqKuJnpXtrpYdKFr7TSzCx222T1+b9xae3IbmaCRO6bQdrL08Q693jBuA==",
       "dependencies": {
         "@casper-ecosystem/casper-eip-712": "1.2.1",
         "@noble/hashes": "^1.8.0",
@@ -11071,7 +11071,7 @@
         "decimal.js": "^10.6.0",
         "deepmerge": "^4.3.1",
         "lru-cache": "11.5.1",
-        "uuid": "^14.0.0"
+        "uuid": "^14.0.1"
       },
       "engines": {
         "node": "20 || >=22"
@@ -11097,14 +11097,13 @@
       }
     },
     "node_modules/casper-wallet-core/node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "license": "MIT",
       "bin": {
         "uuid": "dist-node/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "base64-loader": "1.0.0",
     "big.js": "^6.2.1",
     "casper-js-sdk": "5.0.12",
-    "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#ac71d1f4546d28a121de9494eb7a8896c65fc6de",
+    "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#68f5b58a868d6bea9f3d7811a52a3a4719534b39",
     "date-fns": "^4.1.0",
     "dotenv-webpack": "^8.1.0",
     "i18next": "^23.11.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "base64-loader": "1.0.0",
     "big.js": "^6.2.1",
     "casper-js-sdk": "5.0.12",
-    "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#442723023778ee0bbfce3ca886015d1372a883e2",
+    "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#ac71d1f4546d28a121de9494eb7a8896c65fc6de",
     "date-fns": "^4.1.0",
     "dotenv-webpack": "^8.1.0",
     "i18next": "^23.11.0",

--- a/src/apps/signature-request/pages/sign-eip712/index.tsx
+++ b/src/apps/signature-request/pages/sign-eip712/index.tsx
@@ -104,7 +104,7 @@ export function SignEip712Page() {
   // Stored payload is present but not valid JSON — cannot proceed.
   if (isInvalidPayload) {
     const error = Error(
-      ErrorMessages.signTypedData.INVALID_TYPED_DATA.description
+      ErrorMessages.signTypedDataEIP712.INVALID_TYPED_DATA.description
     );
     sendSdkResponseToSpecificTab(
       sdkMethod.signTypedDataError(error, { requestId }),
@@ -133,7 +133,7 @@ export function SignEip712Page() {
   // Ledger hardware wallets do not support EIP-712 typed data signing.
   if (signingAccount.hardware === HardwareWalletType.Ledger) {
     const error = Error(
-      ErrorMessages.signTypedData.LEDGER_NOT_SUPPORTED.description
+      ErrorMessages.signTypedDataEIP712.LEDGER_NOT_SUPPORTED.description
     );
     sendSdkResponseToSpecificTab(
       sdkMethod.signTypedDataError(error, { requestId }),
@@ -218,7 +218,7 @@ export function SignEip712Page() {
         publicKey.cryptoAlg
       );
 
-      const result = eip712Repository.signTypedData({
+      const result = eip712Repository.signTypedDataEIP712({
         typedData,
         privateKey,
         options
@@ -244,7 +244,7 @@ export function SignEip712Page() {
       responseSentRef.current = true;
       sendSdkResponseToSpecificTab(
         sdkMethod.signTypedDataError(
-          Error(ErrorMessages.signTypedData.SIGNING_FAILED.description),
+          Error(ErrorMessages.signTypedDataEIP712.SIGNING_FAILED.description),
           { requestId }
         ),
         requestTabId

--- a/src/apps/signature-request/pages/sign-eip712/index.tsx
+++ b/src/apps/signature-request/pages/sign-eip712/index.tsx
@@ -107,7 +107,7 @@ export function SignEip712Page() {
       ErrorMessages.signTypedDataEIP712.INVALID_TYPED_DATA.description
     );
     sendSdkResponseToSpecificTab(
-      sdkMethod.signTypedDataError(error, { requestId }),
+      sdkMethod.signTypedDataEIP712Error(error, { requestId }),
       requestTabId
     );
     throw error;
@@ -124,7 +124,7 @@ export function SignEip712Page() {
       ErrorMessages.signTransaction.SIGNING_ACCOUNT_MISSING.description
     );
     sendSdkResponseToSpecificTab(
-      sdkMethod.signTypedDataError(error, { requestId }),
+      sdkMethod.signTypedDataEIP712Error(error, { requestId }),
       requestTabId
     );
     throw error;
@@ -136,7 +136,7 @@ export function SignEip712Page() {
       ErrorMessages.signTypedDataEIP712.LEDGER_NOT_SUPPORTED.description
     );
     sendSdkResponseToSpecificTab(
-      sdkMethod.signTypedDataError(error, { requestId }),
+      sdkMethod.signTypedDataEIP712Error(error, { requestId }),
       requestTabId
     );
     throw error;
@@ -148,7 +148,7 @@ export function SignEip712Page() {
       ErrorMessages.signTransaction.SIGNING_ACCOUNT_MISSING.description
     );
     sendSdkResponseToSpecificTab(
-      sdkMethod.signTypedDataError(error, { requestId }),
+      sdkMethod.signTypedDataEIP712Error(error, { requestId }),
       requestTabId
     );
     throw error;
@@ -188,7 +188,7 @@ export function SignEip712Page() {
     if (responseSentRef.current) return;
     responseSentRef.current = true;
     sendSdkResponseToSpecificTab(
-      sdkMethod.signTypedDataResponse(
+      sdkMethod.signTypedDataEIP712Response(
         {
           cancelled: true,
           signature: null,
@@ -226,7 +226,7 @@ export function SignEip712Page() {
 
       responseSentRef.current = true;
       sendSdkResponseToSpecificTab(
-        sdkMethod.signTypedDataResponse(
+        sdkMethod.signTypedDataEIP712Response(
           {
             cancelled: false,
             signature: result.signature,
@@ -243,7 +243,7 @@ export function SignEip712Page() {
     } catch {
       responseSentRef.current = true;
       sendSdkResponseToSpecificTab(
-        sdkMethod.signTypedDataError(
+        sdkMethod.signTypedDataEIP712Error(
           Error(ErrorMessages.signTypedDataEIP712.SIGNING_FAILED.description),
           { requestId }
         ),

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -468,7 +468,7 @@ runtime.onMessage.addListener(
             return sendResponse(undefined);
           }
 
-          case getType(sdkMethod.signTypedDataRequest): {
+          case getType(sdkMethod.signTypedDataEIP712Request): {
             const origin = getUrlOrigin(sender.url);
             if (!origin) {
               return sendError(CannotGetSenderOriginError());

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -407,7 +407,7 @@ export const ErrorMessages = {
         'Ledger hardware wallets do not support message decryption. Use a software wallet instead.'
     }
   },
-  signTypedData: {
+  signTypedDataEIP712: {
     LEDGER_NOT_SUPPORTED: {
       message: 'Typed data signing with Ledger is not supported',
       description:

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -24,8 +24,8 @@ async function handleSdkMessage(message: SdkEvent | SdkMethod) {
       case getType(sdkMethod.signResponse):
       case getType(sdkMethod.signMessageError):
       case getType(sdkMethod.signMessageResponse):
-      case getType(sdkMethod.signTypedDataResponse):
-      case getType(sdkMethod.signTypedDataError):
+      case getType(sdkMethod.signTypedDataEIP712Response):
+      case getType(sdkMethod.signTypedDataEIP712Error):
       case getType(sdkMethod.decryptMessageResponse):
       case getType(sdkMethod.decryptMessageError):
       case getType(sdkMethod.encryptMessageResponse):

--- a/src/content/sdk-method.ts
+++ b/src/content/sdk-method.ts
@@ -61,7 +61,9 @@ export const sdkMethod = {
     Error,
     Meta
   >(),
-  signTypedDataRequest: createAction('CasperWalletProvider:SignTypedData')<
+  signTypedDataEIP712Request: createAction(
+    'CasperWalletProvider:SignTypedDataEIP712'
+  )<
     {
       typedData: SignTypedDataParams['typedData'];
       options?: SignTypedDataParams['options'];
@@ -69,13 +71,12 @@ export const sdkMethod = {
     },
     Meta
   >(),
-  signTypedDataResponse: createAction(
-    'CasperWalletProvider:SignTypedData:Response'
+  signTypedDataEIP712Response: createAction(
+    'CasperWalletProvider:SignTypedDataEIP712:Response'
   )<SignTypedDataResult, Meta>(),
-  signTypedDataError: createAction('CasperWalletProvider:SignTypedData:Error')<
-    Error,
-    Meta
-  >(),
+  signTypedDataEIP712Error: createAction(
+    'CasperWalletProvider:SignTypedDataEIP712:Error'
+  )<Error, Meta>(),
   encryptMessageRequest: createAction('CasperWalletProvider:EncryptMessage')<
     {
       message: string;

--- a/src/content/sdk-types.ts
+++ b/src/content/sdk-types.ts
@@ -16,7 +16,7 @@ export enum CasperWalletSupports {
   signDeploy = 'sign-deploy',
   signTransactionV1 = 'sign-transactionv1',
   signMessage = 'sign-message',
-  signTypedData = 'sign-typed-data',
+  signTypedDataEIP712 = 'sign-typed-data-eip712',
   messageEncryption = 'message-encryption',
   messageDecryption = 'message-decryption'
 }

--- a/src/content/sdk.ts
+++ b/src/content/sdk.ts
@@ -208,9 +208,9 @@ export const CasperWalletProvider = (options?: CasperWalletProviderOptions) => {
       signingPublicKeyHex: string
     ): Promise<SignTypedDataResult> => {
       return fetchFromBackground<
-        ReturnType<(typeof sdkMethod)['signTypedDataResponse']>['payload']
+        ReturnType<(typeof sdkMethod)['signTypedDataEIP712Response']>['payload']
       >(
-        sdkMethod.signTypedDataRequest(
+        sdkMethod.signTypedDataEIP712Request(
           {
             typedData: params.typedData,
             options: params.options,

--- a/src/content/sdk.ts
+++ b/src/content/sdk.ts
@@ -203,7 +203,7 @@ export const CasperWalletProvider = (options?: CasperWalletProviderOptions) => {
         };
       });
     },
-    signTypedData: (
+    signTypedDataEIP712: (
       params: SignTypedDataParams,
       signingPublicKeyHex: string
     ): Promise<SignTypedDataResult> => {

--- a/src/content/sdk.ts
+++ b/src/content/sdk.ts
@@ -363,7 +363,7 @@ export const CasperWalletProvider = (options?: CasperWalletProviderOptions) => {
     },
     /**
      * Get a list of features that the active public key supports.
-     * It can be `sign-deploy`, `sign-transactionv1`, `sign-message` and `messages-encryption`
+     * It can be `sign-deploy`, `sign-transactionv1`, `sign-message`, `sign-typed-data-eip712`, `message-encryption` and `message-decryption`
      * @returns returns array of features that supports the active public key.
      * @throws when wallet is locked (err.code: 1)
      * @throws when active account not approved to connect with the site (err.code: 2)

--- a/src/libs/services/signature-request-service/use-fetch-data-for-eip712-request.ts
+++ b/src/libs/services/signature-request-service/use-fetch-data-for-eip712-request.ts
@@ -49,7 +49,7 @@ export const useFetchDataForEip712Request = ({
             ErrorMessages.signTransaction.INVALID_TRANSACTION_JSON.description
           );
           sendSdkResponseToSpecificTab(
-            sdkMethod.signTypedDataError(error, { requestId }),
+            sdkMethod.signTypedDataEIP712Error(error, { requestId }),
             requestTabId
           );
           throw error;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -211,7 +211,7 @@ export const getActiveAccountSupports = (activeAccount: Account) => {
     : [
         CasperWalletSupports.signDeploy,
         CasperWalletSupports.signMessage,
-        CasperWalletSupports.signTypedData,
+        CasperWalletSupports.signTypedDataEIP712,
         CasperWalletSupports.signTransactionV1,
         CasperWalletSupports.messageEncryption,
         CasperWalletSupports.messageDecryption


### PR DESCRIPTION
## Summary

Aligns the wallet's EIP-712 identifiers onto the cross-repo `…TypedDataEIP712…` naming convention (the `EIP712` token inserted immediately after the `TypedData` segment), and bumps `casper-wallet-core` to the build that contains the matching core rename.

Pure, behavior-preserving rename — `npm run ci-check` passes (format, lint, tsc, tests).

## Commits

1. `chore(deps)`: bump `casper-wallet-core` to a commit exposing `signTypedDataEIP712` (the bump is what required the rest of this PR — the old call no longer compiled).
2. `feat(eip712)`: rename the `supports` feature value to `sign-typed-data-eip712` (matches CSPR.click's `SignTypedDataEIP712`).
3. `refactor(eip712)`: dApp-facing provider method `signTypedData` → `signTypedDataEIP712`, the `eip712Repository.signTypedData` core call, and the `ErrorMessages.signTypedData` key.
4. `refactor(eip712)`: internal action creators `signTypedData{Request,Response,Error}` → `signTypedDataEIP712{...}` and the wire action strings `'CasperWalletProvider:SignTypedData'` (+ `:Response`/`:Error`).
5. `chore(deps)`: update `casper-wallet-core` to the latest commit.

## Left unchanged (by design)

- Type names `SignTypedDataParams`, `SignTypedDataResult`, and core-imported `IEIP712SignTypedData*` / `IEIP712TypedData`.
- `eip712Repository.prepareSignatureRequest` (not renamed in core).

## Reviewer note — shared wire protocol

The wire action strings `'CasperWalletProvider:SignTypedDataEIP712'` (+ `:Response`/`:Error`) are a protocol shared with the mobile webview bridge. `casper-wallet-mobile` must mirror them in its own pass; wallet and mobile should release together so the bridge stays in sync. The dApp-facing provider method rename is also a breaking change for integrators — acceptable because EIP-712 is not yet released.

## Part of cross-repo effort

`casper-wallet-core` (PR #47) → `casper-wallet-playground` (draft PR #22) → **this** → `casper-wallet-mobile`.
