### PR TITLE
chore: e2e-tests tsconfig for IDE type-checking (WALLET-1338)

### DIFF
--- a/e2e-tests/tsconfig.json
+++ b/e2e-tests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "../playwright.config.ts"]
+}


### PR DESCRIPTION
Jira: https://make-software.atlassian.net/browse/WALLET-1338

## What

Adds `e2e-tests/tsconfig.json` (7 lines) — a nested config extending the root one, covering the Playwright suite and `playwright.config.ts`.

## Why

The e2e suite is outside every existing TypeScript project: the root `tsconfig.json` includes only `src`, and the jest e2e bridge config was removed back in DEP-5. IDEs therefore type-check `e2e-tests/**` in a fallback context without the project's compiler options or automatic `@types` inclusion, producing recurring phantom errors (`TS2591: Cannot find name 'path'`, `TS2304: Cannot find name '__dirname'`) that only disappear temporarily after restarting the TS service.

With a real nested project, IDEs resolve Node globals and the repo's compiler options correctly and permanently. Follow-up to the DEP-13 QA session (#1392) — it just missed that PR's merge window.

## Verification

- `npx tsc -p e2e-tests/tsconfig.json` — exit 0 (26 files: 25 e2e specs/fixtures + `playwright.config.ts`).
- Root `npm run tsc` unchanged (nested config is not referenced by `tsc -p ./`, ts-jest, or ts-loader).
- `npx jest --listTests` unchanged — unit-test discovery unaffected.
