### PR TITLE
chore(deps): bump casper-wallet-core to 4947d06

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "base64-loader": "1.0.0",
         "big.js": "^6.2.1",
         "casper-js-sdk": "5.0.12",
-        "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#08d725e5c78dd4537e5f39f27e8208c450de813d",
+        "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#4947d0652a6bc4346b23d54d0d74015746298ed4",
         "date-fns": "^4.1.0",
         "dotenv-webpack": "^8.1.0",
         "i18next": "^23.11.0",
@@ -11041,8 +11041,8 @@
     "node_modules/casper-wallet-core": {
       "name": "CasperWalletCore",
       "version": "1.3.0",
-      "resolved": "git+ssh://git@github.com/make-software/casper-wallet-core.git#08d725e5c78dd4537e5f39f27e8208c450de813d",
-      "integrity": "sha512-dN7ja46pdMYqQIJGBnZRIE8MRfL8sKMnXG/d404xuNrgeANhdP4meJ5SA/mP7E1qCO5F5GT66u/cANAixGX8iQ==",
+      "resolved": "git+ssh://git@github.com/make-software/casper-wallet-core.git#4947d0652a6bc4346b23d54d0d74015746298ed4",
+      "integrity": "sha512-2dVG1R0pr+qRTqPlu4gyzcuh8ZnOsjWd62ZBXPVbuRl7EkH/lBxKR35FAQXQ7A/jv89ueckoREY0qporvgdXgg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@casper-ecosystem/casper-eip-712": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "base64-loader": "1.0.0",
     "big.js": "^6.2.1",
     "casper-js-sdk": "5.0.12",
-    "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#08d725e5c78dd4537e5f39f27e8208c450de813d",
+    "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#4947d0652a6bc4346b23d54d0d74015746298ed4",
     "date-fns": "^4.1.0",
     "dotenv-webpack": "^8.1.0",
     "i18next": "^23.11.0",


### PR DESCRIPTION
## Summary

Bumps `casper-wallet-core` to `4947d0652a6bc4346b23d54d0d74015746298ed4`.

## Changes
- Updated the `casper-wallet-core` git ref in `package.json` and `package-lock.json` (hash + integrity).

## Verification
- `npm run ci-check` passes (format:check + lint + tsc + test, 28/28 tests green), including the wallet-side `tsc` compile of the core source under target es2017.