### PR TITLE
ci: run CI Check on release/** branches

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -2,9 +2,9 @@ name: CI Check
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ master, develop, release/** ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ master, develop, release/** ]
 
 jobs:
   build:


### PR DESCRIPTION
Extend the CI Check workflow (format/lint/tsc/test) to also run on `push` and `pull_request` events for `release/**` branches.

## Why

CI Check currently triggers only for `master` and `develop`, so PRs targeting release branches — including the DEP-* dependency-bump series merging into `release/2.6.0` — get **no automated Linux gate**. This lets install- or platform-specific regressions pass review and only surface when the release branch later merges into `develop`.

Concretely: a regenerated `package-lock.json` can resolve correctly on the author's macOS machine while dropping the Linux native-binding entries (e.g. `@unrs/resolver-binding-linux-x64-gnu`, used by ESLint's TS import resolver and jest-resolve, plus its `wasm32-wasi` fallback). On `ubuntu-latest` with `npm ci`, lint/test then fail — but with no CI on release PRs, nothing catches it.

## What

Add `release/**` to the `push` and `pull_request` branch filters of the fast CI Check workflow, giving every release-targeted PR the same Linux `npm ci` + format/lint/tsc/test gate as `develop`.

The heavier e2e Playwright workflows (`e2e-popup-tests`, `e2e-onboarding-tests`) are intentionally left on their existing `master`/`develop` schedule, to avoid running 60-minute container jobs on every dependency PR.