### PR TITLE
feat(eip712): improve account presentation — show public key, fix hash label, adaptive row wrap (WALLET-1321)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "base64-loader": "1.0.0",
         "big.js": "^6.2.1",
         "casper-js-sdk": "5.0.12",
-        "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#4947d0652a6bc4346b23d54d0d74015746298ed4",
+        "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#3d944e30ef6b94086e0463efbe7e35584a1a66b8",
         "date-fns": "^4.1.0",
         "dotenv-webpack": "^8.1.0",
         "i18next": "^23.11.0",
@@ -11041,8 +11041,8 @@
     "node_modules/casper-wallet-core": {
       "name": "CasperWalletCore",
       "version": "1.3.0",
-      "resolved": "git+ssh://git@github.com/make-software/casper-wallet-core.git#4947d0652a6bc4346b23d54d0d74015746298ed4",
-      "integrity": "sha512-2dVG1R0pr+qRTqPlu4gyzcuh8ZnOsjWd62ZBXPVbuRl7EkH/lBxKR35FAQXQ7A/jv89ueckoREY0qporvgdXgg==",
+      "resolved": "git+ssh://git@github.com/make-software/casper-wallet-core.git#3d944e30ef6b94086e0463efbe7e35584a1a66b8",
+      "integrity": "sha512-zeGmnotrbw++eDCoGr1yAaXghCVtqPqNJ0QCYKZ/+QxnYOU5d4fWJYCks+7aK000EhMnskRUFvZOWh83psfOtw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@casper-ecosystem/casper-eip-712": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "base64-loader": "1.0.0",
         "big.js": "^6.2.1",
         "casper-js-sdk": "5.0.12",
-        "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#3d944e30ef6b94086e0463efbe7e35584a1a66b8",
+        "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#448c7cbadca5d12afc02ec03f3c7c5ee8d4a2418",
         "date-fns": "^4.1.0",
         "dotenv-webpack": "^8.1.0",
         "i18next": "^23.11.0",
@@ -11041,8 +11041,8 @@
     "node_modules/casper-wallet-core": {
       "name": "CasperWalletCore",
       "version": "1.3.0",
-      "resolved": "git+ssh://git@github.com/make-software/casper-wallet-core.git#3d944e30ef6b94086e0463efbe7e35584a1a66b8",
-      "integrity": "sha512-zeGmnotrbw++eDCoGr1yAaXghCVtqPqNJ0QCYKZ/+QxnYOU5d4fWJYCks+7aK000EhMnskRUFvZOWh83psfOtw==",
+      "resolved": "git+ssh://git@github.com/make-software/casper-wallet-core.git#448c7cbadca5d12afc02ec03f3c7c5ee8d4a2418",
+      "integrity": "sha512-Ou3Xsa85rWB0oFKQHt41jqAV/lxAfQK7NiWN5FGM7pQFfEQMiqI9c4IQvjY9HMSdvKh3ezHUDacA42Ug8jrl1w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@casper-ecosystem/casper-eip-712": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "base64-loader": "1.0.0",
     "big.js": "^6.2.1",
     "casper-js-sdk": "5.0.12",
-    "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#4947d0652a6bc4346b23d54d0d74015746298ed4",
+    "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#3d944e30ef6b94086e0463efbe7e35584a1a66b8",
     "date-fns": "^4.1.0",
     "dotenv-webpack": "^8.1.0",
     "i18next": "^23.11.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "base64-loader": "1.0.0",
     "big.js": "^6.2.1",
     "casper-js-sdk": "5.0.12",
-    "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#3d944e30ef6b94086e0463efbe7e35584a1a66b8",
+    "casper-wallet-core": "git+ssh://git@github.com:make-software/casper-wallet-core.git#448c7cbadca5d12afc02ec03f3c7c5ee8d4a2418",
     "date-fns": "^4.1.0",
     "dotenv-webpack": "^8.1.0",
     "i18next": "^23.11.0",

--- a/src/apps/signature-request/pages/sign-eip712/eip712-display-row.tsx
+++ b/src/apps/signature-request/pages/sign-eip712/eip712-display-row.tsx
@@ -21,6 +21,7 @@ const RowDataContainer = styled(SpaceBetweenFlexRow)`
   margin: 16px;
   width: unset;
   gap: 8px;
+  flex-wrap: wrap;
 `;
 
 interface Eip712DisplayRowProps {
@@ -45,13 +46,16 @@ export function Eip712DisplayRow({ row }: Eip712DisplayRowProps) {
   }
 
   if (row.presentation === 'account') {
+    const publicKey = row.accountInfo?.publicKey;
+
     return (
       <RowDataContainer>
         <Typography type="body" color="contentSecondary">
           {row.label}
         </Typography>
         <AccountInfoRow
-          publicKey={row.value}
+          publicKey={publicKey ?? row.value}
+          isAccountHash={!publicKey}
           csprName={row.accountInfo?.csprName}
           imgLogo={row.accountInfo?.brandingLogo}
           accountName={row.accountInfo?.name}

--- a/src/apps/signature-request/pages/sign-eip712/index.tsx
+++ b/src/apps/signature-request/pages/sign-eip712/index.tsx
@@ -104,10 +104,10 @@ export function SignEip712Page() {
   // Stored payload is present but not valid JSON — cannot proceed.
   if (isInvalidPayload) {
     const error = Error(
-      ErrorMessages.signTypedDataEIP712.INVALID_TYPED_DATA.description
+      ErrorMessages.signTypedData.INVALID_TYPED_DATA.description
     );
     sendSdkResponseToSpecificTab(
-      sdkMethod.signTypedDataEIP712Error(error, { requestId }),
+      sdkMethod.signTypedDataError(error, { requestId }),
       requestTabId
     );
     throw error;
@@ -124,7 +124,7 @@ export function SignEip712Page() {
       ErrorMessages.signTransaction.SIGNING_ACCOUNT_MISSING.description
     );
     sendSdkResponseToSpecificTab(
-      sdkMethod.signTypedDataEIP712Error(error, { requestId }),
+      sdkMethod.signTypedDataError(error, { requestId }),
       requestTabId
     );
     throw error;
@@ -133,10 +133,10 @@ export function SignEip712Page() {
   // Ledger hardware wallets do not support EIP-712 typed data signing.
   if (signingAccount.hardware === HardwareWalletType.Ledger) {
     const error = Error(
-      ErrorMessages.signTypedDataEIP712.LEDGER_NOT_SUPPORTED.description
+      ErrorMessages.signTypedData.LEDGER_NOT_SUPPORTED.description
     );
     sendSdkResponseToSpecificTab(
-      sdkMethod.signTypedDataEIP712Error(error, { requestId }),
+      sdkMethod.signTypedDataError(error, { requestId }),
       requestTabId
     );
     throw error;
@@ -148,7 +148,7 @@ export function SignEip712Page() {
       ErrorMessages.signTransaction.SIGNING_ACCOUNT_MISSING.description
     );
     sendSdkResponseToSpecificTab(
-      sdkMethod.signTypedDataEIP712Error(error, { requestId }),
+      sdkMethod.signTypedDataError(error, { requestId }),
       requestTabId
     );
     throw error;
@@ -188,7 +188,7 @@ export function SignEip712Page() {
     if (responseSentRef.current) return;
     responseSentRef.current = true;
     sendSdkResponseToSpecificTab(
-      sdkMethod.signTypedDataEIP712Response(
+      sdkMethod.signTypedDataResponse(
         {
           cancelled: true,
           signature: null,
@@ -218,7 +218,7 @@ export function SignEip712Page() {
         publicKey.cryptoAlg
       );
 
-      const result = eip712Repository.signTypedDataEIP712({
+      const result = eip712Repository.signTypedData({
         typedData,
         privateKey,
         options
@@ -226,7 +226,7 @@ export function SignEip712Page() {
 
       responseSentRef.current = true;
       sendSdkResponseToSpecificTab(
-        sdkMethod.signTypedDataEIP712Response(
+        sdkMethod.signTypedDataResponse(
           {
             cancelled: false,
             signature: result.signature,
@@ -243,8 +243,8 @@ export function SignEip712Page() {
     } catch {
       responseSentRef.current = true;
       sendSdkResponseToSpecificTab(
-        sdkMethod.signTypedDataEIP712Error(
-          Error(ErrorMessages.signTypedDataEIP712.SIGNING_FAILED.description),
+        sdkMethod.signTypedDataError(
+          Error(ErrorMessages.signTypedData.SIGNING_FAILED.description),
           { requestId }
         ),
         requestTabId

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -468,7 +468,7 @@ runtime.onMessage.addListener(
             return sendResponse(undefined);
           }
 
-          case getType(sdkMethod.signTypedDataEIP712Request): {
+          case getType(sdkMethod.signTypedDataRequest): {
             const origin = getUrlOrigin(sender.url);
             if (!origin) {
               return sendError(CannotGetSenderOriginError());

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -407,7 +407,7 @@ export const ErrorMessages = {
         'Ledger hardware wallets do not support message decryption. Use a software wallet instead.'
     }
   },
-  signTypedDataEIP712: {
+  signTypedData: {
     LEDGER_NOT_SUPPORTED: {
       message: 'Typed data signing with Ledger is not supported',
       description:

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -24,8 +24,8 @@ async function handleSdkMessage(message: SdkEvent | SdkMethod) {
       case getType(sdkMethod.signResponse):
       case getType(sdkMethod.signMessageError):
       case getType(sdkMethod.signMessageResponse):
-      case getType(sdkMethod.signTypedDataEIP712Response):
-      case getType(sdkMethod.signTypedDataEIP712Error):
+      case getType(sdkMethod.signTypedDataResponse):
+      case getType(sdkMethod.signTypedDataError):
       case getType(sdkMethod.decryptMessageResponse):
       case getType(sdkMethod.decryptMessageError):
       case getType(sdkMethod.encryptMessageResponse):

--- a/src/content/sdk-method.ts
+++ b/src/content/sdk-method.ts
@@ -61,9 +61,7 @@ export const sdkMethod = {
     Error,
     Meta
   >(),
-  signTypedDataEIP712Request: createAction(
-    'CasperWalletProvider:SignTypedDataEIP712'
-  )<
+  signTypedDataRequest: createAction('CasperWalletProvider:SignTypedData')<
     {
       typedData: SignTypedDataParams['typedData'];
       options?: SignTypedDataParams['options'];
@@ -71,12 +69,13 @@ export const sdkMethod = {
     },
     Meta
   >(),
-  signTypedDataEIP712Response: createAction(
-    'CasperWalletProvider:SignTypedDataEIP712:Response'
+  signTypedDataResponse: createAction(
+    'CasperWalletProvider:SignTypedData:Response'
   )<SignTypedDataResult, Meta>(),
-  signTypedDataEIP712Error: createAction(
-    'CasperWalletProvider:SignTypedDataEIP712:Error'
-  )<Error, Meta>(),
+  signTypedDataError: createAction('CasperWalletProvider:SignTypedData:Error')<
+    Error,
+    Meta
+  >(),
   encryptMessageRequest: createAction('CasperWalletProvider:EncryptMessage')<
     {
       message: string;

--- a/src/content/sdk.ts
+++ b/src/content/sdk.ts
@@ -203,14 +203,14 @@ export const CasperWalletProvider = (options?: CasperWalletProviderOptions) => {
         };
       });
     },
-    signTypedDataEIP712: (
+    signTypedData: (
       params: SignTypedDataParams,
       signingPublicKeyHex: string
     ): Promise<SignTypedDataResult> => {
       return fetchFromBackground<
-        ReturnType<(typeof sdkMethod)['signTypedDataEIP712Response']>['payload']
+        ReturnType<(typeof sdkMethod)['signTypedDataResponse']>['payload']
       >(
-        sdkMethod.signTypedDataEIP712Request(
+        sdkMethod.signTypedDataRequest(
           {
             typedData: params.typedData,
             options: params.options,

--- a/src/libs/services/signature-request-service/use-fetch-data-for-eip712-request.ts
+++ b/src/libs/services/signature-request-service/use-fetch-data-for-eip712-request.ts
@@ -49,7 +49,7 @@ export const useFetchDataForEip712Request = ({
             ErrorMessages.signTransaction.INVALID_TRANSACTION_JSON.description
           );
           sendSdkResponseToSpecificTab(
-            sdkMethod.signTypedDataEIP712Error(error, { requestId }),
+            sdkMethod.signTypedDataError(error, { requestId }),
             requestTabId
           );
           throw error;

--- a/src/libs/ui/components/account-info-row/account-info-row.tsx
+++ b/src/libs/ui/components/account-info-row/account-info-row.tsx
@@ -39,6 +39,7 @@ interface AccountInfoRowProps {
   withCopyIcon?: boolean;
   containerStyle?: React.CSSProperties;
   nameContainerStyle?: React.CSSProperties;
+  isAccountHash?: boolean;
 }
 
 const AccountInfoContainer = styled(AlignedFlexRow)`
@@ -63,7 +64,8 @@ export const AccountInfoRow = ({
   accountLink,
   withCopyIcon = false,
   containerStyle,
-  nameContainerStyle
+  nameContainerStyle,
+  isAccountHash
 }: AccountInfoRowProps) => {
   const [linkUrl, setLinkUrl] = useState('');
 
@@ -170,9 +172,11 @@ export const AccountInfoRow = ({
                     ownerName={accountName}
                     truncated
                     label={
-                      isPublicKeyHash(publicKey)
-                        ? t('Public key')
-                        : t('Account hash')
+                      isAccountHash
+                        ? t('Account hash')
+                        : isPublicKeyHash(publicKey)
+                          ? t('Public key')
+                          : t('Account hash')
                     }
                     truncatedSize="base"
                     color={isAction ? 'contentAction' : 'contentPrimary'}


### PR DESCRIPTION
## What & why

WALLET-1321 — improve how accounts are presented in EIP-712 signature requests.

After WALLET-1251 fixed `address` decoding, account rows display the bare 32-byte **account hash**, even though the `accountInfo` enrichment already carries the related **public key**. This PR shows the public key (and the saved account/contact name) when we have it, corrects the hash label, and makes long rows wrap adaptively.

> **Invariant preserved (WALLET-1251):** the public key is sourced **only** from `accountInfo.publicKey`. It is never recovered from the `address` bytes (an account hash is a one-way blake2b hash of the public key). When enrichment is absent, the row falls back to the account hash. This is not a regression of the previous decoding fix.

## Changes

- **Show public key from enrichment** (`eip712-display-row.tsx`): the `account` row passes `accountInfo.publicKey` to `AccountInfoRow` when present (fallback to the account hash). This also fixes, for known accounts, the explorer link, the identicon, and the saved-name lookup (which compares against `publicKey` and previously never matched an account hash).
- **Correct hash label** (`account-info-row.tsx`): new optional `isAccountHash?: boolean` prop. When set it forces the `Account hash` / `Public key` label instead of relying on the `startsWith('01'|'02')` heuristic that mislabels some account hashes. Default `undefined` keeps the existing heuristic, so all other screens that use `AccountInfoRow` are unaffected.
- **Adaptive 2-row layout**: `RowDataContainer` gains `flex-wrap: wrap`. Rows stay on a single line when there is room and wrap the value to a second, left-aligned line only when it would crowd the label (no forced column). Scalars (`Value`, `Nonce`, dates) stay single-row.

## Method rename — `signTypedDataEIP712` → `signTypedData`

Reverts the verbose `signTypedDataEIP712` naming back to `signTypedData`, realigning the typed-data signing method with the existing `signMessage` / `signDeploy` convention:

- **Provider method** (`sdk.ts`): the public, dapp-facing method is `provider.signTypedData(...)` again.
- **Action creators** (`sdk-method.ts`) and their action-type strings (`CasperWalletProvider:SignTypedData` / `:Response` / `:Error`), the background and content handlers, and the `ErrorMessages.signTypedData` key.
- **`casper-wallet-core` re-bump** to [`448c7cb`](https://github.com/make-software/casper-wallet-core/pull/52), which renames the repository method to `eip712Repository.signTypedData(...)` (used in `sign-eip712`).
- **Intentionally kept** as-is: the public `CasperWalletSupports.signTypedDataEIP712 = 'sign-typed-data-eip712'` capability value.

> Companion PRs: core [make-software/casper-wallet-core#52](https://github.com/make-software/casper-wallet-core/pull/52), playground [make-software/casper-wallet-playground#24](https://github.com/make-software/casper-wallet-playground/pull/24).

## Scope

The account-presentation changes are wallet frontend only — core already exposes `row.accountInfo.publicKey`, so they need no core change. The bundled method rename (above) additionally re-bumps `casper-wallet-core` to the `signTypedData` repository-method commit.

## Testing

This repo does not unit-test React components (zero `.tsx` tests; `testEnvironment: node`; `npm run test` runs without `--coverage`), so changes are verified the established way:

- `npm run ci-check` — format, lint (0 errors), tsc, test (28 passed) all green.
- Manual (playground): Permit `owner`/`spender` show the public key + saved name for known accounts; unknown accounts show the account hash labelled "Account hash" with no false "Public key"; the TransferWithAuthorization package row is unchanged; long rows wrap only when cramped; signing a typed-data request resolves through `provider.signTypedData(...)`.

## Out of scope

- The `subject == signer` warning (still deferred from WALLET-1251).
