### PR TITLE
build(deps): DEP-16 — Redux Toolkit migration + P0.1/P1.1 (WALLET-1342)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
     '^.+\\.(j|t)sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.json' }]
   },
   transformIgnorePatterns: [
-    '<rootDir>/node_modules/(?!(@lapo/asn1js|@noble/ciphers|@formatjs|intl-messageformat)/)'
+    '<rootDir>/node_modules/(?!(@lapo/asn1js|@noble/ciphers|@formatjs|intl-messageformat|casper-wallet-core|uuid)/)'
   ],
   coveragePathIgnorePatterns: ['/node_modules/'],
   testRegex: '(/tests?/.*|(\\.|/)(test|spec))\\.tsx?$',

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,9 +13,22 @@ module.exports = {
   modulePathIgnorePatterns: ['<rootDir>/e2e-tests'],
   moduleNameMapper: {
     '^@src/(.*)$': '<rootDir>/src/$1',
-    '^@content/sdk-types$': '<rootDir>/src/content/sdk-types',
-    '^@libs/types/(.*)$': '<rootDir>/src/libs/types/$1'
+    '^@popup/(.*)$': '<rootDir>/src/apps/popup/$1',
+    '^@import-account-with-file/(.*)$':
+      '<rootDir>/src/apps/import-account-with-file/$1',
+    '^@connect-to-app/(.*)$': '<rootDir>/src/apps/connect-to-app/$1',
+    '^@signature-request/(.*)$': '<rootDir>/src/apps/signature-request/$1',
+    '^@onboarding/(.*)$': '<rootDir>/src/apps/onboarding/$1',
+    '^@background/(.*)$': '<rootDir>/src/background/$1',
+    '^@content/(.*)$': '<rootDir>/src/content/$1',
+    '^@libs/(.*)$': '<rootDir>/src/libs/$1',
+    '^@hooks/(.*)$': '<rootDir>/src/hooks/$1'
   },
+  // Coverage gate decision (DEP-16, shared with P1.6/DEP-5): the global 100%
+  // threshold now applies to this explicit universe instead of "whatever a
+  // test happens to import". P1.6 will widen the universe with realistic
+  // targets when the background test foundation lands.
+  collectCoverageFrom: ['src/background/redux/**/reducer.ts', '!**/*.d.ts'],
   setupFilesAfterEnv: ['@testing-library/jest-dom'],
   coverageReporters: ['json', 'text'],
   coverageThreshold: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
         "redux-saga": "^1.5.0",
         "reselect": "^5.2.0",
         "styled-components": "6.4.3",
-        "typesafe-actions": "5.1.0",
         "yup": "^1.7.1"
       },
       "devDependencies": {
@@ -26363,15 +26362,6 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.1"
-      }
-    },
-    "node_modules/typesafe-actions": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/typesafe-actions/-/typesafe-actions-5.1.0.tgz",
-      "integrity": "sha512-bna6Yi1pRznoo6Bz1cE6btB/Yy8Xywytyfrzu/wc+NFW3ZF0I+2iCGImhBsoYYCOWuICtRO4yHcnDlzgo1AdNg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/typescript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@ledgerhq/hw-transport-webusb": "^6.34.4",
         "@lottiefiles/react-lottie-player": "3.6.0",
         "@noble/ciphers": "^2.2.0",
+        "@reduxjs/toolkit": "^2.12.0",
         "@scure/bip32": "1.6.2",
         "@scure/bip39": "1.2.1",
         "@tanstack/react-query": "^5.101.2",
@@ -4895,7 +4896,6 @@
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
       "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -4922,7 +4922,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
       "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "redux": "^5.0.0"
@@ -5102,7 +5101,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
@@ -14977,7 +14975,6 @@
       "version": "11.1.8",
       "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
       "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lint": "eslint ./src",
     "tsc": "tsc -p ./ --noEmit",
     "test": "jest --no-cache --passWithNoTests",
+    "test:coverage": "jest --no-cache --coverage",
     "prepare": "husky",
     "locale:extract_pot": "i18next 'src/**/*.{ts,tsx}' && node scripts/locale_extract_pot.mjs",
     "locale:update_translations": "node scripts/locale_update_translations.mjs",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@ledgerhq/hw-transport-webusb": "^6.34.4",
     "@lottiefiles/react-lottie-player": "3.6.0",
     "@noble/ciphers": "^2.2.0",
+    "@reduxjs/toolkit": "^2.12.0",
     "@scure/bip32": "1.6.2",
     "@scure/bip39": "1.2.1",
     "@tanstack/react-query": "^5.101.2",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "redux-saga": "^1.5.0",
     "reselect": "^5.2.0",
     "styled-components": "6.4.3",
-    "typesafe-actions": "5.1.0",
     "yup": "^1.7.1"
   },
   "overrides": {

--- a/src/apps/onboarding/app-router.tsx
+++ b/src/apps/onboarding/app-router.tsx
@@ -27,7 +27,7 @@ import {
 } from '@onboarding/router';
 
 import { selectKeysDoesExist } from '@background/redux/keys/selectors';
-import { selectEncryptionKeyHash } from '@background/redux/session/selectors';
+import { selectEncryptionKeyDoesExist } from '@background/redux/session/selectors';
 
 import { ErrorPath, TabErrorPage } from '@libs/layout';
 
@@ -38,9 +38,9 @@ export function AppRouter() {
   const isLoggedIn = loadIsLoggedIn();
 
   const keysDoesExist = useSelector(selectKeysDoesExist);
-  const encryptionKeyHash = useSelector(selectEncryptionKeyHash);
+  const encryptionKeyDoesExist = useSelector(selectEncryptionKeyDoesExist);
 
-  if (keysDoesExist && encryptionKeyHash != null) {
+  if (keysDoesExist && encryptionKeyDoesExist) {
     if (isLoggedIn) {
       return (
         <AuthorizedUserRoutes

--- a/src/apps/onboarding/pages/create-vault-password/index.tsx
+++ b/src/apps/onboarding/pages/create-vault-password/index.tsx
@@ -9,7 +9,7 @@ import { Stepper } from '@onboarding/components/stepper';
 import { RouterPath } from '@onboarding/router';
 import { useTypedNavigate } from '@onboarding/router/use-typed-navigate';
 
-import { selectPasswordHash } from '@background/redux/keys/selectors';
+import { selectKeysDoesExist } from '@background/redux/keys/selectors';
 import { initKeys } from '@background/redux/sagas/actions';
 import { dispatchToMainStore } from '@background/redux/utils';
 
@@ -37,7 +37,7 @@ export function CreateVaultPasswordPage({
   const [isChecked, setIsChecked] = useState(false);
   const navigate = useTypedNavigate();
   const { t } = useTranslation();
-  const passwordHash = useSelector(selectPasswordHash);
+  const keysDoesExist = useSelector(selectKeysDoesExist);
 
   const {
     register,
@@ -52,10 +52,10 @@ export function CreateVaultPasswordPage({
   });
 
   useEffect(() => {
-    if (passwordHash) {
+    if (keysDoesExist) {
       navigate(RouterPath.CreateSecretPhrase);
     }
-  }, [navigate, passwordHash]);
+  }, [navigate, keysDoesExist]);
 
   async function onSubmit(data: CreatePasswordFormValues) {
     dispatchToMainStore(initKeys({ password: data.password }));

--- a/src/apps/onboarding/pages/unlock-wallet/index.tsx
+++ b/src/apps/onboarding/pages/unlock-wallet/index.tsx
@@ -8,13 +8,12 @@ import { PasswordDoesNotExistError } from '@src/errors';
 import { UnlockWalletPageContent } from '@onboarding/pages/unlock-wallet/content';
 import { RouterPath, useTypedNavigate } from '@onboarding/router';
 
-import {
-  selectPasswordHash,
-  selectPasswordSaltHash
-} from '@background/redux/keys/selectors';
+import { selectKeysDoesExist } from '@background/redux/keys/selectors';
 import { loginRetryCountReseted } from '@background/redux/login-retry-count/actions';
 import { selectLoginRetryCount } from '@background/redux/login-retry-count/selectors';
 import { dispatchToMainStore } from '@background/redux/utils';
+
+import { usePrivateState } from '@hooks/use-private-state';
 
 import {
   LayoutTab,
@@ -33,16 +32,49 @@ interface UnlockWalletPageProps {
 }
 
 export function UnlockWalletPage({ saveIsLoggedIn }: UnlockWalletPageProps) {
-  const navigate = useTypedNavigate();
-  const { t } = useTranslation();
+  const privateState = usePrivateState();
+  const keysDoesExist = useSelector(selectKeysDoesExist);
 
-  const loginRetryCount = useSelector(selectLoginRetryCount);
-  const passwordHash = useSelector(selectPasswordHash);
-  const passwordSaltHash = useSelector(selectPasswordSaltHash);
+  if (!keysDoesExist) {
+    throw new PasswordDoesNotExistError();
+  }
+
+  // private state (hashes) arrives in ms; matches existing async-boot behavior
+  if (privateState == null) {
+    return null;
+  }
+
+  const { passwordHash, passwordSaltHash } = privateState;
 
   if (passwordHash == null || passwordSaltHash == null) {
     throw new PasswordDoesNotExistError();
   }
+
+  return (
+    <UnlockWalletForm
+      passwordHash={passwordHash}
+      passwordSaltHash={passwordSaltHash}
+      saveIsLoggedIn={saveIsLoggedIn}
+    />
+  );
+}
+
+interface UnlockWalletFormProps extends UnlockWalletPageProps {
+  passwordHash: string;
+  passwordSaltHash: string;
+}
+
+// Inner component: the form hook needs the hashes at render time, so it is
+// only mounted once the private state has arrived (keeps hook order legal)
+function UnlockWalletForm({
+  passwordHash,
+  passwordSaltHash,
+  saveIsLoggedIn
+}: UnlockWalletFormProps) {
+  const navigate = useTypedNavigate();
+  const { t } = useTranslation();
+
+  const loginRetryCount = useSelector(selectLoginRetryCount);
 
   const {
     register,

--- a/src/apps/onboarding/pages/unlock-wallet/index.tsx
+++ b/src/apps/onboarding/pages/unlock-wallet/index.tsx
@@ -17,6 +17,7 @@ import { usePrivateState } from '@hooks/use-private-state';
 
 import {
   LayoutTab,
+  PrivateStateErrorPage,
   TabFooterContainer as TabFooterContainerBase
 } from '@libs/layout';
 import { Button } from '@libs/ui/components';
@@ -32,11 +33,19 @@ interface UnlockWalletPageProps {
 }
 
 export function UnlockWalletPage({ saveIsLoggedIn }: UnlockWalletPageProps) {
-  const privateState = usePrivateState();
+  const {
+    privateState,
+    error: privateStateError,
+    retry: retryPrivateState
+  } = usePrivateState();
   const keysDoesExist = useSelector(selectKeysDoesExist);
 
   if (!keysDoesExist) {
     throw new PasswordDoesNotExistError();
+  }
+
+  if (privateStateError) {
+    return <PrivateStateErrorPage layout="tab" onRetry={retryPrivateState} />;
   }
 
   // private state (hashes) arrives in ms; matches existing async-boot behavior

--- a/src/apps/popup/pages/account-settings/content.tsx
+++ b/src/apps/popup/pages/account-settings/content.tsx
@@ -4,10 +4,10 @@ import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import styled, { useTheme } from 'styled-components';
-import { RootState } from 'typesafe-actions';
 
 import { RouterPath, useTypedNavigate } from '@popup/router';
 
+import { RootState } from '@background/redux/store-types';
 import { dispatchToMainStore } from '@background/redux/utils';
 import { hideAccountFromListChanged } from '@background/redux/vault/actions';
 import {

--- a/src/apps/popup/pages/account-settings/index.tsx
+++ b/src/apps/popup/pages/account-settings/index.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
-import { RootState } from 'typesafe-actions';
 
 import { getBlockExplorerAccountUrl } from '@src/constants';
 
 import { RouterPath, useTypedNavigate } from '@popup/router';
 
 import { selectApiConfigBasedOnActiveNetwork } from '@background/redux/settings/selectors';
+import { RootState } from '@background/redux/store-types';
 import { selectVaultAccount } from '@background/redux/vault/selectors';
 
 import {

--- a/src/apps/popup/pages/password-protection-page/index.tsx
+++ b/src/apps/popup/pages/password-protection-page/index.tsx
@@ -10,16 +10,15 @@ import {
 import { PasswordDoesNotExistError } from '@src/errors';
 import { getErrorMessageForIncorrectPassword } from '@src/utils';
 
-import {
-  selectPasswordHash,
-  selectPasswordSaltHash
-} from '@background/redux/keys/selectors';
+import { selectKeysDoesExist } from '@background/redux/keys/selectors';
 import {
   loginRetryCountIncremented,
   loginRetryCountReseted
 } from '@background/redux/login-retry-count/actions';
 import { selectLoginRetryCount } from '@background/redux/login-retry-count/selectors';
 import { dispatchToMainStore } from '@background/redux/utils';
+
+import { usePrivateState } from '@hooks/use-private-state';
 
 import {
   FooterButtonsContainer,
@@ -51,8 +50,8 @@ export const PasswordProtectionPage = ({
 
   const { t } = useTranslation();
 
-  const passwordHash = useSelector(selectPasswordHash);
-  const passwordSaltHash = useSelector(selectPasswordSaltHash);
+  const privateState = usePrivateState();
+  const keysDoesExist = useSelector(selectKeysDoesExist);
   const loginRetryCount = useSelector(selectLoginRetryCount);
 
   const attemptsLeft =
@@ -60,7 +59,7 @@ export const PasswordProtectionPage = ({
     loginRetryCount -
     ERROR_DISPLAYED_BEFORE_ATTEMPT_IS_DECREMENTED;
 
-  if (passwordHash == null || passwordSaltHash == null) {
+  if (!keysDoesExist) {
     throw new PasswordDoesNotExistError();
   }
 
@@ -77,6 +76,10 @@ export const PasswordProtectionPage = ({
   });
 
   const onSubmit = () => {
+    if (privateState == null) return;
+
+    const { passwordHash, passwordSaltHash } = privateState;
+
     setIsSubmitting(true);
 
     const { password } = getValues();
@@ -124,6 +127,11 @@ export const PasswordProtectionPage = ({
       setIsSubmitting(false);
     };
   };
+
+  // private state (hashes) arrives in ms; matches existing async-boot behavior
+  if (privateState == null) {
+    return null;
+  }
 
   return (
     <PopupLayout

--- a/src/apps/popup/pages/password-protection-page/index.tsx
+++ b/src/apps/popup/pages/password-protection-page/index.tsx
@@ -25,6 +25,7 @@ import {
   HeaderPopup,
   HeaderSubmenuBarNavLink,
   PopupLayout,
+  PrivateStateErrorPage,
   UnlockProtectedPageContent
 } from '@libs/layout';
 import { Button } from '@libs/ui/components';
@@ -50,7 +51,11 @@ export const PasswordProtectionPage = ({
 
   const { t } = useTranslation();
 
-  const privateState = usePrivateState();
+  const {
+    privateState,
+    error: privateStateError,
+    retry: retryPrivateState
+  } = usePrivateState();
   const keysDoesExist = useSelector(selectKeysDoesExist);
   const loginRetryCount = useSelector(selectLoginRetryCount);
 
@@ -127,6 +132,10 @@ export const PasswordProtectionPage = ({
       setIsSubmitting(false);
     };
   };
+
+  if (privateStateError) {
+    return <PrivateStateErrorPage layout="popup" onRetry={retryPrivateState} />;
+  }
 
   // private state (hashes) arrives in ms; matches existing async-boot behavior
   if (privateState == null) {

--- a/src/background/background-events.ts
+++ b/src/background/background-events.ts
@@ -1,15 +1,17 @@
-import { ActionType, createAction } from 'typesafe-actions';
+import { createAction } from '@reduxjs/toolkit';
 
 import { PopupState } from './redux/types';
 
 // General purpose events emitted by background to all extension windows
 
 export const backgroundEvent = {
-  popupStateUpdated: createAction('popupStateUpdated')<PopupState>()
+  popupStateUpdated: createAction<PopupState>('popupStateUpdated')
 };
 
-export type BackgroundEvent = ActionType<typeof backgroundEvent>;
-export type popupStateUpdated = ActionType<
+export type BackgroundEvent = ReturnType<
+  (typeof backgroundEvent)[keyof typeof backgroundEvent]
+>;
+export type popupStateUpdated = ReturnType<
   typeof backgroundEvent.popupStateUpdated
 >;
 

--- a/src/background/bring-web3-events.ts
+++ b/src/background/bring-web3-events.ts
@@ -1,15 +1,17 @@
-import { ActionType, createAction } from 'typesafe-actions';
+import { createAction } from '@reduxjs/toolkit';
 
 export const bringWeb3Events = {
-  getActivePublicKey: createAction('GET_ACTIVE_PUBLIC_KEY')(),
-  getActivePublicKeyResponse: createAction('GET_ACTIVE_PUBLIC_KEY_RESPONSE')<{
-    publicKey: string;
-  }>(),
-  promptLoginRequest: createAction('PROMPT_LOGIN_REQUEST')(),
-  getTheme: createAction('GET_THEME')(),
-  getThemeResponse: createAction('GET_THEME_RESPONSE')<{
-    theme: 'light' | 'dark';
-  }>()
+  getActivePublicKey: createAction('GET_ACTIVE_PUBLIC_KEY'),
+  getActivePublicKeyResponse: createAction<{ publicKey: string }>(
+    'GET_ACTIVE_PUBLIC_KEY_RESPONSE'
+  ),
+  promptLoginRequest: createAction('PROMPT_LOGIN_REQUEST'),
+  getTheme: createAction('GET_THEME'),
+  getThemeResponse: createAction<{ theme: 'light' | 'dark' }>(
+    'GET_THEME_RESPONSE'
+  )
 };
 
-export type BringWeb3Events = ActionType<typeof bringWeb3Events>;
+export type BringWeb3Events = ReturnType<
+  (typeof bringWeb3Events)[keyof typeof bringWeb3Events]
+>;

--- a/src/background/handlers/bringweb3.ts
+++ b/src/background/handlers/bringweb3.ts
@@ -1,0 +1,92 @@
+import { windows } from 'webextension-polyfill';
+
+import { getActiveAccountSupports } from '@src/utils';
+
+import { bringWeb3Events } from '@background/bring-web3-events';
+import { MainStore } from '@background/redux/get-main-store';
+import { selectVaultActiveAccount } from '@background/redux/vault/selectors';
+
+import { sdkEvent } from '@content/sdk-event';
+
+import { selectVaultIsLocked } from '../redux/session/selectors';
+import {
+  selectSystemColorScheme,
+  selectThemeModeSetting
+} from '../redux/settings/selectors';
+import { ThemeMode } from '../redux/settings/types';
+import { emitSdkEventToActiveTabs } from '../utils';
+import { HandlerResult } from './types';
+
+export async function handleBringWeb3(
+  action: { type: string },
+  store: MainStore
+): Promise<HandlerResult> {
+  if (bringWeb3Events.getActivePublicKey.match(action)) {
+    const activeAccount = selectVaultActiveAccount(store.getState());
+
+    return {
+      handled: true,
+      response: bringWeb3Events.getActivePublicKeyResponse({
+        publicKey: activeAccount?.publicKey!
+      })
+    };
+  } else if (bringWeb3Events.promptLoginRequest.match(action)) {
+    const isLocked = selectVaultIsLocked(store.getState());
+
+    if (isLocked) {
+      windows.getCurrent().then(currentWindow => {
+        const windowWidth = currentWindow.width ?? 0;
+        const xOffset = currentWindow.left ?? 0;
+        const yOffset = currentWindow.top ?? 0;
+        const popupWidth = 360;
+        const popupHeight = 700;
+
+        windows.create({
+          url: 'popup.html#/bring-web3-unlock',
+          type: 'popup',
+          height: popupHeight,
+          width: popupWidth,
+          left: windowWidth + xOffset - popupWidth,
+          top: yOffset,
+          focused: true
+        });
+      });
+    } else {
+      emitSdkEventToActiveTabs(tab => {
+        if (!tab.url) {
+          return;
+        }
+
+        const activeAccount = selectVaultActiveAccount(store.getState());
+
+        return sdkEvent.changedConnectedAccountEvent({
+          isLocked: isLocked,
+          isConnected: undefined,
+          activeKey: activeAccount?.publicKey,
+          activeKeySupports: activeAccount
+            ? getActiveAccountSupports(activeAccount)
+            : undefined
+        });
+      });
+    }
+
+    return { handled: true, response: undefined };
+  } else if (bringWeb3Events.getTheme.match(action)) {
+    const themeMode = selectThemeModeSetting(store.getState());
+    const systemColorScheme = selectSystemColorScheme(store.getState());
+
+    const isDarkMode =
+      themeMode === ThemeMode.SYSTEM
+        ? systemColorScheme === null || systemColorScheme === 'dark'
+        : themeMode === ThemeMode.DARK;
+
+    return {
+      handled: true,
+      response: bringWeb3Events.getThemeResponse({
+        theme: isDarkMode ? 'dark' : 'light'
+      })
+    };
+  }
+
+  return { handled: false };
+}

--- a/src/background/handlers/legacy-import.ts
+++ b/src/background/handlers/legacy-import.ts
@@ -1,0 +1,72 @@
+import { Runtime } from 'webextension-polyfill';
+
+import { MainStore } from '@background/redux/get-main-store';
+import {
+  CheckAccountNameIsTakenAction,
+  CheckSecretKeyExistAction
+} from '@background/redux/import-account-actions-should-be-removed';
+import {
+  selectVaultAccountsNames,
+  selectVaultAccountsSecretKeysBase64
+} from '@background/redux/vault/selectors';
+import { selectWindowId } from '@background/redux/windowManagement/selectors';
+
+import { isTrustedUiSender } from './private-state';
+import { HandlerResult } from './types';
+
+// TODO: All below should be removed when Import Account is integrated with window
+export function handleLegacyImport(
+  action: { type: string },
+  sender: Runtime.MessageSender,
+  store: MainStore
+): HandlerResult {
+  const isLegacyImportRequest =
+    action.type === 'check-secret-key-exist' ||
+    action.type === 'check-account-name-is-taken' ||
+    action.type === 'get-window-id';
+
+  if (!isLegacyImportRequest) {
+    return { handled: false };
+  }
+
+  // P0.1: these cases are a secret-key / account-name membership oracle and a
+  // window-id disclosure — gate to trusted extension UI senders only (the
+  // legitimate import-account-with-file window passes); silently ignore anyone
+  // else, matching the private-state gate's no-response shape.
+  if (!isTrustedUiSender(sender)) {
+    return { handled: true };
+  }
+
+  switch (action.type) {
+    case 'check-secret-key-exist': {
+      const { secretKeyBase64 } = (action as any as CheckSecretKeyExistAction)
+        .payload;
+      const vaultAccountsSecretKeysBase64 = selectVaultAccountsSecretKeysBase64(
+        store.getState()
+      );
+
+      const response = secretKeyBase64
+        ? vaultAccountsSecretKeysBase64.includes(secretKeyBase64)
+        : false;
+      return { handled: true, response };
+    }
+
+    case 'check-account-name-is-taken': {
+      const { accountName } = (action as any as CheckAccountNameIsTakenAction)
+        .payload;
+      const vaultAccountsNames = selectVaultAccountsNames(store.getState());
+      const response = accountName
+        ? vaultAccountsNames.includes(accountName)
+        : false;
+      return { handled: true, response };
+    }
+
+    case 'get-window-id': {
+      const windowId = selectWindowId(store.getState());
+      return { handled: true, response: windowId };
+    }
+
+    default:
+      return { handled: false };
+  }
+}

--- a/src/background/handlers/private-state.ts
+++ b/src/background/handlers/private-state.ts
@@ -1,5 +1,6 @@
-import { RootState } from 'typesafe-actions';
 import { Runtime, runtime } from 'webextension-polyfill';
+
+import { RootState } from '@background/redux/store-types';
 
 export const PRIVATE_STATE_REQUEST_TYPE = 'PRIVATE_STATE_REQUEST' as const;
 

--- a/src/background/handlers/private-state.ts
+++ b/src/background/handlers/private-state.ts
@@ -1,0 +1,48 @@
+import { RootState } from 'typesafe-actions';
+import { Runtime, runtime } from 'webextension-polyfill';
+
+export const PRIVATE_STATE_REQUEST_TYPE = 'PRIVATE_STATE_REQUEST' as const;
+
+export interface PrivateStateRequest {
+  type: typeof PRIVATE_STATE_REQUEST_TYPE;
+}
+
+/** P0.1: at-rest secrets served on demand instead of broadcast to every replica */
+export interface PrivateState {
+  passwordHash: string | null;
+  passwordSaltHash: string | null;
+  keyDerivationSaltHash: string | null;
+  vaultCipher: string | null;
+}
+
+export function isPrivateStateRequest(
+  action: unknown
+): action is PrivateStateRequest {
+  return (
+    (action as PrivateStateRequest | undefined)?.type ===
+    PRIVATE_STATE_REQUEST_TYPE
+  );
+}
+
+/** UI side: explicit request replacing the removed replica fields */
+export function fetchPrivateState(): Promise<PrivateState> {
+  return runtime.sendMessage({ type: PRIVATE_STATE_REQUEST_TYPE });
+}
+
+/** Only extension UI pages (popup/onboarding/windows) — never content scripts / web pages */
+export function isTrustedUiSender(sender: Runtime.MessageSender): boolean {
+  return (
+    sender.id === runtime.id &&
+    sender.url != null &&
+    sender.url.startsWith(runtime.getURL(''))
+  );
+}
+
+export function selectPrivateState(state: RootState): PrivateState {
+  return {
+    passwordHash: state.keys.passwordHash,
+    passwordSaltHash: state.keys.passwordSaltHash,
+    keyDerivationSaltHash: state.keys.keyDerivationSaltHash,
+    vaultCipher: state.vaultCipher
+  };
+}

--- a/src/background/handlers/redux-actions.ts
+++ b/src/background/handlers/redux-actions.ts
@@ -1,0 +1,208 @@
+import { backgroundEvent } from '@background/background-events';
+import {
+  accountInfoReset,
+  accountPendingDeployHashesChanged,
+  accountPendingDeployHashesRemove,
+  accountTrackingIdOfSentNftTokensChanged,
+  accountTrackingIdOfSentNftTokensRemoved
+} from '@background/redux/account-info/actions';
+import {
+  dismissAppEvent,
+  resetAppEventsDismission
+} from '@background/redux/app-events/actions';
+import {
+  contactRemoved,
+  contactUpdated,
+  contactsReseted,
+  newContactAdded
+} from '@background/redux/contacts/actions';
+import { MainStore } from '@background/redux/get-main-store';
+import {
+  ledgerDeployChanged,
+  ledgerNewWindowIdChanged,
+  ledgerRecipientToSaveOnSuccessChanged,
+  ledgerStateCleared,
+  ledgerTransactionChanged
+} from '@background/redux/ledger/actions';
+import {
+  askForReviewAfterChanged,
+  ratedInStoreChanged,
+  resetRateApp
+} from '@background/redux/rate-app/actions';
+import { RootAction } from '@background/redux/store-types';
+import {
+  addWasmToTrusted,
+  removeAllWasmFromTrustedOrigin,
+  removeWasmFromTrusted,
+  resetTrustedWasmState
+} from '@background/redux/trusted-wasm/actions';
+import {
+  accountAdded,
+  accountDisconnected,
+  accountImported,
+  accountRemoved,
+  accountRenamed,
+  accountsAdded,
+  accountsImported,
+  activeAccountChanged,
+  activeAccountSupportsChanged,
+  addWatchingAccount,
+  anotherAccountConnected,
+  deploysReseted,
+  hideAccountFromListChanged,
+  secretPhraseCreated,
+  siteConnected,
+  siteDisconnected,
+  vaultLoaded,
+  vaultReseted
+} from '@background/redux/vault/actions';
+import {
+  connectWindowInit,
+  importWindowInit,
+  onboardingAppInit,
+  popupWindowInit,
+  signWindowInit,
+  windowIdChanged,
+  windowIdCleared
+} from '@background/redux/windowManagement/actions';
+
+import { enableOnboardingFlow } from '../open-onboarding-flow';
+import { keysReseted, keysUpdated } from '../redux/keys/actions';
+import { lastActivityTimeRefreshed } from '../redux/last-activity-time/actions';
+import {
+  loginRetryCountIncremented,
+  loginRetryCountReseted
+} from '../redux/login-retry-count/actions';
+import { loginRetryLockoutTimeSet } from '../redux/login-retry-lockout-time/actions';
+import {
+  recipientPublicKeyAdded,
+  recipientPublicKeyReseted
+} from '../redux/recent-recipient-public-keys/actions';
+import {
+  createAccount,
+  initKeys,
+  initVault,
+  lockVault,
+  recoverVault,
+  resetVault,
+  unlockVault
+} from '../redux/sagas/actions';
+import {
+  contactEditingPermissionChanged,
+  encryptionKeyHashCreated,
+  sessionReseted,
+  vaultUnlocked
+} from '../redux/session/actions';
+import {
+  activeNetworkSettingChanged,
+  activeTimeoutDurationSettingChanged,
+  systemColorSchemeChanged,
+  themeModeSettingChanged,
+  vaultSettingsReseted
+} from '../redux/settings/actions';
+import {
+  vaultCipherCreated,
+  vaultCipherReseted
+} from '../redux/vault-cipher/actions';
+import { HandlerResult } from './types';
+
+const FORWARDED_ACTION_TYPES: ReadonlySet<string> = new Set(
+  [
+    lockVault,
+    unlockVault,
+    initKeys,
+    initVault,
+    recoverVault,
+    createAccount,
+    deploysReseted,
+    sessionReseted,
+    encryptionKeyHashCreated,
+    vaultUnlocked,
+    vaultLoaded,
+    vaultReseted,
+    secretPhraseCreated,
+    accountImported,
+    accountsImported,
+    accountAdded,
+    accountsAdded,
+    accountRemoved,
+    accountRenamed,
+    activeAccountChanged,
+    activeAccountSupportsChanged,
+    hideAccountFromListChanged,
+    activeTimeoutDurationSettingChanged,
+    activeNetworkSettingChanged,
+    vaultSettingsReseted,
+    themeModeSettingChanged,
+    lastActivityTimeRefreshed,
+    siteConnected,
+    anotherAccountConnected,
+    accountDisconnected,
+    siteDisconnected,
+    windowIdChanged,
+    windowIdCleared,
+    onboardingAppInit,
+    popupWindowInit,
+    connectWindowInit,
+    importWindowInit,
+    signWindowInit,
+    vaultCipherReseted,
+    vaultCipherCreated,
+    keysReseted,
+    keysUpdated,
+    loginRetryCountReseted,
+    loginRetryCountIncremented,
+    loginRetryLockoutTimeSet,
+    recipientPublicKeyAdded,
+    recipientPublicKeyReseted,
+    accountInfoReset,
+    accountPendingDeployHashesChanged,
+    accountPendingDeployHashesRemove,
+    accountTrackingIdOfSentNftTokensChanged,
+    accountTrackingIdOfSentNftTokensRemoved,
+    newContactAdded,
+    contactRemoved,
+    contactEditingPermissionChanged,
+    contactUpdated,
+    contactsReseted,
+    ratedInStoreChanged,
+    askForReviewAfterChanged,
+    resetRateApp,
+    ledgerNewWindowIdChanged,
+    ledgerStateCleared,
+    ledgerDeployChanged,
+    ledgerTransactionChanged,
+    ledgerRecipientToSaveOnSuccessChanged,
+    addWatchingAccount,
+    dismissAppEvent,
+    resetAppEventsDismission,
+    addWasmToTrusted,
+    removeWasmFromTrusted,
+    removeAllWasmFromTrustedOrigin,
+    resetTrustedWasmState,
+    systemColorSchemeChanged
+  ].map(creator => creator.type)
+);
+
+export async function handleReduxAction(
+  action: { type: string },
+  store: MainStore
+): Promise<HandlerResult> {
+  if (action.type === resetVault.type) {
+    store.dispatch(action as unknown as RootAction);
+    await enableOnboardingFlow();
+    return { handled: true, response: undefined };
+  }
+
+  if (FORWARDED_ACTION_TYPES.has(action.type)) {
+    store.dispatch(action as unknown as RootAction);
+    return { handled: true, response: undefined };
+  }
+
+  if (backgroundEvent.popupStateUpdated.match(action)) {
+    // do nothing — never respond (promise stays pending)
+    return { handled: true };
+  }
+
+  return { handled: false };
+}

--- a/src/background/handlers/sdk-methods.ts
+++ b/src/background/handlers/sdk-methods.ts
@@ -1,0 +1,467 @@
+import { Deploy, PublicKey } from 'casper-js-sdk';
+import { Runtime, runtime } from 'webextension-polyfill';
+
+import {
+  getActiveAccountSupports,
+  getUrlOrigin,
+  isEqualCaseInsensitive
+} from '@src/utils';
+
+import { WindowApp } from '@background/create-open-window';
+import {
+  CannotGetActiveAccountError,
+  CannotGetSenderOriginError,
+  ENCRYPT_MESSAGE_MAX_LENGTH
+} from '@background/internal-errors';
+import { openWindow } from '@background/open-window';
+import { MainStore } from '@background/redux/get-main-store';
+import {
+  deployPayloadReceived,
+  eip712PayloadReceived,
+  siteDisconnected
+} from '@background/redux/vault/actions';
+import {
+  selectAccountNamesByOriginDict,
+  selectIsAccountConnected,
+  selectVaultActiveAccount
+} from '@background/redux/vault/selectors';
+import { emitSdkEventToActiveTabsWithOrigin } from '@background/utils';
+
+import { SiteNotConnectedError, WalletLockedError } from '@content/sdk-errors';
+import { sdkEvent } from '@content/sdk-event';
+import { SdkMethod, sdkMethod } from '@content/sdk-method';
+
+import { encryptAsHexWithCasperPublicKey } from '@libs/crypto';
+
+import { selectVaultIsLocked } from '../redux/session/selectors';
+import { HandlerResult } from './types';
+
+export async function handleSdkMethod(
+  action: SdkMethod,
+  sender: Runtime.MessageSender,
+  store: MainStore
+): Promise<HandlerResult> {
+  if (sdkMethod.connectRequest.match(action)) {
+    const origin = getUrlOrigin(sender.url);
+    if (!origin) {
+      throw CannotGetSenderOriginError();
+    }
+    const senderTabId = sender.tab?.id;
+
+    if (senderTabId == null) {
+      throw Error('Missing sender tab id');
+    }
+
+    const activeAccount = selectVaultActiveAccount(store.getState());
+
+    const query: Record<string, string> = {
+      requestId: action.meta.requestId,
+      origin: origin,
+      tabId: String(senderTabId)
+    };
+    if (action.payload.title != null) {
+      query.title = action.payload.title;
+    }
+    const isAccountAlreadyConnected = selectIsAccountConnected(
+      store.getState(),
+      origin,
+      activeAccount?.name
+    );
+
+    if (isAccountAlreadyConnected) {
+      return {
+        handled: true,
+        response: sdkMethod.connectResponse(true, action.meta)
+      };
+    } else {
+      openWindow({
+        windowApp: WindowApp.ConnectToApp,
+        searchParams: query
+      });
+    }
+
+    return { handled: true, response: undefined };
+  } else if (sdkMethod.switchAccountRequest.match(action)) {
+    const origin = getUrlOrigin(sender.url);
+    if (!origin) {
+      throw CannotGetSenderOriginError();
+    }
+
+    const senderTabId = sender.tab?.id;
+
+    if (senderTabId == null) {
+      throw Error('Missing sender tab id');
+    }
+
+    const query: Record<string, string> = {
+      requestId: action.meta.requestId,
+      origin: origin,
+      tabId: String(senderTabId)
+    };
+    if (action.payload.title != null) {
+      query.title = action.payload.title;
+    }
+
+    openWindow({
+      windowApp: WindowApp.SwitchAccount,
+      searchParams: query
+    });
+
+    return { handled: true, response: undefined };
+  } else if (sdkMethod.signRequest.match(action)) {
+    const origin = getUrlOrigin(sender.url);
+    if (!origin) {
+      throw CannotGetSenderOriginError();
+    }
+
+    const senderTabId = sender.tab?.id;
+
+    if (senderTabId == null) {
+      throw Error('Missing sender tab id');
+    }
+
+    const { signingPublicKeyHex } = action.payload;
+    let deployJson;
+    try {
+      deployJson = JSON.parse(action.payload.deployJson);
+    } catch (err) {
+      throw Error('Desploy json string parse error');
+    }
+
+    const deploy: Deploy = deployJson.deploy;
+
+    const isDeployAlreadySigningWithThisAccount =
+      deploy?.approvals?.some(approvals =>
+        isEqualCaseInsensitive(approvals.signer.toString(), signingPublicKeyHex)
+      ) ?? false;
+
+    if (isDeployAlreadySigningWithThisAccount) {
+      return {
+        handled: true,
+        response: sdkMethod.signResponse(
+          {
+            cancelled: true,
+            message: 'This deploy already sign by this account'
+          },
+          { requestId: action.meta.requestId }
+        )
+      };
+    }
+
+    store.dispatch(
+      deployPayloadReceived({
+        id: action.meta.requestId,
+        json: deployJson
+      })
+    );
+
+    openWindow({
+      windowApp: WindowApp.SignatureRequestDeploy,
+      searchParams: {
+        requestId: action.meta.requestId,
+        signingPublicKeyHex,
+        origin,
+        tabId: String(senderTabId)
+      }
+    });
+
+    return { handled: true, response: undefined };
+  } else if (sdkMethod.signMessageRequest.match(action)) {
+    const origin = getUrlOrigin(sender.url);
+    if (!origin) {
+      throw CannotGetSenderOriginError();
+    }
+
+    const senderTabId = sender.tab?.id;
+
+    if (senderTabId == null) {
+      throw Error('Missing sender tab id');
+    }
+
+    const { signingPublicKeyHex, message } = action.payload;
+
+    openWindow({
+      windowApp: WindowApp.SignatureRequestMessage,
+      searchParams: {
+        requestId: action.meta.requestId,
+        signingPublicKeyHex,
+        message,
+        origin,
+        tabId: String(senderTabId)
+      }
+    });
+
+    return { handled: true, response: undefined };
+  } else if (sdkMethod.signTypedDataRequest.match(action)) {
+    const origin = getUrlOrigin(sender.url);
+    if (!origin) {
+      throw CannotGetSenderOriginError();
+    }
+
+    const senderTabId = sender.tab?.id;
+
+    if (senderTabId == null) {
+      throw Error('Missing sender tab id');
+    }
+
+    const { signingPublicKeyHex, typedData, options } = action.payload;
+
+    store.dispatch(
+      eip712PayloadReceived({
+        id: action.meta.requestId,
+        json: JSON.stringify({ typedData, options })
+      })
+    );
+
+    openWindow({
+      windowApp: WindowApp.SignatureRequestEip712,
+      searchParams: {
+        requestId: action.meta.requestId,
+        signingPublicKeyHex,
+        origin,
+        tabId: String(senderTabId)
+      }
+    });
+
+    return { handled: true, response: undefined };
+  } else if (sdkMethod.decryptMessageRequest.match(action)) {
+    const origin = getUrlOrigin(sender.url);
+
+    if (!origin) {
+      throw CannotGetSenderOriginError();
+    }
+
+    const senderTabId = sender.tab?.id;
+
+    if (senderTabId == null) {
+      throw Error('Missing sender tab id');
+    }
+
+    const { signingPublicKeyHex, message } = action.payload;
+
+    openWindow({
+      windowApp: WindowApp.DecryptMessageRequest,
+      searchParams: {
+        requestId: action.meta.requestId,
+        signingPublicKeyHex,
+        message,
+        origin,
+        tabId: String(senderTabId)
+      }
+    });
+
+    return { handled: true, response: undefined };
+  } else if (sdkMethod.disconnectRequest.match(action)) {
+    const origin = getUrlOrigin(sender.url);
+    if (!origin) {
+      throw CannotGetSenderOriginError();
+    }
+
+    let success = false;
+
+    const isLocked = selectVaultIsLocked(store.getState());
+
+    const activeAccount = selectVaultActiveAccount(store.getState());
+    if (activeAccount == null) {
+      throw CannotGetActiveAccountError();
+    }
+    const isActiveAccountConnected = selectIsAccountConnected(
+      store.getState(),
+      origin,
+      activeAccount.name
+    );
+
+    emitSdkEventToActiveTabsWithOrigin(
+      origin,
+      sdkEvent.disconnectedAccountEvent({
+        isLocked: isLocked,
+        isConnected: isLocked ? undefined : false,
+        activeKey:
+          !isLocked && isActiveAccountConnected
+            ? activeAccount.publicKey
+            : undefined,
+        activeKeySupports:
+          !isLocked && isActiveAccountConnected
+            ? getActiveAccountSupports(activeAccount)
+            : undefined
+      })
+    );
+    store.dispatch(
+      siteDisconnected({
+        siteOrigin: origin
+      })
+    );
+    success = true;
+
+    return {
+      handled: true,
+      response: sdkMethod.disconnectResponse(success, action.meta)
+    };
+  } else if (sdkMethod.isConnectedRequest.match(action)) {
+    const origin = getUrlOrigin(sender.url);
+    if (!origin) {
+      throw CannotGetSenderOriginError();
+    }
+
+    const isLocked = selectVaultIsLocked(store.getState());
+    if (isLocked) {
+      return {
+        handled: true,
+        response: sdkMethod.isConnectedError(WalletLockedError(), action.meta)
+      };
+    }
+    const accountNamesByOriginDict = selectAccountNamesByOriginDict(
+      store.getState()
+    );
+    const isConnected = Boolean(origin in accountNamesByOriginDict);
+
+    return {
+      handled: true,
+      response: sdkMethod.isConnectedResponse(isConnected, action.meta)
+    };
+  } else if (sdkMethod.getActivePublicKeyRequest.match(action)) {
+    const origin = getUrlOrigin(sender.url);
+    if (!origin) {
+      throw CannotGetSenderOriginError();
+    }
+
+    const isLocked = selectVaultIsLocked(store.getState());
+    if (isLocked) {
+      return {
+        handled: true,
+        response: sdkMethod.getActivePublicKeyError(
+          WalletLockedError(),
+          action.meta
+        )
+      };
+    }
+
+    const activeAccount = selectVaultActiveAccount(store.getState());
+    if (activeAccount == null) {
+      throw CannotGetActiveAccountError();
+    }
+
+    const isConnected = selectIsAccountConnected(
+      store.getState(),
+      origin,
+      activeAccount?.name
+    );
+
+    if (!isConnected) {
+      return {
+        handled: true,
+        response: sdkMethod.getActivePublicKeyError(
+          SiteNotConnectedError(),
+          action.meta
+        )
+      };
+    }
+
+    return {
+      handled: true,
+      response: sdkMethod.getActivePublicKeyResponse(
+        activeAccount.publicKey,
+        action.meta
+      )
+    };
+  } else if (sdkMethod.encryptMessageRequest.match(action)) {
+    const origin = getUrlOrigin(sender.url);
+
+    const { signingPublicKeyHex, message = '' } = action.payload;
+
+    if (!origin) {
+      throw CannotGetSenderOriginError();
+    }
+
+    try {
+      PublicKey.fromHex(signingPublicKeyHex);
+    } catch (e) {
+      throw Error('Public key hex is not valid');
+    }
+
+    if (message.length > ENCRYPT_MESSAGE_MAX_LENGTH) {
+      throw Error(
+        `Message should be less than ${ENCRYPT_MESSAGE_MAX_LENGTH} symbols`
+      );
+    }
+
+    try {
+      const encryptedMessage = await encryptAsHexWithCasperPublicKey(
+        signingPublicKeyHex,
+        message
+      );
+
+      return {
+        handled: true,
+        response: sdkMethod.encryptMessageResponse(
+          {
+            encryptedMessage
+          },
+          action.meta
+        )
+      };
+    } catch (e) {
+      throw Error('Error during message encryption');
+    }
+  } else if (sdkMethod.getActivePublicKeySupportsRequest.match(action)) {
+    const origin = getUrlOrigin(sender.url);
+
+    if (!origin) {
+      throw CannotGetSenderOriginError();
+    }
+
+    const isLocked = selectVaultIsLocked(store.getState());
+
+    if (isLocked) {
+      return {
+        handled: true,
+        response: sdkMethod.getActivePublicKeySupportsError(
+          WalletLockedError(),
+          action.meta
+        )
+      };
+    }
+
+    const activeAccount = selectVaultActiveAccount(store.getState());
+
+    if (!activeAccount) {
+      throw CannotGetActiveAccountError();
+    }
+
+    const isConnected = selectIsAccountConnected(
+      store.getState(),
+      origin,
+      activeAccount?.name
+    );
+
+    if (!isConnected) {
+      return {
+        handled: true,
+        response: sdkMethod.getActivePublicKeySupportsError(
+          SiteNotConnectedError(),
+          action.meta
+        )
+      };
+    }
+
+    const supports = getActiveAccountSupports(activeAccount);
+
+    return {
+      handled: true,
+      response: sdkMethod.getActivePublicKeySupportsResponse(
+        supports,
+        action.meta
+      )
+    };
+  } else if (sdkMethod.getVersionRequest.match(action)) {
+    const manifestData = runtime.getManifest();
+    const version = manifestData.version;
+
+    return {
+      handled: true,
+      response: sdkMethod.getVersionResponse(version, action.meta)
+    };
+  }
+
+  return { handled: false };
+}

--- a/src/background/handlers/types.ts
+++ b/src/background/handlers/types.ts
@@ -1,0 +1,11 @@
+// Shared result convention for all background message handlers:
+//   { handled: false }                    → try the next handler
+//   { handled: true }                     → handled, DO NOT respond (promise
+//                                            stays pending — preserves current
+//                                            popupStateUpdated / bringweb3-noise
+//                                            no-response behavior)
+//   { handled: true, response: <value> }  → handled, sendResponse(value)
+// Handlers THROW to signal sendError (preserves the previous
+// `return sendError(...)` semantics).
+export type HandlerResult =
+  { handled: false } | { handled: true; response?: unknown };

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -795,13 +795,13 @@ runtime.onMessage.addListener(
           case getType(connectWindowInit):
           case getType(importWindowInit):
           case getType(signWindowInit):
-          case getType(vaultCipherReseted):
-          case getType(vaultCipherCreated):
+          case vaultCipherReseted.type:
+          case vaultCipherCreated.type:
           case getType(keysReseted):
           case getType(keysUpdated):
-          case getType(loginRetryCountReseted):
-          case getType(loginRetryCountIncremented):
-          case getType(loginRetryLockoutTimeSet):
+          case loginRetryCountReseted.type:
+          case loginRetryCountIncremented.type:
+          case loginRetryLockoutTimeSet.type:
           case getType(recipientPublicKeyAdded):
           case getType(recipientPublicKeyReseted):
           case getType(accountInfoReset):

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -788,13 +788,13 @@ runtime.onMessage.addListener(
           case getType(anotherAccountConnected):
           case getType(accountDisconnected):
           case getType(siteDisconnected):
-          case getType(windowIdChanged):
-          case getType(windowIdCleared):
-          case getType(onboardingAppInit):
-          case getType(popupWindowInit):
-          case getType(connectWindowInit):
-          case getType(importWindowInit):
-          case getType(signWindowInit):
+          case windowIdChanged.type:
+          case windowIdCleared.type:
+          case onboardingAppInit.type:
+          case popupWindowInit.type:
+          case connectWindowInit.type:
+          case importWindowInit.type:
+          case signWindowInit.type:
           case vaultCipherReseted.type:
           case vaultCipherCreated.type:
           case getType(keysReseted):
@@ -817,18 +817,18 @@ runtime.onMessage.addListener(
           case ratedInStoreChanged.type:
           case askForReviewAfterChanged.type:
           case resetRateApp.type:
-          case getType(ledgerNewWindowIdChanged):
-          case getType(ledgerStateCleared):
-          case getType(ledgerDeployChanged):
-          case getType(ledgerTransactionChanged):
-          case getType(ledgerRecipientToSaveOnSuccessChanged):
+          case ledgerNewWindowIdChanged.type:
+          case ledgerStateCleared.type:
+          case ledgerDeployChanged.type:
+          case ledgerTransactionChanged.type:
+          case ledgerRecipientToSaveOnSuccessChanged.type:
           case getType(addWatchingAccount):
           case dismissAppEvent.type:
           case resetAppEventsDismission.type:
-          case getType(addWasmToTrusted):
-          case getType(removeWasmFromTrusted):
-          case getType(removeAllWasmFromTrustedOrigin):
-          case getType(resetTrustedWasmState):
+          case addWasmToTrusted.type:
+          case removeWasmFromTrusted.type:
+          case removeAllWasmFromTrustedOrigin.type:
+          case resetTrustedWasmState.type:
           case getType(systemColorSchemeChanged):
             store.dispatch(action);
             return sendResponse(undefined);

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -751,18 +751,18 @@ runtime.onMessage.addListener(
         }
       } else if (action.type != null) {
         switch (action.type) {
-          case getType(resetVault): {
+          case resetVault.type: {
             store.dispatch(action);
             await enableOnboardingFlow();
             return sendResponse(undefined);
           }
 
-          case getType(lockVault):
-          case getType(unlockVault):
-          case getType(initKeys):
-          case getType(initVault):
-          case getType(recoverVault):
-          case getType(createAccount):
+          case lockVault.type:
+          case unlockVault.type:
+          case initKeys.type:
+          case initVault.type:
+          case recoverVault.type:
+          case createAccount.type:
           case deploysReseted.type:
           case sessionReseted.type:
           case encryptionKeyHashCreated.type:

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -763,31 +763,31 @@ runtime.onMessage.addListener(
           case getType(initVault):
           case getType(recoverVault):
           case getType(createAccount):
-          case getType(deploysReseted):
+          case deploysReseted.type:
           case sessionReseted.type:
           case encryptionKeyHashCreated.type:
           case vaultUnlocked.type:
-          case getType(vaultLoaded):
-          case getType(vaultReseted):
-          case getType(secretPhraseCreated):
-          case getType(accountImported):
-          case getType(accountsImported):
-          case getType(accountAdded):
-          case getType(accountsAdded):
-          case getType(accountRemoved):
-          case getType(accountRenamed):
-          case getType(activeAccountChanged):
-          case getType(activeAccountSupportsChanged):
-          case getType(hideAccountFromListChanged):
+          case vaultLoaded.type:
+          case vaultReseted.type:
+          case secretPhraseCreated.type:
+          case accountImported.type:
+          case accountsImported.type:
+          case accountAdded.type:
+          case accountsAdded.type:
+          case accountRemoved.type:
+          case accountRenamed.type:
+          case activeAccountChanged.type:
+          case activeAccountSupportsChanged.type:
+          case hideAccountFromListChanged.type:
           case activeTimeoutDurationSettingChanged.type:
           case activeNetworkSettingChanged.type:
           case vaultSettingsReseted.type:
           case themeModeSettingChanged.type:
           case lastActivityTimeRefreshed.type:
-          case getType(siteConnected):
-          case getType(anotherAccountConnected):
-          case getType(accountDisconnected):
-          case getType(siteDisconnected):
+          case siteConnected.type:
+          case anotherAccountConnected.type:
+          case accountDisconnected.type:
+          case siteDisconnected.type:
           case windowIdChanged.type:
           case windowIdCleared.type:
           case onboardingAppInit.type:
@@ -822,7 +822,7 @@ runtime.onMessage.addListener(
           case ledgerDeployChanged.type:
           case ledgerTransactionChanged.type:
           case ledgerRecipientToSaveOnSuccessChanged.type:
-          case getType(addWatchingAccount):
+          case addWatchingAccount.type:
           case dismissAppEvent.type:
           case resetAppEventsDismission.type:
           case addWasmToTrusted.type:

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -29,6 +29,11 @@ import {
   bringWeb3Events
 } from '@background/bring-web3-events';
 import { WindowApp } from '@background/create-open-window';
+import {
+  PRIVATE_STATE_REQUEST_TYPE,
+  isTrustedUiSender,
+  selectPrivateState
+} from '@background/handlers/private-state';
 import { initKeepAlive } from '@background/keep-alive';
 import {
   disableOnboardingFlow,
@@ -906,6 +911,14 @@ runtime.onMessage.addListener(
                 theme: isDarkMode ? 'dark' : 'light'
               })
             );
+          }
+
+          case PRIVATE_STATE_REQUEST_TYPE as any: {
+            if (!isTrustedUiSender(sender)) {
+              // No data (and no error detail) for untrusted senders
+              return;
+            }
+            return sendResponse(selectPrivateState(store.getState()));
           }
 
           // TODO: All below should be removed when Import Account is integrated with window

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -203,8 +203,24 @@ runtime.onMessage.addListener(
           );
         }
 
+        // Must stay AFTER the isSDKMethod branch: a page-crafted message with
+        // this type and meta.requestId passes the content-script relay filter
+        // and has to be captured (and rejected) by the SDK branch first
         if (isPrivateStateRequest(action)) {
           if (!isTrustedUiSender(sender)) {
+            if (sender.id === runtime.id) {
+              // Same-extension sender rejected by the URL-prefix check —
+              // distinguishes a legitimate-but-unrecognized UI origin
+              // (packaging variant, sandboxed frame) from a probing sender.
+              // Origin only: a content-script sender's full page URL could
+              // carry tokens in query strings
+              const senderOrigin =
+                sender.url != null ? new URL(sender.url).origin : undefined;
+              console.warn(
+                'Background: private-state request from same-extension sender rejected by URL check:',
+                senderOrigin
+              );
+            }
             // No data (and no error detail) for untrusted senders
             return;
           }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -802,8 +802,8 @@ runtime.onMessage.addListener(
           case loginRetryCountReseted.type:
           case loginRetryCountIncremented.type:
           case loginRetryLockoutTimeSet.type:
-          case getType(recipientPublicKeyAdded):
-          case getType(recipientPublicKeyReseted):
+          case recipientPublicKeyAdded.type:
+          case recipientPublicKeyReseted.type:
           case getType(accountInfoReset):
           case getType(accountPendingDeployHashesChanged):
           case getType(accountPendingDeployHashesRemove):
@@ -814,17 +814,17 @@ runtime.onMessage.addListener(
           case getType(contactEditingPermissionChanged):
           case getType(contactUpdated):
           case getType(contactsReseted):
-          case getType(ratedInStoreChanged):
-          case getType(askForReviewAfterChanged):
-          case getType(resetRateApp):
+          case ratedInStoreChanged.type:
+          case askForReviewAfterChanged.type:
+          case resetRateApp.type:
           case getType(ledgerNewWindowIdChanged):
           case getType(ledgerStateCleared):
           case getType(ledgerDeployChanged):
           case getType(ledgerTransactionChanged):
           case getType(ledgerRecipientToSaveOnSuccessChanged):
           case getType(addWatchingAccount):
-          case getType(dismissAppEvent):
-          case getType(resetAppEventsDismission):
+          case dismissAppEvent.type:
+          case resetAppEventsDismission.type:
           case getType(addWasmToTrusted):
           case getType(removeWasmFromTrusted):
           case getType(removeAllWasmFromTrustedOrigin):

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -783,7 +783,7 @@ runtime.onMessage.addListener(
           case getType(activeNetworkSettingChanged):
           case getType(vaultSettingsReseted):
           case getType(themeModeSettingChanged):
-          case getType(lastActivityTimeRefreshed):
+          case lastActivityTimeRefreshed.type:
           case getType(siteConnected):
           case getType(anotherAccountConnected):
           case getType(accountDisconnected):

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -804,16 +804,16 @@ runtime.onMessage.addListener(
           case loginRetryLockoutTimeSet.type:
           case recipientPublicKeyAdded.type:
           case recipientPublicKeyReseted.type:
-          case getType(accountInfoReset):
-          case getType(accountPendingDeployHashesChanged):
-          case getType(accountPendingDeployHashesRemove):
-          case getType(accountTrackingIdOfSentNftTokensChanged):
-          case getType(accountTrackingIdOfSentNftTokensRemoved):
-          case getType(newContactAdded):
-          case getType(contactRemoved):
+          case accountInfoReset.type:
+          case accountPendingDeployHashesChanged.type:
+          case accountPendingDeployHashesRemove.type:
+          case accountTrackingIdOfSentNftTokensChanged.type:
+          case accountTrackingIdOfSentNftTokensRemoved.type:
+          case newContactAdded.type:
+          case contactRemoved.type:
           case getType(contactEditingPermissionChanged):
-          case getType(contactUpdated):
-          case getType(contactsReseted):
+          case contactUpdated.type:
+          case contactsReseted.type:
           case ratedInStoreChanged.type:
           case askForReviewAfterChanged.type:
           case resetRateApp.type:

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -764,9 +764,9 @@ runtime.onMessage.addListener(
           case getType(recoverVault):
           case getType(createAccount):
           case getType(deploysReseted):
-          case getType(sessionReseted):
-          case getType(encryptionKeyHashCreated):
-          case getType(vaultUnlocked):
+          case sessionReseted.type:
+          case encryptionKeyHashCreated.type:
+          case vaultUnlocked.type:
           case getType(vaultLoaded):
           case getType(vaultReseted):
           case getType(secretPhraseCreated):
@@ -779,10 +779,10 @@ runtime.onMessage.addListener(
           case getType(activeAccountChanged):
           case getType(activeAccountSupportsChanged):
           case getType(hideAccountFromListChanged):
-          case getType(activeTimeoutDurationSettingChanged):
-          case getType(activeNetworkSettingChanged):
-          case getType(vaultSettingsReseted):
-          case getType(themeModeSettingChanged):
+          case activeTimeoutDurationSettingChanged.type:
+          case activeNetworkSettingChanged.type:
+          case vaultSettingsReseted.type:
+          case themeModeSettingChanged.type:
           case lastActivityTimeRefreshed.type:
           case getType(siteConnected):
           case getType(anotherAccountConnected):
@@ -797,8 +797,8 @@ runtime.onMessage.addListener(
           case signWindowInit.type:
           case vaultCipherReseted.type:
           case vaultCipherCreated.type:
-          case getType(keysReseted):
-          case getType(keysUpdated):
+          case keysReseted.type:
+          case keysUpdated.type:
           case loginRetryCountReseted.type:
           case loginRetryCountIncremented.type:
           case loginRetryLockoutTimeSet.type:
@@ -811,7 +811,7 @@ runtime.onMessage.addListener(
           case accountTrackingIdOfSentNftTokensRemoved.type:
           case newContactAdded.type:
           case contactRemoved.type:
-          case getType(contactEditingPermissionChanged):
+          case contactEditingPermissionChanged.type:
           case contactUpdated.type:
           case contactsReseted.type:
           case ratedInStoreChanged.type:
@@ -829,7 +829,7 @@ runtime.onMessage.addListener(
           case removeWasmFromTrusted.type:
           case removeAllWasmFromTrustedOrigin.type:
           case resetTrustedWasmState.type:
-          case getType(systemColorSchemeChanged):
+          case systemColorSchemeChanged.type:
             store.dispatch(action);
             return sendResponse(undefined);
 

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,6 +1,4 @@
 import { bringInitBackground } from '@bringweb3/chrome-extension-kit';
-import { Deploy, PublicKey } from 'casper-js-sdk';
-import { RootAction, getType } from 'typesafe-actions';
 import {
   Runtime,
   Tabs,
@@ -16,173 +14,38 @@ import {
   getActiveAccountSupports,
   getUrlOrigin,
   hasHttpPrefix,
-  isChromeBuild,
-  isEqualCaseInsensitive
+  isChromeBuild
 } from '@src/utils';
 
+import { handleBringWeb3 } from '@background/handlers/bringweb3';
+import { handleLegacyImport } from '@background/handlers/legacy-import';
 import {
-  backgroundEvent,
-  popupStateUpdated
-} from '@background/background-events';
-import {
-  BringWeb3Events,
-  bringWeb3Events
-} from '@background/bring-web3-events';
-import { WindowApp } from '@background/create-open-window';
-import {
-  PRIVATE_STATE_REQUEST_TYPE,
+  isPrivateStateRequest,
   isTrustedUiSender,
   selectPrivateState
 } from '@background/handlers/private-state';
+import { handleReduxAction } from '@background/handlers/redux-actions';
+import { handleSdkMethod } from '@background/handlers/sdk-methods';
 import { initKeepAlive } from '@background/keep-alive';
 import {
   disableOnboardingFlow,
-  enableOnboardingFlow,
   openOnboardingUi
 } from '@background/open-onboarding-flow';
-import {
-  accountInfoReset,
-  accountPendingDeployHashesChanged,
-  accountPendingDeployHashesRemove,
-  accountTrackingIdOfSentNftTokensChanged,
-  accountTrackingIdOfSentNftTokensRemoved
-} from '@background/redux/account-info/actions';
 import { activeOriginFaviconChanged } from '@background/redux/active-origin-favicon/actions';
-import {
-  dismissAppEvent,
-  resetAppEventsDismission
-} from '@background/redux/app-events/actions';
-import {
-  contactRemoved,
-  contactUpdated,
-  contactsReseted,
-  newContactAdded
-} from '@background/redux/contacts/actions';
 import { getExistingMainStoreSingletonOrInit } from '@background/redux/get-main-store';
 import {
-  CheckAccountNameIsTakenAction,
-  CheckSecretKeyExistAction
-} from '@background/redux/import-account-actions-should-be-removed';
-import {
-  ledgerDeployChanged,
-  ledgerNewWindowIdChanged,
-  ledgerRecipientToSaveOnSuccessChanged,
-  ledgerStateCleared,
-  ledgerTransactionChanged
-} from '@background/redux/ledger/actions';
-import {
-  askForReviewAfterChanged,
-  ratedInStoreChanged,
-  resetRateApp
-} from '@background/redux/rate-app/actions';
-import { ThemeMode } from '@background/redux/settings/types';
-import {
-  addWasmToTrusted,
-  removeAllWasmFromTrustedOrigin,
-  removeWasmFromTrusted,
-  resetTrustedWasmState
-} from '@background/redux/trusted-wasm/actions';
-import {
-  accountAdded,
-  accountDisconnected,
-  accountImported,
-  accountRemoved,
-  accountRenamed,
-  accountsAdded,
-  accountsImported,
-  activeAccountChanged,
-  activeAccountSupportsChanged,
-  addWatchingAccount,
-  anotherAccountConnected,
-  deployPayloadReceived,
-  deploysReseted,
-  eip712PayloadReceived,
-  hideAccountFromListChanged,
-  secretPhraseCreated,
-  siteConnected,
-  siteDisconnected,
-  vaultLoaded,
-  vaultReseted
-} from '@background/redux/vault/actions';
-import {
-  selectAccountNamesByOriginDict,
   selectIsAccountConnected,
-  selectVaultAccountsNames,
-  selectVaultAccountsSecretKeysBase64,
   selectVaultActiveAccount
 } from '@background/redux/vault/selectors';
-import {
-  connectWindowInit,
-  importWindowInit,
-  onboardingAppInit,
-  popupWindowInit,
-  signWindowInit,
-  windowIdChanged,
-  windowIdCleared
-} from '@background/redux/windowManagement/actions';
-import { selectWindowId } from '@background/redux/windowManagement/selectors';
 
-import { SiteNotConnectedError, WalletLockedError } from '@content/sdk-errors';
 import { sdkEvent } from '@content/sdk-event';
-import { SdkMethod, isSDKMethod, sdkMethod } from '@content/sdk-method';
+import { isSDKMethod } from '@content/sdk-method';
 
-import { encryptAsHexWithCasperPublicKey } from '@libs/crypto';
-
-import {
-  CannotGetActiveAccountError,
-  CannotGetSenderOriginError,
-  ENCRYPT_MESSAGE_MAX_LENGTH
-} from './internal-errors';
-import { openWindow } from './open-window';
 import { activeOriginChanged } from './redux/active-origin/actions';
-import { keysReseted, keysUpdated } from './redux/keys/actions';
 import { selectKeysDoesExist } from './redux/keys/selectors';
-import { lastActivityTimeRefreshed } from './redux/last-activity-time/actions';
-import {
-  loginRetryCountIncremented,
-  loginRetryCountReseted
-} from './redux/login-retry-count/actions';
-import { loginRetryLockoutTimeSet } from './redux/login-retry-lockout-time/actions';
-import {
-  recipientPublicKeyAdded,
-  recipientPublicKeyReseted
-} from './redux/recent-recipient-public-keys/actions';
-import {
-  createAccount,
-  initKeys,
-  initVault,
-  lockVault,
-  recoverVault,
-  resetVault,
-  unlockVault
-} from './redux/sagas/actions';
-import {
-  contactEditingPermissionChanged,
-  encryptionKeyHashCreated,
-  sessionReseted,
-  vaultUnlocked
-} from './redux/session/actions';
 import { selectVaultIsLocked } from './redux/session/selectors';
-import {
-  activeNetworkSettingChanged,
-  activeTimeoutDurationSettingChanged,
-  systemColorSchemeChanged,
-  themeModeSettingChanged,
-  vaultSettingsReseted
-} from './redux/settings/actions';
-import {
-  selectSystemColorScheme,
-  selectThemeModeSetting
-} from './redux/settings/selectors';
-import {
-  vaultCipherCreated,
-  vaultCipherReseted
-} from './redux/vault-cipher/actions';
 import { selectVaultCipherDoesExist } from './redux/vault-cipher/selectors';
-import {
-  emitSdkEventToActiveTabs,
-  emitSdkEventToActiveTabsWithOrigin
-} from './utils';
+import { emitSdkEventToActiveTabsWithOrigin } from './utils';
 // to resolve all repositories
 import './wallet-repositories';
 
@@ -305,674 +168,79 @@ tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 });
 
 // NOTE: if two events are send at the same time (same function) it must reuse the same store instance
+// Thin router: parse → route → delegate. All business logic lives in
+// `@background/handlers/*`; each handler returns a `HandlerResult`:
+//   { handled: false }                   → try the next handler
+//   { handled: true }                    → handled, never respond (promise
+//                                           stays pending — e.g. popupStateUpdated)
+//   { handled: true, response: <value> } → handled, sendResponse(value)
+// A thrown error becomes sendError(error).
 runtime.onMessage.addListener(
   async (message: unknown, sender: Runtime.MessageSender) => {
-    const action = message as
-      RootAction | SdkMethod | popupStateUpdated | BringWeb3Events;
     const store = await getExistingMainStoreSingletonOrInit();
 
     return new Promise(async (sendResponse, sendError) => {
-      // Popup comms handling
-      if (isSDKMethod(action)) {
-        switch (action.type) {
-          case getType(sdkMethod.connectRequest): {
-            const origin = getUrlOrigin(sender.url);
-            if (!origin) {
-              return sendError(CannotGetSenderOriginError());
-            }
-            const senderTabId = sender.tab?.id;
-
-            if (senderTabId == null) {
-              return sendError(Error('Missing sender tab id'));
-            }
-
-            const activeAccount = selectVaultActiveAccount(store.getState());
-
-            const query: Record<string, string> = {
-              requestId: action.meta.requestId,
-              origin: origin,
-              tabId: String(senderTabId)
-            };
-            if (action.payload.title != null) {
-              query.title = action.payload.title;
-            }
-            const isAccountAlreadyConnected = selectIsAccountConnected(
-              store.getState(),
-              origin,
-              activeAccount?.name
-            );
-
-            if (isAccountAlreadyConnected) {
-              return sendResponse(sdkMethod.connectResponse(true, action.meta));
-            } else {
-              openWindow({
-                windowApp: WindowApp.ConnectToApp,
-                searchParams: query
-              });
-            }
-
-            return sendResponse(undefined);
-          }
-
-          case getType(sdkMethod.switchAccountRequest): {
-            const origin = getUrlOrigin(sender.url);
-            if (!origin) {
-              return sendError(CannotGetSenderOriginError());
-            }
-
-            const senderTabId = sender.tab?.id;
-
-            if (senderTabId == null) {
-              return sendError(Error('Missing sender tab id'));
-            }
-
-            const query: Record<string, string> = {
-              requestId: action.meta.requestId,
-              origin: origin,
-              tabId: String(senderTabId)
-            };
-            if (action.payload.title != null) {
-              query.title = action.payload.title;
-            }
-
-            openWindow({
-              windowApp: WindowApp.SwitchAccount,
-              searchParams: query
-            });
-
-            return sendResponse(undefined);
-          }
-
-          case getType(sdkMethod.signRequest): {
-            const origin = getUrlOrigin(sender.url);
-            if (!origin) {
-              return sendError(CannotGetSenderOriginError());
-            }
-
-            const senderTabId = sender.tab?.id;
-
-            if (senderTabId == null) {
-              return sendError(Error('Missing sender tab id'));
-            }
-
-            const { signingPublicKeyHex } = action.payload;
-            let deployJson;
-            try {
-              deployJson = JSON.parse(action.payload.deployJson);
-            } catch (err) {
-              return sendError(Error('Desploy json string parse error'));
-            }
-
-            const deploy: Deploy = deployJson.deploy;
-
-            const isDeployAlreadySigningWithThisAccount =
-              deploy?.approvals?.some(approvals =>
-                isEqualCaseInsensitive(
-                  approvals.signer.toString(),
-                  signingPublicKeyHex
-                )
-              ) ?? false;
-
-            if (isDeployAlreadySigningWithThisAccount) {
-              return sendResponse(
-                sdkMethod.signResponse(
-                  {
-                    cancelled: true,
-                    message: 'This deploy already sign by this account'
-                  },
-                  { requestId: action.meta.requestId }
-                )
-              );
-            }
-
-            store.dispatch(
-              deployPayloadReceived({
-                id: action.meta.requestId,
-                json: deployJson
-              })
-            );
-
-            openWindow({
-              windowApp: WindowApp.SignatureRequestDeploy,
-              searchParams: {
-                requestId: action.meta.requestId,
-                signingPublicKeyHex,
-                origin,
-                tabId: String(senderTabId)
-              }
-            });
-
-            return sendResponse(undefined);
-          }
-
-          case getType(sdkMethod.signMessageRequest): {
-            const origin = getUrlOrigin(sender.url);
-            if (!origin) {
-              return sendError(CannotGetSenderOriginError());
-            }
-
-            const senderTabId = sender.tab?.id;
-
-            if (senderTabId == null) {
-              return sendError(Error('Missing sender tab id'));
-            }
-
-            const { signingPublicKeyHex, message } = action.payload;
-
-            openWindow({
-              windowApp: WindowApp.SignatureRequestMessage,
-              searchParams: {
-                requestId: action.meta.requestId,
-                signingPublicKeyHex,
-                message,
-                origin,
-                tabId: String(senderTabId)
-              }
-            });
-
-            return sendResponse(undefined);
-          }
-
-          case getType(sdkMethod.signTypedDataRequest): {
-            const origin = getUrlOrigin(sender.url);
-            if (!origin) {
-              return sendError(CannotGetSenderOriginError());
-            }
-
-            const senderTabId = sender.tab?.id;
-
-            if (senderTabId == null) {
-              return sendError(Error('Missing sender tab id'));
-            }
-
-            const { signingPublicKeyHex, typedData, options } = action.payload;
-
-            store.dispatch(
-              eip712PayloadReceived({
-                id: action.meta.requestId,
-                json: JSON.stringify({ typedData, options })
-              })
-            );
-
-            openWindow({
-              windowApp: WindowApp.SignatureRequestEip712,
-              searchParams: {
-                requestId: action.meta.requestId,
-                signingPublicKeyHex,
-                origin,
-                tabId: String(senderTabId)
-              }
-            });
-
-            return sendResponse(undefined);
-          }
-
-          case getType(sdkMethod.decryptMessageRequest): {
-            const origin = getUrlOrigin(sender.url);
-
-            if (!origin) {
-              return sendError(CannotGetSenderOriginError());
-            }
-
-            const senderTabId = sender.tab?.id;
-
-            if (senderTabId == null) {
-              return sendError(Error('Missing sender tab id'));
-            }
-
-            const { signingPublicKeyHex, message } = action.payload;
-
-            openWindow({
-              windowApp: WindowApp.DecryptMessageRequest,
-              searchParams: {
-                requestId: action.meta.requestId,
-                signingPublicKeyHex,
-                message,
-                origin,
-                tabId: String(senderTabId)
-              }
-            });
-
-            return sendResponse(undefined);
-          }
-
-          case getType(sdkMethod.disconnectRequest): {
-            const origin = getUrlOrigin(sender.url);
-            if (!origin) {
-              return sendError(CannotGetSenderOriginError());
-            }
-
-            let success = false;
-
-            const isLocked = selectVaultIsLocked(store.getState());
-
-            const activeAccount = selectVaultActiveAccount(store.getState());
-            if (activeAccount == null) {
-              return sendError(CannotGetActiveAccountError());
-            }
-            const isActiveAccountConnected = selectIsAccountConnected(
-              store.getState(),
-              origin,
-              activeAccount.name
-            );
-
-            emitSdkEventToActiveTabsWithOrigin(
-              origin,
-              sdkEvent.disconnectedAccountEvent({
-                isLocked: isLocked,
-                isConnected: isLocked ? undefined : false,
-                activeKey:
-                  !isLocked && isActiveAccountConnected
-                    ? activeAccount.publicKey
-                    : undefined,
-                activeKeySupports:
-                  !isLocked && isActiveAccountConnected
-                    ? getActiveAccountSupports(activeAccount)
-                    : undefined
-              })
-            );
-            store.dispatch(
-              siteDisconnected({
-                siteOrigin: origin
-              })
-            );
-            success = true;
-
-            return sendResponse(
-              sdkMethod.disconnectResponse(success, action.meta)
-            );
-          }
-
-          case getType(sdkMethod.isConnectedRequest): {
-            const origin = getUrlOrigin(sender.url);
-            if (!origin) {
-              return sendError(CannotGetSenderOriginError());
-            }
-
-            const isLocked = selectVaultIsLocked(store.getState());
-            if (isLocked) {
-              return sendResponse(
-                sdkMethod.isConnectedError(WalletLockedError(), action.meta)
-              );
-            }
-            const accountNamesByOriginDict = selectAccountNamesByOriginDict(
-              store.getState()
-            );
-            const isConnected = Boolean(origin in accountNamesByOriginDict);
-
-            return sendResponse(
-              sdkMethod.isConnectedResponse(isConnected, action.meta)
-            );
-          }
-
-          case getType(sdkMethod.getActivePublicKeyRequest): {
-            const origin = getUrlOrigin(sender.url);
-            if (!origin) {
-              return sendError(CannotGetSenderOriginError());
-            }
-
-            const isLocked = selectVaultIsLocked(store.getState());
-            if (isLocked) {
-              return sendResponse(
-                sdkMethod.getActivePublicKeyError(
-                  WalletLockedError(),
-                  action.meta
-                )
-              );
-            }
-
-            const activeAccount = selectVaultActiveAccount(store.getState());
-            if (activeAccount == null) {
-              return sendError(CannotGetActiveAccountError());
-            }
-
-            const isConnected = selectIsAccountConnected(
-              store.getState(),
-              origin,
-              activeAccount?.name
-            );
-
-            if (!isConnected) {
-              return sendResponse(
-                sdkMethod.getActivePublicKeyError(
-                  SiteNotConnectedError(),
-                  action.meta
-                )
-              );
-            }
-
-            return sendResponse(
-              sdkMethod.getActivePublicKeyResponse(
-                activeAccount.publicKey,
-                action.meta
-              )
-            );
-          }
-
-          case getType(sdkMethod.encryptMessageRequest): {
-            const origin = getUrlOrigin(sender.url);
-
-            const { signingPublicKeyHex, message = '' } = action.payload;
-
-            if (!origin) {
-              return sendError(CannotGetSenderOriginError());
-            }
-
-            try {
-              PublicKey.fromHex(signingPublicKeyHex);
-            } catch (e) {
-              return sendError(Error('Public key hex is not valid'));
-            }
-
-            if (message.length > ENCRYPT_MESSAGE_MAX_LENGTH) {
-              return sendError(
-                Error(
-                  `Message should be less than ${ENCRYPT_MESSAGE_MAX_LENGTH} symbols`
-                )
-              );
-            }
-
-            try {
-              const encryptedMessage = await encryptAsHexWithCasperPublicKey(
-                signingPublicKeyHex,
-                message
-              );
-
-              return sendResponse(
-                sdkMethod.encryptMessageResponse(
-                  {
-                    encryptedMessage
-                  },
-                  action.meta
-                )
-              );
-            } catch (e) {
-              return sendError(Error('Error during message encryption'));
-            }
-          }
-
-          case getType(sdkMethod.getActivePublicKeySupportsRequest): {
-            const origin = getUrlOrigin(sender.url);
-
-            if (!origin) {
-              return sendError(CannotGetSenderOriginError());
-            }
-
-            const isLocked = selectVaultIsLocked(store.getState());
-
-            if (isLocked) {
-              return sendResponse(
-                sdkMethod.getActivePublicKeySupportsError(
-                  WalletLockedError(),
-                  action.meta
-                )
-              );
-            }
-
-            const activeAccount = selectVaultActiveAccount(store.getState());
-
-            if (!activeAccount) {
-              return sendError(CannotGetActiveAccountError());
-            }
-
-            const isConnected = selectIsAccountConnected(
-              store.getState(),
-              origin,
-              activeAccount?.name
-            );
-
-            if (!isConnected) {
-              return sendResponse(
-                sdkMethod.getActivePublicKeySupportsError(
-                  SiteNotConnectedError(),
-                  action.meta
-                )
-              );
-            }
-
-            const supports = getActiveAccountSupports(activeAccount);
-
-            return sendResponse(
-              sdkMethod.getActivePublicKeySupportsResponse(
-                supports,
-                action.meta
-              )
-            );
-          }
-
-          case getType(sdkMethod.getVersionRequest): {
-            const manifestData = runtime.getManifest();
-            const version = manifestData.version;
-
-            return sendResponse(
-              sdkMethod.getVersionResponse(version, action.meta)
-            );
-          }
-
-          default:
-            throw Error(
-              'Background: Unknown sdk message: ' + JSON.stringify(action)
-            );
+      // A handled result either carries a `response` (→ sendResponse) or not
+      // (→ leave the promise pending). Centralized so all handler call sites
+      // route their result identically.
+      const respond = (result: { response?: unknown }) =>
+        'response' in result ? sendResponse(result.response) : undefined;
+
+      try {
+        if (message === 'keepAlive') {
+          return sendResponse({ status: 'alive' });
         }
-      } else if (action.type != null) {
-        switch (action.type) {
-          case resetVault.type: {
-            store.dispatch(action);
-            await enableOnboardingFlow();
-            return sendResponse(undefined);
+
+        const action = message as { type?: unknown; from?: unknown };
+
+        if (isSDKMethod(action)) {
+          const result = await handleSdkMethod(action, sender, store);
+          if (result.handled) {
+            return respond(result);
           }
+          throw Error(
+            'Background: Unknown sdk message: ' + JSON.stringify(action)
+          );
+        }
 
-          case lockVault.type:
-          case unlockVault.type:
-          case initKeys.type:
-          case initVault.type:
-          case recoverVault.type:
-          case createAccount.type:
-          case deploysReseted.type:
-          case sessionReseted.type:
-          case encryptionKeyHashCreated.type:
-          case vaultUnlocked.type:
-          case vaultLoaded.type:
-          case vaultReseted.type:
-          case secretPhraseCreated.type:
-          case accountImported.type:
-          case accountsImported.type:
-          case accountAdded.type:
-          case accountsAdded.type:
-          case accountRemoved.type:
-          case accountRenamed.type:
-          case activeAccountChanged.type:
-          case activeAccountSupportsChanged.type:
-          case hideAccountFromListChanged.type:
-          case activeTimeoutDurationSettingChanged.type:
-          case activeNetworkSettingChanged.type:
-          case vaultSettingsReseted.type:
-          case themeModeSettingChanged.type:
-          case lastActivityTimeRefreshed.type:
-          case siteConnected.type:
-          case anotherAccountConnected.type:
-          case accountDisconnected.type:
-          case siteDisconnected.type:
-          case windowIdChanged.type:
-          case windowIdCleared.type:
-          case onboardingAppInit.type:
-          case popupWindowInit.type:
-          case connectWindowInit.type:
-          case importWindowInit.type:
-          case signWindowInit.type:
-          case vaultCipherReseted.type:
-          case vaultCipherCreated.type:
-          case keysReseted.type:
-          case keysUpdated.type:
-          case loginRetryCountReseted.type:
-          case loginRetryCountIncremented.type:
-          case loginRetryLockoutTimeSet.type:
-          case recipientPublicKeyAdded.type:
-          case recipientPublicKeyReseted.type:
-          case accountInfoReset.type:
-          case accountPendingDeployHashesChanged.type:
-          case accountPendingDeployHashesRemove.type:
-          case accountTrackingIdOfSentNftTokensChanged.type:
-          case accountTrackingIdOfSentNftTokensRemoved.type:
-          case newContactAdded.type:
-          case contactRemoved.type:
-          case contactEditingPermissionChanged.type:
-          case contactUpdated.type:
-          case contactsReseted.type:
-          case ratedInStoreChanged.type:
-          case askForReviewAfterChanged.type:
-          case resetRateApp.type:
-          case ledgerNewWindowIdChanged.type:
-          case ledgerStateCleared.type:
-          case ledgerDeployChanged.type:
-          case ledgerTransactionChanged.type:
-          case ledgerRecipientToSaveOnSuccessChanged.type:
-          case addWatchingAccount.type:
-          case dismissAppEvent.type:
-          case resetAppEventsDismission.type:
-          case addWasmToTrusted.type:
-          case removeWasmFromTrusted.type:
-          case removeAllWasmFromTrustedOrigin.type:
-          case resetTrustedWasmState.type:
-          case systemColorSchemeChanged.type:
-            store.dispatch(action);
-            return sendResponse(undefined);
-
-          case getType(backgroundEvent.popupStateUpdated):
-            // do nothing
+        if (isPrivateStateRequest(action)) {
+          if (!isTrustedUiSender(sender)) {
+            // No data (and no error detail) for untrusted senders
             return;
-
-          case getType(bringWeb3Events.getActivePublicKey): {
-            const activeAccount = selectVaultActiveAccount(store.getState());
-
-            return sendResponse(
-              bringWeb3Events.getActivePublicKeyResponse({
-                publicKey: activeAccount?.publicKey!
-              })
-            );
           }
-
-          case getType(bringWeb3Events.promptLoginRequest): {
-            const isLocked = selectVaultIsLocked(store.getState());
-
-            if (isLocked) {
-              windows.getCurrent().then(currentWindow => {
-                const windowWidth = currentWindow.width ?? 0;
-                const xOffset = currentWindow.left ?? 0;
-                const yOffset = currentWindow.top ?? 0;
-                const popupWidth = 360;
-                const popupHeight = 700;
-
-                windows.create({
-                  url: 'popup.html#/bring-web3-unlock',
-                  type: 'popup',
-                  height: popupHeight,
-                  width: popupWidth,
-                  left: windowWidth + xOffset - popupWidth,
-                  top: yOffset,
-                  focused: true
-                });
-              });
-            } else {
-              emitSdkEventToActiveTabs(tab => {
-                if (!tab.url) {
-                  return;
-                }
-
-                const activeAccount = selectVaultActiveAccount(
-                  store.getState()
-                );
-
-                return sdkEvent.changedConnectedAccountEvent({
-                  isLocked: isLocked,
-                  isConnected: undefined,
-                  activeKey: activeAccount?.publicKey,
-                  activeKeySupports: activeAccount
-                    ? getActiveAccountSupports(activeAccount)
-                    : undefined
-                });
-              });
-            }
-
-            return sendResponse(undefined);
-          }
-
-          case getType(bringWeb3Events.getTheme): {
-            const themeMode = selectThemeModeSetting(store.getState());
-            const systemColorScheme = selectSystemColorScheme(store.getState());
-
-            const isDarkMode =
-              themeMode === ThemeMode.SYSTEM
-                ? systemColorScheme === null || systemColorScheme === 'dark'
-                : themeMode === ThemeMode.DARK;
-
-            return sendResponse(
-              bringWeb3Events.getThemeResponse({
-                theme: isDarkMode ? 'dark' : 'light'
-              })
-            );
-          }
-
-          case PRIVATE_STATE_REQUEST_TYPE as any: {
-            if (!isTrustedUiSender(sender)) {
-              // No data (and no error detail) for untrusted senders
-              return;
-            }
-            return sendResponse(selectPrivateState(store.getState()));
-          }
-
-          // TODO: All below should be removed when Import Account is integrated with window
-          case 'check-secret-key-exist' as any: {
-            const { secretKeyBase64 } = (
-              action as any as CheckSecretKeyExistAction
-            ).payload;
-            const vaultAccountsSecretKeysBase64 =
-              selectVaultAccountsSecretKeysBase64(store.getState());
-
-            const response = secretKeyBase64
-              ? vaultAccountsSecretKeysBase64.includes(secretKeyBase64)
-              : false;
-            return sendResponse(response);
-          }
-
-          case 'check-account-name-is-taken' as any: {
-            const { accountName } = (
-              action as any as CheckAccountNameIsTakenAction
-            ).payload;
-            const vaultAccountsNames = selectVaultAccountsNames(
-              store.getState()
-            );
-            const response = accountName
-              ? vaultAccountsNames.includes(accountName)
-              : false;
-            return sendResponse(response);
-          }
-
-          case 'get-window-id' as any:
-            const windowId = selectWindowId(store.getState());
-            return sendResponse(windowId);
-
-          default:
-            throw Error(
-              'Background: Unknown redux action: ' + JSON.stringify(action)
-            );
+          return sendResponse(selectPrivateState(store.getState()));
         }
-      } else {
-        if (action === 'keepAlive') {
-          // Send an asynchronous response
-          sendResponse({ status: 'alive' });
 
-          // returning true to indicate an asynchronous response
-          return true;
+        if (typeof action.type === 'string') {
+          const typedAction = action as { type: string };
+
+          for (const handle of [handleReduxAction, handleBringWeb3] as const) {
+            const result = await handle(typedAction, store);
+            if (result.handled) {
+              return respond(result);
+            }
+          }
+
+          // Legacy import handler is gated on `sender` (P0.1), so it is called
+          // outside the uniform loop above.
+          const legacyResult = handleLegacyImport(typedAction, sender, store);
+          if (legacyResult.handled) {
+            return respond(legacyResult);
+          }
+
+          throw Error(
+            'Background: Unknown redux action: ' + JSON.stringify(action)
+          );
         }
+
         // this is added for not spamming with errors from bringweb3
-        if ('from' in action) {
-          // @ts-ignore
-          if (action.from === 'bringweb3') {
-            return;
-          }
+        if (action?.from === 'bringweb3') {
+          return;
         }
+
         throw Error('Background: Unknown message: ' + JSON.stringify(action));
+      } catch (error) {
+        return sendError(error);
       }
     });
   }

--- a/src/background/redux/account-info/actions.ts
+++ b/src/background/redux/account-info/actions.ts
@@ -1,22 +1,7 @@
-import { createAction } from 'typesafe-actions';
-
-export const accountInfoReset = createAction('ACCOUNT_INFO_RESET')();
-
-export const accountPendingDeployHashesChanged = createAction(
-  'ACCOUNT_PENDING_DEPLOY_HASHES_CHANGED'
-)<string>();
-
-export const accountPendingDeployHashesRemove = createAction(
-  'ACCOUNT_PENDING_TRANSACTIONS_REMOVE'
-)<string>();
-
-export const accountTrackingIdOfSentNftTokensChanged = createAction(
-  'ACCOUNT_TRACKING_ID_OF_SENT_NFT_TOKENS_CHANGED'
-)<{
-  trackingId: string;
-  deployHash: string;
-}>();
-
-export const accountTrackingIdOfSentNftTokensRemoved = createAction(
-  'ACCOUNT_TRACKING_ID_OF_SENT_NFT_TOKENS_REMOVED'
-)<string>();
+export {
+  accountInfoReset,
+  accountPendingDeployHashesChanged,
+  accountPendingDeployHashesRemove,
+  accountTrackingIdOfSentNftTokensChanged,
+  accountTrackingIdOfSentNftTokensRemoved
+} from './reducer';

--- a/src/background/redux/account-info/reducer.test.ts
+++ b/src/background/redux/account-info/reducer.test.ts
@@ -1,0 +1,56 @@
+import {
+  accountInfoReset,
+  accountPendingDeployHashesChanged,
+  accountPendingDeployHashesRemove,
+  accountTrackingIdOfSentNftTokensChanged,
+  accountTrackingIdOfSentNftTokensRemoved
+} from './actions';
+import { reducer } from './reducer';
+
+const initial = {
+  pendingDeployHashes: [],
+  accountTrackingIdOfSentNftTokens: {}
+};
+
+describe('account-info reducer', () => {
+  it('has correct initial state', () => {
+    expect(reducer(undefined, { type: '@@INIT' } as any)).toEqual(initial);
+  });
+  it('prepends pending deploy hashes', () => {
+    const s = reducer(
+      { ...initial, pendingDeployHashes: ['0xB'] },
+      accountPendingDeployHashesChanged('0xA')
+    );
+    expect(s.pendingDeployHashes).toEqual(['0xA', '0xB']);
+  });
+  it('removes pending hashes case-insensitively', () => {
+    const s = reducer(
+      { ...initial, pendingDeployHashes: ['0xAbC', '0xD'] },
+      accountPendingDeployHashesRemove('0xabc')
+    );
+    expect(s.pendingDeployHashes).toEqual(['0xD']);
+  });
+  it('adds and removes nft tracking ids', () => {
+    const s1 = reducer(
+      initial,
+      accountTrackingIdOfSentNftTokensChanged({
+        trackingId: 't1',
+        deployHash: 'd1'
+      })
+    );
+    expect(s1.accountTrackingIdOfSentNftTokens).toEqual({ t1: 'd1' });
+    const s2 = reducer(s1, accountTrackingIdOfSentNftTokensRemoved('t1'));
+    expect(s2.accountTrackingIdOfSentNftTokens).toEqual({});
+  });
+  it('resets', () => {
+    expect(
+      reducer(
+        {
+          pendingDeployHashes: ['x'],
+          accountTrackingIdOfSentNftTokens: { a: 'b' }
+        },
+        accountInfoReset()
+      )
+    ).toEqual(initial);
+  });
+});

--- a/src/background/redux/account-info/reducer.ts
+++ b/src/background/redux/account-info/reducer.ts
@@ -1,14 +1,7 @@
-import { createReducer } from 'typesafe-actions';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import { isEqualCaseInsensitive } from '@src/utils';
 
-import {
-  accountInfoReset,
-  accountPendingDeployHashesChanged,
-  accountPendingDeployHashesRemove,
-  accountTrackingIdOfSentNftTokensChanged,
-  accountTrackingIdOfSentNftTokensRemoved
-} from './actions';
 import { AccountInfoState } from './types';
 
 const initialState: AccountInfoState = {
@@ -16,33 +9,43 @@ const initialState: AccountInfoState = {
   accountTrackingIdOfSentNftTokens: {}
 };
 
-export const reducer = createReducer(initialState)
-  .handleAction(accountInfoReset, () => initialState)
-  .handleAction(accountPendingDeployHashesChanged, (state, { payload }) => {
-    return {
+const slice = createSlice({
+  name: 'accountInfo',
+  initialState,
+  reducers: {
+    accountInfoReset: () => initialState,
+    accountPendingDeployHashesChanged: (
+      state,
+      { payload }: PayloadAction<string>
+    ) => ({
       ...state,
       pendingDeployHashes: [payload, ...state.pendingDeployHashes]
-    };
-  })
-  .handleAction(accountPendingDeployHashesRemove, (state, { payload }) => ({
-    ...state,
-    pendingDeployHashes: state.pendingDeployHashes.filter(
-      deploy => !isEqualCaseInsensitive(deploy, payload)
-    )
-  }))
-  .handleAction(
-    accountTrackingIdOfSentNftTokensChanged,
-    (state, { payload: { trackingId, deployHash } }) => ({
+    }),
+    accountPendingDeployHashesRemove: (
+      state,
+      { payload }: PayloadAction<string>
+    ) => ({
+      ...state,
+      pendingDeployHashes: state.pendingDeployHashes.filter(
+        deploy => !isEqualCaseInsensitive(deploy, payload)
+      )
+    }),
+    accountTrackingIdOfSentNftTokensChanged: (
+      state,
+      {
+        payload: { trackingId, deployHash }
+      }: PayloadAction<{ trackingId: string; deployHash: string }>
+    ) => ({
       ...state,
       accountTrackingIdOfSentNftTokens: {
         ...state.accountTrackingIdOfSentNftTokens,
         [trackingId]: deployHash
       }
-    })
-  )
-  .handleAction(
-    accountTrackingIdOfSentNftTokensRemoved,
-    (state, { payload }) => {
+    }),
+    accountTrackingIdOfSentNftTokensRemoved: (
+      state,
+      { payload }: PayloadAction<string>
+    ) => {
       const accountTrackingIdOfSentNftTokens = {
         ...state.accountTrackingIdOfSentNftTokens
       };
@@ -53,4 +56,14 @@ export const reducer = createReducer(initialState)
         accountTrackingIdOfSentNftTokens
       };
     }
-  );
+  }
+});
+
+export const {
+  accountInfoReset,
+  accountPendingDeployHashesChanged,
+  accountPendingDeployHashesRemove,
+  accountTrackingIdOfSentNftTokensChanged,
+  accountTrackingIdOfSentNftTokensRemoved
+} = slice.actions;
+export const reducer = slice.reducer;

--- a/src/background/redux/account-info/selectors.ts
+++ b/src/background/redux/account-info/selectors.ts
@@ -1,4 +1,4 @@
-import { RootState } from 'typesafe-actions';
+import { RootState } from '@background/redux/store-types';
 
 export const selectPendingDeployHashes = (state: RootState) =>
   state.accountInfo.pendingDeployHashes;

--- a/src/background/redux/active-origin-favicon/actions.ts
+++ b/src/background/redux/active-origin-favicon/actions.ts
@@ -1,5 +1,1 @@
-import { createAction } from 'typesafe-actions';
-
-export const activeOriginFaviconChanged = createAction(
-  'ACTIVE_ORIGIN_FAVICON_CHANGED'
-)<string | null>();
+export { activeOriginFaviconChanged } from './reducer';

--- a/src/background/redux/active-origin-favicon/reducer.test.ts
+++ b/src/background/redux/active-origin-favicon/reducer.test.ts
@@ -1,0 +1,16 @@
+import { activeOriginFaviconChanged } from './actions';
+import { reducer } from './reducer';
+
+describe('active-origin-favicon reducer', () => {
+  it('has null initial state', () => {
+    expect(reducer(undefined, { type: '@@INIT' } as any)).toBeNull();
+  });
+  it('stores and clears the favicon url', () => {
+    expect(reducer(null, activeOriginFaviconChanged('https://x/i.png'))).toBe(
+      'https://x/i.png'
+    );
+    expect(
+      reducer('https://x/i.png', activeOriginFaviconChanged(null))
+    ).toBeNull();
+  });
+});

--- a/src/background/redux/active-origin-favicon/reducer.ts
+++ b/src/background/redux/active-origin-favicon/reducer.ts
@@ -1,10 +1,19 @@
-import { createReducer } from 'typesafe-actions';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import { activeOriginFaviconChanged } from './actions';
 import { ActiveOriginFaviconState } from './types';
 
-const initialState: ActiveOriginFaviconState = null;
+const initialState = null as ActiveOriginFaviconState;
 
-export const reducer = createReducer<ActiveOriginFaviconState>(
-  initialState
-).handleAction(activeOriginFaviconChanged, (state, { payload }) => payload);
+const slice = createSlice({
+  name: 'activeOriginFavicon',
+  initialState,
+  reducers: {
+    activeOriginFaviconChanged: (
+      _state,
+      action: PayloadAction<string | null>
+    ) => action.payload
+  }
+});
+
+export const { activeOriginFaviconChanged } = slice.actions;
+export const reducer = slice.reducer;

--- a/src/background/redux/active-origin-favicon/selectors.ts
+++ b/src/background/redux/active-origin-favicon/selectors.ts
@@ -1,4 +1,4 @@
-import { RootState } from 'typesafe-actions';
+import { RootState } from '@background/redux/store-types';
 
 export const selectActiveOriginFavicon = (state: RootState): string | null =>
   state.activeOriginFavicon;

--- a/src/background/redux/active-origin/actions.ts
+++ b/src/background/redux/active-origin/actions.ts
@@ -1,5 +1,1 @@
-import { createAction } from 'typesafe-actions';
-
-export const activeOriginChanged = createAction('ACTIVE_ORIGIN_CHANGED')<
-  string | null
->();
+export { activeOriginChanged } from './reducer';

--- a/src/background/redux/active-origin/reducer.test.ts
+++ b/src/background/redux/active-origin/reducer.test.ts
@@ -1,0 +1,26 @@
+import { activeOriginChanged } from './actions';
+import { reducer } from './reducer';
+
+describe('active-origin reducer', () => {
+  it('has null initial state', () => {
+    expect(reducer(undefined, { type: '@@INIT' } as any)).toBeNull();
+  });
+
+  it('stores the new origin on activeOriginChanged', () => {
+    expect(reducer(null, activeOriginChanged('https://app.example'))).toBe(
+      'https://app.example'
+    );
+  });
+
+  it('clears the origin on activeOriginChanged(null)', () => {
+    expect(
+      reducer('https://app.example', activeOriginChanged(null))
+    ).toBeNull();
+  });
+
+  it('ignores unknown actions', () => {
+    expect(reducer('https://app.example', { type: 'NOPE' } as any)).toBe(
+      'https://app.example'
+    );
+  });
+});

--- a/src/background/redux/active-origin/reducer.ts
+++ b/src/background/redux/active-origin/reducer.ts
@@ -1,11 +1,17 @@
-import { createReducer } from 'typesafe-actions';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import { activeOriginChanged } from './actions';
 import { ActiveOriginState } from './types';
 
 const initialState = null as ActiveOriginState;
 
-export const reducer = createReducer(initialState).handleAction(
-  activeOriginChanged,
-  (state, { payload }) => payload
-);
+const slice = createSlice({
+  name: 'activeOrigin',
+  initialState,
+  reducers: {
+    activeOriginChanged: (_state, action: PayloadAction<string | null>) =>
+      action.payload
+  }
+});
+
+export const { activeOriginChanged } = slice.actions;
+export const reducer = slice.reducer;

--- a/src/background/redux/active-origin/selectors.ts
+++ b/src/background/redux/active-origin/selectors.ts
@@ -1,4 +1,4 @@
-import { RootState } from 'typesafe-actions';
+import { RootState } from '@background/redux/store-types';
 
 export const selectActiveOrigin = (state: RootState): string | null =>
   state.activeOrigin;

--- a/src/background/redux/app-events/actions.ts
+++ b/src/background/redux/app-events/actions.ts
@@ -1,7 +1,1 @@
-import { createAction } from 'typesafe-actions';
-
-export const dismissAppEvent = createAction('DISMISS_APP_EVENT')<number>();
-
-export const resetAppEventsDismission = createAction(
-  'RESET_APP_EVENTS_DISMISSION'
-)();
+export { dismissAppEvent, resetAppEventsDismission } from './reducer';

--- a/src/background/redux/app-events/reducer.test.ts
+++ b/src/background/redux/app-events/reducer.test.ts
@@ -1,0 +1,22 @@
+import { dismissAppEvent, resetAppEventsDismission } from './actions';
+import { reducer } from './reducer';
+
+describe('app-events reducer', () => {
+  it('has empty initial state', () => {
+    expect(reducer(undefined, { type: '@@INIT' } as any)).toEqual({
+      dismissedEventIds: []
+    });
+  });
+  it('adds dismissed ids without duplicates', () => {
+    const s1 = reducer({ dismissedEventIds: [1] }, dismissAppEvent(2));
+    expect(s1).toEqual({ dismissedEventIds: [1, 2] });
+    expect(reducer(s1, dismissAppEvent(2))).toEqual({
+      dismissedEventIds: [1, 2]
+    });
+  });
+  it('resets', () => {
+    expect(
+      reducer({ dismissedEventIds: [1, 2] }, resetAppEventsDismission())
+    ).toEqual({ dismissedEventIds: [] });
+  });
+});

--- a/src/background/redux/app-events/reducer.ts
+++ b/src/background/redux/app-events/reducer.ts
@@ -1,9 +1,4 @@
-import { createReducer } from 'typesafe-actions';
-
-import {
-  dismissAppEvent,
-  resetAppEventsDismission
-} from '@background/redux/app-events/actions';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import { AppEventsState } from './types';
 
@@ -11,14 +6,19 @@ const initialState: AppEventsState = {
   dismissedEventIds: []
 };
 
-export const reducer = createReducer(initialState)
-  .handleAction(
-    dismissAppEvent,
-    (state: AppEventsState, action: ReturnType<typeof dismissAppEvent>) => ({
+const slice = createSlice({
+  name: 'appEvents',
+  initialState,
+  reducers: {
+    dismissAppEvent: (state, action: PayloadAction<number>) => ({
       ...state,
       dismissedEventIds: [
         ...new Set([...state.dismissedEventIds, action.payload])
       ]
-    })
-  )
-  .handleAction(resetAppEventsDismission, () => initialState);
+    }),
+    resetAppEventsDismission: () => initialState
+  }
+});
+
+export const { dismissAppEvent, resetAppEventsDismission } = slice.actions;
+export const reducer = slice.reducer;

--- a/src/background/redux/app-events/selectors.ts
+++ b/src/background/redux/app-events/selectors.ts
@@ -1,4 +1,4 @@
-import { RootState } from 'typesafe-actions';
+import { RootState } from '@background/redux/store-types';
 
 export const selectDismissedAppEvents = (state: RootState) =>
   state.appEvents.dismissedEventIds;

--- a/src/background/redux/contacts/actions.ts
+++ b/src/background/redux/contacts/actions.ts
@@ -1,15 +1,6 @@
-import { createAction } from 'typesafe-actions';
-
-import {
-  Contact,
-  EditContactActionType
-} from '@background/redux/contacts/types';
-
-export const newContactAdded = createAction('NEW_CONTACT_ADDED')<Contact>();
-
-export const contactRemoved = createAction('CONTACT_REMOVED')<string>();
-
-export const contactUpdated =
-  createAction('CONTACT_UPDATED')<EditContactActionType>();
-
-export const contactsReseted = createAction('CONTACTS_RESETED')();
+export {
+  newContactAdded,
+  contactRemoved,
+  contactUpdated,
+  contactsReseted
+} from './reducer';

--- a/src/background/redux/contacts/reducer.test.ts
+++ b/src/background/redux/contacts/reducer.test.ts
@@ -1,0 +1,64 @@
+import {
+  contactRemoved,
+  contactUpdated,
+  contactsReseted,
+  newContactAdded
+} from './actions';
+import { reducer } from './reducer';
+
+const bob = {
+  name: 'Bob',
+  publicKey: '01bb',
+  lastModified: '2026-01-02T00:00:00.000Z'
+};
+const ann = {
+  name: 'Ann',
+  publicKey: '01aa',
+  lastModified: '2026-01-03T00:00:00.000Z'
+};
+
+describe('contacts reducer', () => {
+  it('has empty initial state', () => {
+    expect(reducer(undefined, { type: '@@INIT' } as any)).toEqual({
+      contacts: [],
+      lastModified: null
+    });
+  });
+  it('adds contacts sorted by name and stamps lastModified from payload', () => {
+    const s1 = reducer(
+      { contacts: [bob], lastModified: bob.lastModified },
+      newContactAdded(ann)
+    );
+    expect(s1.contacts.map(c => c.name)).toEqual(['Ann', 'Bob']);
+    expect(s1.lastModified).toBe(ann.lastModified);
+  });
+  it('removes by name and stamps a fresh ISO timestamp', () => {
+    const s = reducer(
+      { contacts: [ann, bob], lastModified: null },
+      contactRemoved('Ann')
+    );
+    expect(s.contacts).toEqual([bob]);
+    expect(new Date(s.lastModified!).toISOString()).toBe(s.lastModified);
+  });
+  it('updates by oldName', () => {
+    const s = reducer(
+      { contacts: [ann, bob], lastModified: null },
+      contactUpdated({
+        oldName: 'Bob',
+        name: 'Rob',
+        publicKey: '01cc',
+        lastModified: '2026-02-01T00:00:00.000Z'
+      })
+    );
+    expect(s.contacts.map(c => c.name)).toEqual(['Ann', 'Rob']);
+    expect(s.lastModified).toBe('2026-02-01T00:00:00.000Z');
+  });
+  it('resets', () => {
+    expect(
+      reducer({ contacts: [ann], lastModified: 'x' }, contactsReseted())
+    ).toEqual({
+      contacts: [],
+      lastModified: null
+    });
+  });
+});

--- a/src/background/redux/contacts/reducer.ts
+++ b/src/background/redux/contacts/reducer.ts
@@ -1,44 +1,56 @@
-import { createReducer } from 'typesafe-actions';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import {
-  contactRemoved,
-  contactUpdated,
-  contactsReseted,
-  newContactAdded
-} from '@background/redux/contacts/actions';
-import { ContactsState } from '@background/redux/contacts/types';
+  Contact,
+  ContactsState,
+  EditContactActionType
+} from '@background/redux/contacts/types';
 
 const initialState = { contacts: [], lastModified: null } as ContactsState;
 
-export const reducer = createReducer(initialState)
-  .handleAction(contactsReseted, () => initialState)
-  .handleAction(newContactAdded, (state, action) => {
-    const sortedContacts = [...state.contacts, action.payload].sort((a, b) =>
-      a.name.localeCompare(b.name)
-    );
-    return {
-      contacts: sortedContacts,
-      lastModified: action.payload.lastModified
-    };
-  })
-  .handleAction(contactRemoved, (state, action) => {
-    return {
+const slice = createSlice({
+  name: 'contacts',
+  initialState,
+  reducers: {
+    contactsReseted: () => initialState,
+    newContactAdded: (state, action: PayloadAction<Contact>) => {
+      const sortedContacts = [...state.contacts, action.payload].sort((a, b) =>
+        a.name.localeCompare(b.name)
+      );
+      return {
+        contacts: sortedContacts,
+        lastModified: action.payload.lastModified
+      };
+    },
+    contactRemoved: (state, action: PayloadAction<string>) => ({
       contacts: state.contacts.filter(
         contact => contact.name !== action.payload
       ),
       lastModified: new Date().toISOString()
-    };
-  })
-  .handleAction(contactUpdated, (state, { payload }) => {
-    const newContacts = {
-      name: payload.name,
-      publicKey: payload.publicKey,
-      lastModified: payload.lastModified
-    };
-    return {
-      contacts: state.contacts.map(contact =>
-        contact.name === payload.oldName ? newContacts : contact
-      ),
-      lastModified: payload.lastModified
-    };
-  });
+    }),
+    contactUpdated: (
+      state,
+      { payload }: PayloadAction<EditContactActionType>
+    ) => {
+      const newContacts = {
+        name: payload.name,
+        publicKey: payload.publicKey,
+        lastModified: payload.lastModified
+      };
+      return {
+        contacts: state.contacts.map(contact =>
+          contact.name === payload.oldName ? newContacts : contact
+        ),
+        lastModified: payload.lastModified
+      };
+    }
+  }
+});
+
+export const {
+  contactRemoved,
+  contactUpdated,
+  contactsReseted,
+  newContactAdded
+} = slice.actions;
+export const reducer = slice.reducer;

--- a/src/background/redux/contacts/selectors.ts
+++ b/src/background/redux/contacts/selectors.ts
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
-import { RootState } from 'typesafe-actions';
+
+import { RootState } from '@background/redux/store-types';
 
 export const selectAllContacts = (state: RootState) => state.contacts.contacts;
 

--- a/src/background/redux/get-main-store.ts
+++ b/src/background/redux/get-main-store.ts
@@ -1,4 +1,3 @@
-import { RootState } from 'typesafe-actions';
 import { runtime, storage } from 'webextension-polyfill';
 
 import { backgroundEvent } from '@background/background-events';
@@ -12,6 +11,7 @@ import { RateAppState } from '@background/redux/rate-app/types';
 import { RecentRecipientPublicKeysState } from '@background/redux/recent-recipient-public-keys/types';
 import { startBackground } from '@background/redux/sagas/actions';
 import { SettingsState } from '@background/redux/settings/types';
+import { RootState } from '@background/redux/store-types';
 import { TrustedWasmState } from '@background/redux/trusted-wasm/types';
 import { PopupState } from '@background/redux/types';
 
@@ -186,6 +186,10 @@ export async function getExistingMainStoreSingletonOrInit() {
 
   return storeSingleton;
 }
+
+export type MainStore = Awaited<
+  ReturnType<typeof getExistingMainStoreSingletonOrInit>
+>;
 
 export function createMainStoreReplica<T extends PopupState>(state: T) {
   return createStore(state);

--- a/src/background/redux/get-main-store.ts
+++ b/src/background/redux/get-main-store.ts
@@ -109,7 +109,13 @@ export async function getExistingMainStoreSingletonOrInit() {
       } else {
         storeSingleton = createStore({
           vaultCipher,
-          keys,
+          keys: keys && {
+            ...keys,
+            keysDoesExist:
+              keys.passwordHash != null &&
+              keys.passwordSaltHash != null &&
+              keys.keyDerivationSaltHash != null
+          },
           loginRetryCount,
           loginRetryLockoutTime,
           lastActivityTime,

--- a/src/background/redux/get-main-store.ts
+++ b/src/background/redux/get-main-store.ts
@@ -43,16 +43,20 @@ type StorageState = {
 // this needs to be private
 let storeSingleton: ReturnType<typeof createStore>;
 
-// These state keys will be passed to popups
+// These state keys will be passed to popups. P0.1: cipher/hash material is
+// NOT broadcast — UI flows that need it use fetchPrivateState() explicitly.
 export const selectPopupState = (state: RootState): PopupState => {
-  // TODO: must sanitize state to not send private data back to front
   return {
-    keys: state.keys,
+    keys: {
+      passwordHash: null,
+      passwordSaltHash: null,
+      keyDerivationSaltHash: null,
+      keysDoesExist: state.keys.keysDoesExist
+    },
+    session: { ...state.session, encryptionKeyHash: null },
     loginRetryCount: state.loginRetryCount,
-    session: state.session,
     vault: state.vault,
     windowManagement: state.windowManagement,
-    vaultCipher: state.vaultCipher,
     loginRetryLockoutTime: state.loginRetryLockoutTime,
     lastActivityTime: state.lastActivityTime,
     activeOrigin: state.activeOrigin,
@@ -105,7 +109,9 @@ export async function getExistingMainStoreSingletonOrInit() {
         const { initialStateForPopupTests } = await import(
           /* webpackMode: "eager" */ '@src/fixtures'
         );
-        storeSingleton = createStore(initialStateForPopupTests as PopupState);
+        // The MOCK store IS the background store: it keeps the full RootState
+        // (incl. vaultCipher + real hashes); only the broadcast is sanitized.
+        storeSingleton = createStore(initialStateForPopupTests);
       } else {
         storeSingleton = createStore({
           vaultCipher,

--- a/src/background/redux/import-account-actions-should-be-removed.ts
+++ b/src/background/redux/import-account-actions-should-be-removed.ts
@@ -1,4 +1,3 @@
-import { EmptyAction, PayloadAction } from 'typesafe-actions';
 import { runtime } from 'webextension-polyfill';
 
 // WARNING: legacy to be refactored, don't reuse!
@@ -6,10 +5,10 @@ import { runtime } from 'webextension-polyfill';
 export type RemoteAction =
   CheckAccountNameIsTakenAction | CheckSecretKeyExistAction | GetWindowIdAction;
 
-export type CheckAccountNameIsTakenAction = PayloadAction<
-  'check-account-name-is-taken',
-  { accountName: string }
->;
+export type CheckAccountNameIsTakenAction = {
+  type: 'check-account-name-is-taken';
+  payload: { accountName: string };
+};
 
 export const checkAccountNameIsTaken = (value: string): Promise<boolean> => {
   const action: CheckAccountNameIsTakenAction = {
@@ -21,10 +20,10 @@ export const checkAccountNameIsTaken = (value: string): Promise<boolean> => {
   return runtime.sendMessage(action);
 };
 
-export type CheckSecretKeyExistAction = PayloadAction<
-  'check-secret-key-exist',
-  { secretKeyBase64: string }
->;
+export type CheckSecretKeyExistAction = {
+  type: 'check-secret-key-exist';
+  payload: { secretKeyBase64: string };
+};
 export const checkSecretKeyExist = (
   secretKeyBase64: string
 ): Promise<boolean> => {
@@ -37,7 +36,7 @@ export const checkSecretKeyExist = (
   return runtime.sendMessage(action);
 };
 
-export type GetWindowIdAction = EmptyAction<'get-window-id'>;
+export type GetWindowIdAction = { type: 'get-window-id' };
 
 export const getWindowId = (): Promise<number | null> => {
   const action: GetWindowIdAction = { type: 'get-window-id' };

--- a/src/background/redux/index.ts
+++ b/src/background/redux/index.ts
@@ -1,16 +1,12 @@
 import { devToolsEnhancer } from '@redux-devtools/remote';
-import {
-  Reducer,
-  StoreEnhancer,
-  UnknownAction,
-  configureStore
-} from '@reduxjs/toolkit';
+import { Reducer, StoreEnhancer, configureStore } from '@reduxjs/toolkit';
 import createSagaMiddleware from 'redux-saga';
-import { RootState } from 'typesafe-actions';
 
 import { isChromeBuild } from '@src/utils';
 
-import reduxAction from './redux-action';
+import { RootState } from '@background/redux/store-types';
+
+import reduxAction, { ReduxAction } from './redux-action';
 import rootReducer from './root-reducer';
 import rootSaga from './root-saga';
 
@@ -18,13 +14,13 @@ export const createStore = (initialState: Partial<RootState>) => {
   const sagaMiddleware = createSagaMiddleware();
 
   const store = configureStore({
-    // `rootReducer` is a `typesafe-actions` `combineReducers` result; RTK
+    // `rootReducer` is a `combineReducers` result; RTK
     // cannot infer its combined shape, so it collapses `preloadedState` to a
     // never-shape. Re-assert the reducer's real type (state + `Partial` preload
     // slot) so `preloadedState: Partial<RootState>` type-checks unchanged.
     reducer: rootReducer as unknown as Reducer<
       RootState,
-      UnknownAction,
+      ReduxAction,
       Partial<RootState>
     >,
     preloadedState: initialState,

--- a/src/background/redux/index.ts
+++ b/src/background/redux/index.ts
@@ -1,9 +1,10 @@
-import { composeWithDevTools } from '@redux-devtools/remote';
+import { devToolsEnhancer } from '@redux-devtools/remote';
 import {
-  applyMiddleware, // TODO: Move to actual `createStore`
-  compose,
-  legacy_createStore as createStoreRedux
-} from 'redux';
+  Reducer,
+  StoreEnhancer,
+  UnknownAction,
+  configureStore
+} from '@reduxjs/toolkit';
 import createSagaMiddleware from 'redux-saga';
 import { RootState } from 'typesafe-actions';
 
@@ -13,26 +14,48 @@ import reduxAction from './redux-action';
 import rootReducer from './root-reducer';
 import rootSaga from './root-saga';
 
-export const composeEnhancers =
-  process.env.NODE_ENV === 'development' && isChromeBuild
-    ? composeWithDevTools({
-        name: 'Casper Wallet',
-        hostname: 'localhost',
-        port: 8000
-      })
-    : compose;
-
 export const createStore = (initialState: Partial<RootState>) => {
   const sagaMiddleware = createSagaMiddleware();
-  // configure middlewares
-  const middlewares = [sagaMiddleware];
-  // compose enhancers
-  // @ts-ignore
-  const enhancer = composeEnhancers(applyMiddleware(...middlewares));
-  // create store
-  // @ts-ignore
-  const store = createStoreRedux(rootReducer, initialState, enhancer);
-  // run sagas
+
+  const store = configureStore({
+    // `rootReducer` is a `typesafe-actions` `combineReducers` result; RTK
+    // cannot infer its combined shape, so it collapses `preloadedState` to a
+    // never-shape. Re-assert the reducer's real type (state + `Partial` preload
+    // slot) so `preloadedState: Partial<RootState>` type-checks unchanged.
+    reducer: rootReducer as unknown as Reducer<
+      RootState,
+      UnknownAction,
+      Partial<RootState>
+    >,
+    preloadedState: initialState,
+    middleware: getDefaultMiddleware =>
+      getDefaultMiddleware({
+        thunk: false,
+        serializableCheck: false,
+        immutableCheck: false
+      }).concat(sagaMiddleware),
+    devTools: false,
+    enhancers: getDefaultEnhancers => {
+      const enhancers = getDefaultEnhancers();
+
+      if (process.env.NODE_ENV === 'development' && isChromeBuild) {
+        // `@redux-devtools/remote` bundles its own `redux`, so its
+        // `StoreEnhancer` is nominally unrelated to RTK's — cast to reconcile.
+        return enhancers.concat(
+          devToolsEnhancer({
+            name: 'Casper Wallet',
+            hostname: 'localhost',
+            port: 8000,
+            realtime: true,
+            secure: false
+          }) as StoreEnhancer
+        );
+      }
+
+      return enhancers;
+    }
+  });
+
   sagaMiddleware.run(rootSaga);
 
   return store;

--- a/src/background/redux/keys/actions.ts
+++ b/src/background/redux/keys/actions.ts
@@ -1,7 +1,1 @@
-import { createAction } from 'typesafe-actions';
-
-import { KeysState } from './types';
-
-export const keysUpdated = createAction('KEYS_UPDATED')<Partial<KeysState>>();
-
-export const keysReseted = createAction('KEYS_RESETED')<void>();
+export { keysReseted, keysUpdated } from './reducer';

--- a/src/background/redux/keys/reducer.test.ts
+++ b/src/background/redux/keys/reducer.test.ts
@@ -1,0 +1,61 @@
+import { keysReseted, keysUpdated } from './actions';
+import { reducer } from './reducer';
+
+const full = {
+  passwordHash: 'ph',
+  passwordSaltHash: 'psh',
+  keyDerivationSaltHash: 'kdsh'
+};
+
+describe('keys reducer', () => {
+  it('starts with null hashes', () => {
+    const s = reducer(undefined, { type: '@@INIT' } as any);
+    expect(s.passwordHash).toBeNull();
+    expect(s.passwordSaltHash).toBeNull();
+    expect(s.keyDerivationSaltHash).toBeNull();
+  });
+  it('merges a full update', () => {
+    const s = reducer(undefined as any, keysUpdated(full));
+    expect(s).toMatchObject(full);
+  });
+  it('merges a PARTIAL update without dropping other hashes', () => {
+    const s0 = reducer(undefined as any, keysUpdated(full));
+    const s1 = reducer(s0, keysUpdated({ keyDerivationSaltHash: 'kdsh2' }));
+    expect(s1).toMatchObject({ ...full, keyDerivationSaltHash: 'kdsh2' });
+  });
+  it('resets', () => {
+    const s = reducer(
+      reducer(undefined as any, keysUpdated(full)),
+      keysReseted()
+    );
+    expect(s.passwordHash).toBeNull();
+  });
+
+  it('keysDoesExist starts false', () => {
+    const s = reducer(undefined, { type: '@@INIT' } as any);
+    expect(s.keysDoesExist).toBe(false);
+  });
+  it('keysDoesExist is true once all three hashes are present', () => {
+    const s = reducer(undefined as any, keysUpdated(full));
+    expect(s.keysDoesExist).toBe(true);
+  });
+  it('keysDoesExist stays false while only a partial payload has arrived', () => {
+    const s = reducer(
+      undefined as any,
+      keysUpdated({ keyDerivationSaltHash: 'kdsh' })
+    );
+    expect(s.keysDoesExist).toBe(false);
+  });
+  it('keysDoesExist recomputes from post-merge state on a partial update', () => {
+    const s0 = reducer(undefined as any, keysUpdated(full));
+    const s1 = reducer(s0, keysUpdated({ keyDerivationSaltHash: 'kdsh2' }));
+    expect(s1.keysDoesExist).toBe(true);
+  });
+  it('keysDoesExist is false after reset', () => {
+    const s = reducer(
+      reducer(undefined as any, keysUpdated(full)),
+      keysReseted()
+    );
+    expect(s.keysDoesExist).toBe(false);
+  });
+});

--- a/src/background/redux/keys/reducer.ts
+++ b/src/background/redux/keys/reducer.ts
@@ -1,19 +1,34 @@
-import { createReducer } from 'typesafe-actions';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import { keysReseted, keysUpdated } from './actions';
 import { KeysState } from './types';
 
-type State = KeysState;
-
-const initialState: State = {
+const initialState: KeysState = {
   passwordHash: null,
   passwordSaltHash: null,
-  keyDerivationSaltHash: null
+  keyDerivationSaltHash: null,
+  keysDoesExist: false
 };
 
-export const reducer = createReducer(initialState)
-  .handleAction(keysUpdated, (state, action): State => ({
-    ...state,
-    ...action.payload
-  }))
-  .handleAction(keysReseted, () => initialState);
+const withDerivedFlag = (state: KeysState): KeysState => ({
+  ...state,
+  keysDoesExist:
+    state.passwordHash != null &&
+    state.passwordSaltHash != null &&
+    state.keyDerivationSaltHash != null
+});
+
+const slice = createSlice({
+  name: 'keys',
+  initialState,
+  reducers: {
+    keysUpdated: (
+      state,
+      // keysDoesExist is derived — callers can never set it, even type-level
+      action: PayloadAction<Partial<Omit<KeysState, 'keysDoesExist'>>>
+    ) => withDerivedFlag({ ...state, ...action.payload }),
+    keysReseted: () => initialState
+  }
+});
+
+export const { keysReseted, keysUpdated } = slice.actions;
+export const reducer = slice.reducer;

--- a/src/background/redux/keys/selectors.ts
+++ b/src/background/redux/keys/selectors.ts
@@ -1,9 +1,7 @@
 import { RootState } from 'typesafe-actions';
 
 export const selectKeysDoesExist = (state: RootState): boolean =>
-  state.keys.passwordHash != null &&
-  state.keys.passwordSaltHash != null &&
-  state.keys.keyDerivationSaltHash != null;
+  state.keys.keysDoesExist;
 
 export const selectPasswordHash = (state: RootState): string | null =>
   state.keys.passwordHash;

--- a/src/background/redux/keys/selectors.ts
+++ b/src/background/redux/keys/selectors.ts
@@ -1,4 +1,4 @@
-import { RootState } from 'typesafe-actions';
+import { RootState } from '@background/redux/store-types';
 
 export const selectKeysDoesExist = (state: RootState): boolean =>
   state.keys.keysDoesExist;

--- a/src/background/redux/keys/types.ts
+++ b/src/background/redux/keys/types.ts
@@ -2,4 +2,6 @@ export type KeysState = {
   passwordHash: string | null;
   passwordSaltHash: string | null;
   keyDerivationSaltHash: string | null;
+  /** P0.1: public existence flag — the only keys fact the popup replica receives */
+  keysDoesExist: boolean;
 };

--- a/src/background/redux/last-activity-time/actions.ts
+++ b/src/background/redux/last-activity-time/actions.ts
@@ -1,10 +1,1 @@
-import { createAction } from 'typesafe-actions';
-
-export const lastActivityTimeRefreshed = createAction(
-  'LAST_ACTIVITY_TIME_REFRESHED',
-  () => ({
-    lastActivityTime: Date.now()
-  })
-)<{
-  lastActivityTime: number;
-}>();
+export { lastActivityTimeRefreshed } from './reducer';

--- a/src/background/redux/last-activity-time/reducer.test.ts
+++ b/src/background/redux/last-activity-time/reducer.test.ts
@@ -1,0 +1,21 @@
+import { vaultUnlocked } from '../session/actions';
+import { lastActivityTimeRefreshed } from './actions';
+import { reducer } from './reducer';
+
+describe('last-activity-time reducer', () => {
+  it('has null initial state', () => {
+    expect(reducer(undefined, { type: '@@INIT' } as any)).toBeNull();
+  });
+  it('stores now() on lastActivityTimeRefreshed', () => {
+    const before = Date.now();
+    const next = reducer(null, lastActivityTimeRefreshed());
+    expect(next).toBeGreaterThanOrEqual(before);
+    expect(next).toBeLessThanOrEqual(Date.now());
+  });
+  it('stores now() on vaultUnlocked', () => {
+    const before = Date.now();
+    const next = reducer(null, vaultUnlocked());
+    expect(next).toBeGreaterThanOrEqual(before);
+    expect(next).toBeLessThanOrEqual(Date.now());
+  });
+});

--- a/src/background/redux/last-activity-time/reducer.ts
+++ b/src/background/redux/last-activity-time/reducer.ts
@@ -1,5 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+import { vaultUnlocked } from '../session/reducer';
+
 export type LastActivityTimeState = number | null;
 
 const initialState = null as LastActivityTimeState;
@@ -16,11 +18,9 @@ const slice = createSlice({
   },
   extraReducers: builder => {
     // session's vaultUnlocked also refreshes activity time.
-    // Interim: session is still typesafe-actions — match by its bare string.
-    // Task 9 (session conversion) MUST replace this with addCase(vaultUnlocked, …).
     builder.addCase(
-      'VAULT_UNLOCKED',
-      (_state, action: any) => action.payload.lastActivityTime
+      vaultUnlocked,
+      (_state, action) => action.payload.lastActivityTime
     );
   }
 });

--- a/src/background/redux/last-activity-time/reducer.ts
+++ b/src/background/redux/last-activity-time/reducer.ts
@@ -1,13 +1,29 @@
-import { createReducer } from 'typesafe-actions';
-
-import { vaultUnlocked } from '../session/actions';
-import { lastActivityTimeRefreshed } from './actions';
+import { createSlice } from '@reduxjs/toolkit';
 
 export type LastActivityTimeState = number | null;
 
 const initialState = null as LastActivityTimeState;
 
-export const reducer = createReducer(initialState).handleAction(
-  [lastActivityTimeRefreshed, vaultUnlocked],
-  (state, { payload: { lastActivityTime } }) => lastActivityTime
-);
+const slice = createSlice({
+  name: 'lastActivityTime',
+  initialState,
+  reducers: {
+    lastActivityTimeRefreshed: {
+      prepare: () => ({ payload: { lastActivityTime: Date.now() } }),
+      reducer: (_state, action: { payload: { lastActivityTime: number } }) =>
+        action.payload.lastActivityTime
+    }
+  },
+  extraReducers: builder => {
+    // session's vaultUnlocked also refreshes activity time.
+    // Interim: session is still typesafe-actions — match by its bare string.
+    // Task 9 (session conversion) MUST replace this with addCase(vaultUnlocked, …).
+    builder.addCase(
+      'VAULT_UNLOCKED',
+      (_state, action: any) => action.payload.lastActivityTime
+    );
+  }
+});
+
+export const { lastActivityTimeRefreshed } = slice.actions;
+export const reducer = slice.reducer;

--- a/src/background/redux/last-activity-time/selectors.ts
+++ b/src/background/redux/last-activity-time/selectors.ts
@@ -1,4 +1,4 @@
-import { RootState } from 'typesafe-actions';
+import { RootState } from '@background/redux/store-types';
 
 export const selectVaultLastActivityTime = (state: RootState): number | null =>
   state.lastActivityTime;

--- a/src/background/redux/ledger/actions.ts
+++ b/src/background/redux/ledger/actions.ts
@@ -1,15 +1,7 @@
-import { createAction } from 'typesafe-actions';
-
-export const ledgerNewWindowIdChanged = createAction(
-  'LEDGER_NEW_WINDOW_ID_CHANGED'
-)<number>();
-export const ledgerDeployChanged = createAction(
-  'LEDGER_DEPLOY_CHANGED'
-)<string>();
-export const ledgerTransactionChanged = createAction(
-  'LEDGER_TRANSACTION_CHANGED'
-)<string>();
-export const ledgerRecipientToSaveOnSuccessChanged = createAction(
-  'LEDGER_RECIPIENT_TO_SAVE_ON_SUCCESS_CHANGED'
-)<string>();
-export const ledgerStateCleared = createAction('LEDGER_STATE_CLEARED')<void>();
+export {
+  ledgerDeployChanged,
+  ledgerNewWindowIdChanged,
+  ledgerRecipientToSaveOnSuccessChanged,
+  ledgerStateCleared,
+  ledgerTransactionChanged
+} from './reducer';

--- a/src/background/redux/ledger/reducer.test.ts
+++ b/src/background/redux/ledger/reducer.test.ts
@@ -1,0 +1,56 @@
+import {
+  ledgerDeployChanged,
+  ledgerNewWindowIdChanged,
+  ledgerRecipientToSaveOnSuccessChanged,
+  ledgerStateCleared,
+  ledgerTransactionChanged
+} from './actions';
+import { reducer } from './reducer';
+
+describe('ledger reducer', () => {
+  const initialState = {
+    windowId: null,
+    deploy: null,
+    transaction: null,
+    recipientToSaveOnSuccess: null
+  };
+
+  it('has the expected initial state', () => {
+    expect(reducer(undefined, { type: '@@INIT' } as any)).toEqual(initialState);
+  });
+
+  it('sets windowId on ledgerNewWindowIdChanged', () => {
+    expect(reducer(initialState, ledgerNewWindowIdChanged(7))).toEqual({
+      ...initialState,
+      windowId: 7
+    });
+  });
+
+  it('sets deploy on ledgerDeployChanged', () => {
+    expect(
+      reducer(initialState, ledgerDeployChanged('deploy-payload'))
+    ).toEqual({ ...initialState, deploy: 'deploy-payload' });
+  });
+
+  it('sets transaction on ledgerTransactionChanged', () => {
+    expect(
+      reducer(initialState, ledgerTransactionChanged('tx-payload'))
+    ).toEqual({ ...initialState, transaction: 'tx-payload' });
+  });
+
+  it('sets recipientToSaveOnSuccess on ledgerRecipientToSaveOnSuccessChanged', () => {
+    expect(
+      reducer(initialState, ledgerRecipientToSaveOnSuccessChanged('01deadbeef'))
+    ).toEqual({ ...initialState, recipientToSaveOnSuccess: '01deadbeef' });
+  });
+
+  it('resets to initial state on ledgerStateCleared', () => {
+    const populated = {
+      windowId: 7,
+      deploy: 'deploy-payload',
+      transaction: 'tx-payload',
+      recipientToSaveOnSuccess: '01deadbeef'
+    };
+    expect(reducer(populated, ledgerStateCleared())).toEqual(initialState);
+  });
+});

--- a/src/background/redux/ledger/reducer.ts
+++ b/src/background/redux/ledger/reducer.ts
@@ -1,47 +1,46 @@
-import { createReducer } from 'typesafe-actions';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import {
-  ledgerDeployChanged,
-  ledgerNewWindowIdChanged,
-  ledgerRecipientToSaveOnSuccessChanged,
-  ledgerStateCleared,
-  ledgerTransactionChanged
-} from './actions';
 import { LedgerState } from './types';
 
-type State = LedgerState;
-
-const initialState: State = {
+const initialState: LedgerState = {
   windowId: null,
   deploy: null,
   transaction: null,
   recipientToSaveOnSuccess: null
 };
 
-export const reducer = createReducer(initialState)
-  .handleAction(ledgerNewWindowIdChanged, (state, { payload }): State => ({
-    ...state,
-    windowId: payload
-  }))
-  .handleAction(ledgerStateCleared, (): State => initialState)
-  .handleAction(ledgerDeployChanged, (state, { payload }): State => {
-    return {
+const slice = createSlice({
+  name: 'ledger',
+  initialState,
+  reducers: {
+    ledgerNewWindowIdChanged: (state, { payload }: PayloadAction<number>) => ({
+      ...state,
+      windowId: payload
+    }),
+    ledgerStateCleared: () => initialState,
+    ledgerDeployChanged: (state, { payload }: PayloadAction<string>) => ({
       ...state,
       deploy: payload
-    };
-  })
-  .handleAction(ledgerTransactionChanged, (state, { payload }): State => {
-    return {
+    }),
+    ledgerTransactionChanged: (state, { payload }: PayloadAction<string>) => ({
       ...state,
       transaction: payload
-    };
-  })
-  .handleAction(
-    ledgerRecipientToSaveOnSuccessChanged,
-    (state, { payload }): State => {
-      return {
-        ...state,
-        recipientToSaveOnSuccess: payload
-      };
-    }
-  );
+    }),
+    ledgerRecipientToSaveOnSuccessChanged: (
+      state,
+      { payload }: PayloadAction<string>
+    ) => ({
+      ...state,
+      recipientToSaveOnSuccess: payload
+    })
+  }
+});
+
+export const {
+  ledgerDeployChanged,
+  ledgerNewWindowIdChanged,
+  ledgerRecipientToSaveOnSuccessChanged,
+  ledgerStateCleared,
+  ledgerTransactionChanged
+} = slice.actions;
+export const reducer = slice.reducer;

--- a/src/background/redux/ledger/selectors.ts
+++ b/src/background/redux/ledger/selectors.ts
@@ -1,4 +1,4 @@
-import { RootState } from 'typesafe-actions';
+import { RootState } from '@background/redux/store-types';
 
 export const selectLedgerNewWindowId = (state: RootState): number | null =>
   state.ledger.windowId;

--- a/src/background/redux/login-retry-count/actions.ts
+++ b/src/background/redux/login-retry-count/actions.ts
@@ -1,9 +1,1 @@
-import { createAction } from 'typesafe-actions';
-
-export const loginRetryCountReseted = createAction(
-  'LOGIN_RETRY_COUNT_RESETED'
-)<void>();
-
-export const loginRetryCountIncremented = createAction(
-  'LOGIN_RETRY_COUNT_INCREMENTED'
-)<void>();
+export { loginRetryCountIncremented, loginRetryCountReseted } from './reducer';

--- a/src/background/redux/login-retry-count/reducer.test.ts
+++ b/src/background/redux/login-retry-count/reducer.test.ts
@@ -1,0 +1,14 @@
+import { loginRetryCountIncremented, loginRetryCountReseted } from './actions';
+import { reducer } from './reducer';
+
+describe('login-retry-count reducer', () => {
+  it('starts at 0', () => {
+    expect(reducer(undefined, { type: '@@INIT' } as any)).toBe(0);
+  });
+  it('increments', () => {
+    expect(reducer(2, loginRetryCountIncremented())).toBe(3);
+  });
+  it('resets to 0', () => {
+    expect(reducer(4, loginRetryCountReseted())).toBe(0);
+  });
+});

--- a/src/background/redux/login-retry-count/reducer.ts
+++ b/src/background/redux/login-retry-count/reducer.ts
@@ -1,17 +1,18 @@
-import { createReducer } from 'typesafe-actions';
-
-import { loginRetryCountIncremented, loginRetryCountReseted } from './actions';
+import { createSlice } from '@reduxjs/toolkit';
 
 export type LoginRetryCountState = number;
 
 const initialState = 0 as LoginRetryCountState;
 
-export const reducer = createReducer(initialState)
-  .handleAction(
-    loginRetryCountReseted,
-    (): LoginRetryCountState => initialState
-  )
-  .handleAction(
-    loginRetryCountIncremented,
-    (state): LoginRetryCountState => state + 1
-  );
+const slice = createSlice({
+  name: 'loginRetryCount',
+  initialState,
+  reducers: {
+    loginRetryCountReseted: () => initialState,
+    loginRetryCountIncremented: state => state + 1
+  }
+});
+
+export const { loginRetryCountIncremented, loginRetryCountReseted } =
+  slice.actions;
+export const reducer = slice.reducer;

--- a/src/background/redux/login-retry-count/selectors.ts
+++ b/src/background/redux/login-retry-count/selectors.ts
@@ -1,4 +1,4 @@
-import { RootState } from 'typesafe-actions';
+import { RootState } from '@background/redux/store-types';
 
 export const selectLoginRetryCount = (state: RootState): number =>
   state.loginRetryCount;

--- a/src/background/redux/login-retry-lockout-time/actions.ts
+++ b/src/background/redux/login-retry-lockout-time/actions.ts
@@ -1,10 +1,4 @@
-import { createAction } from 'typesafe-actions';
-
-export const loginRetryLockoutTimeReseted = createAction(
-  'LOGIN_RETRY_LOCKOUT_TIME_RESETED'
-)<void>();
-
-export const loginRetryLockoutTimeSet = createAction(
-  'LOGIN_RETRY_LOCKOUT_TIME_SET',
-  (payload: number) => payload
-)<number>();
+export {
+  loginRetryLockoutTimeReseted,
+  loginRetryLockoutTimeSet
+} from './reducer';

--- a/src/background/redux/login-retry-lockout-time/reducer.test.ts
+++ b/src/background/redux/login-retry-lockout-time/reducer.test.ts
@@ -1,0 +1,19 @@
+import {
+  loginRetryLockoutTimeReseted,
+  loginRetryLockoutTimeSet
+} from './actions';
+import { reducer } from './reducer';
+
+describe('login-retry-lockout-time reducer', () => {
+  it('has null initial state', () => {
+    expect(reducer(undefined, { type: '@@INIT' } as any)).toBeNull();
+  });
+  it('stores the lockout timestamp', () => {
+    expect(reducer(null, loginRetryLockoutTimeSet(1234567890))).toBe(
+      1234567890
+    );
+  });
+  it('resets to null', () => {
+    expect(reducer(1234567890, loginRetryLockoutTimeReseted())).toBeNull();
+  });
+});

--- a/src/background/redux/login-retry-lockout-time/reducer.ts
+++ b/src/background/redux/login-retry-lockout-time/reducer.ts
@@ -1,13 +1,19 @@
-import { createReducer } from 'typesafe-actions';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import {
-  loginRetryLockoutTimeReseted,
-  loginRetryLockoutTimeSet
-} from './actions';
 import { LoginRetryLockoutTimeState } from './types';
 
 const initialState = null as LoginRetryLockoutTimeState;
 
-export const reducer = createReducer(initialState)
-  .handleAction(loginRetryLockoutTimeReseted, () => initialState)
-  .handleAction(loginRetryLockoutTimeSet, (state, action) => action.payload);
+const slice = createSlice({
+  name: 'loginRetryLockoutTime',
+  initialState,
+  reducers: {
+    loginRetryLockoutTimeReseted: () => initialState,
+    loginRetryLockoutTimeSet: (_state, action: PayloadAction<number>) =>
+      action.payload
+  }
+});
+
+export const { loginRetryLockoutTimeReseted, loginRetryLockoutTimeSet } =
+  slice.actions;
+export const reducer = slice.reducer;

--- a/src/background/redux/login-retry-lockout-time/selectors.ts
+++ b/src/background/redux/login-retry-lockout-time/selectors.ts
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
-import { RootState } from 'typesafe-actions';
+
+import { RootState } from '@background/redux/store-types';
 
 import { LoginRetryLockoutTimeState } from './types';
 

--- a/src/background/redux/rate-app/actions.ts
+++ b/src/background/redux/rate-app/actions.ts
@@ -1,11 +1,5 @@
-import { createAction } from 'typesafe-actions';
-
-export const ratedInStoreChanged = createAction(
-  'RATED_IN_STORE_CHANGED'
-)<boolean>();
-
-export const askForReviewAfterChanged = createAction(
-  'ASK_FOR_REVIEW_AFTER_CHANGED'
-)<number>();
-
-export const resetRateApp = createAction('RESET_RATE_APP')();
+export {
+  askForReviewAfterChanged,
+  ratedInStoreChanged,
+  resetRateApp
+} from './reducer';

--- a/src/background/redux/rate-app/reducer.test.ts
+++ b/src/background/redux/rate-app/reducer.test.ts
@@ -1,0 +1,31 @@
+import {
+  askForReviewAfterChanged,
+  ratedInStoreChanged,
+  resetRateApp
+} from './actions';
+import { reducer } from './reducer';
+
+const initial = { ratedInStore: false, askForReviewAfter: null };
+
+describe('rate-app reducer', () => {
+  it('has correct initial state', () => {
+    expect(reducer(undefined, { type: '@@INIT' } as any)).toEqual(initial);
+  });
+  it('sets ratedInStore', () => {
+    expect(reducer(initial, ratedInStoreChanged(true))).toEqual({
+      ratedInStore: true,
+      askForReviewAfter: null
+    });
+  });
+  it('sets askForReviewAfter', () => {
+    expect(reducer(initial, askForReviewAfterChanged(42))).toEqual({
+      ratedInStore: false,
+      askForReviewAfter: 42
+    });
+  });
+  it('resets', () => {
+    expect(
+      reducer({ ratedInStore: true, askForReviewAfter: 1 }, resetRateApp())
+    ).toEqual(initial);
+  });
+});

--- a/src/background/redux/rate-app/reducer.ts
+++ b/src/background/redux/rate-app/reducer.ts
@@ -1,40 +1,28 @@
-import { createReducer } from 'typesafe-actions';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import {
-  askForReviewAfterChanged,
-  ratedInStoreChanged,
-  resetRateApp
-} from '@background/redux/rate-app/actions';
 import { RateAppState } from '@background/redux/rate-app/types';
 
-// Define the initial State for the Rate App
 const initialState: RateAppState = {
   ratedInStore: false,
   askForReviewAfter: null
 };
 
-/**
- * Reducer for handling changes related to Reviews
- *
- * @name reducer
- * @function
- * @returns {RateAppState} - The updated state
- */
-export const reducer = createReducer(initialState)
-  // Handling action when InStore rating changes
-  .handleAction(
-    ratedInStoreChanged,
-    (state: RateAppState, action: ReturnType<typeof ratedInStoreChanged>) => ({
+const slice = createSlice({
+  name: 'rateApp',
+  initialState,
+  reducers: {
+    ratedInStoreChanged: (state, action: PayloadAction<boolean>) => ({
       ...state,
       ratedInStore: action.payload
-    })
-  )
-  // Handles the action triggered when the time period, after which a rate app request should be made, is updated.
-  .handleAction(
-    askForReviewAfterChanged,
-    (state, action: ReturnType<typeof askForReviewAfterChanged>) => ({
+    }),
+    askForReviewAfterChanged: (state, action: PayloadAction<number>) => ({
       ...state,
       askForReviewAfter: action.payload
-    })
-  )
-  .handleAction(resetRateApp, () => initialState);
+    }),
+    resetRateApp: () => initialState
+  }
+});
+
+export const { askForReviewAfterChanged, ratedInStoreChanged, resetRateApp } =
+  slice.actions;
+export const reducer = slice.reducer;

--- a/src/background/redux/rate-app/selectors.ts
+++ b/src/background/redux/rate-app/selectors.ts
@@ -1,4 +1,4 @@
-import { RootState } from 'typesafe-actions';
+import { RootState } from '@background/redux/store-types';
 
 export const selectRatedInStore = (state: RootState) =>
   state.rateApp.ratedInStore;

--- a/src/background/redux/recent-recipient-public-keys/actions.ts
+++ b/src/background/redux/recent-recipient-public-keys/actions.ts
@@ -1,10 +1,1 @@
-import { createAction } from 'typesafe-actions';
-
-export const recipientPublicKeyAdded = createAction(
-  'RECIPIENT_PUBLIC_KEY_ADDED',
-  (payload: string) => payload
-)<string>();
-
-export const recipientPublicKeyReseted = createAction(
-  'RECIPIENT_PUBLIC_KEY_RESETED'
-)();
+export { recipientPublicKeyAdded, recipientPublicKeyReseted } from './reducer';

--- a/src/background/redux/recent-recipient-public-keys/reducer.test.ts
+++ b/src/background/redux/recent-recipient-public-keys/reducer.test.ts
@@ -1,0 +1,20 @@
+import { recipientPublicKeyAdded, recipientPublicKeyReseted } from './actions';
+import { reducer } from './reducer';
+
+describe('recent-recipient-public-keys reducer', () => {
+  it('has [] initial state', () => {
+    expect(reducer(undefined, { type: '@@INIT' } as any)).toEqual([]);
+  });
+  it('prepends new keys', () => {
+    expect(reducer(['b'], recipientPublicKeyAdded('a'))).toEqual(['a', 'b']);
+  });
+  it('moves an existing key to the front without duplicating', () => {
+    expect(reducer(['a', 'b'], recipientPublicKeyAdded('b'))).toEqual([
+      'b',
+      'a'
+    ]);
+  });
+  it('resets to []', () => {
+    expect(reducer(['a'], recipientPublicKeyReseted())).toEqual([]);
+  });
+});

--- a/src/background/redux/recent-recipient-public-keys/reducer.ts
+++ b/src/background/redux/recent-recipient-public-keys/reducer.ts
@@ -1,14 +1,20 @@
-import { createReducer } from 'typesafe-actions';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import { recipientPublicKeyAdded, recipientPublicKeyReseted } from './actions';
 import { RecentRecipientPublicKeysState } from './types';
 
 const initialState = [] as RecentRecipientPublicKeysState;
 
-export const reducer = createReducer(initialState)
-  .handleAction(recipientPublicKeyReseted, () => initialState)
-  .handleAction(
-    recipientPublicKeyAdded,
-    // This is a hack to make sure the most recent recipient is always at the top of the list.
-    (state, action) => [...new Set([action.payload, ...state])]
-  );
+const slice = createSlice({
+  name: 'recentRecipientPublicKeys',
+  initialState,
+  reducers: {
+    recipientPublicKeyReseted: () => initialState,
+    recipientPublicKeyAdded: (state, action: PayloadAction<string>) => [
+      ...new Set([action.payload, ...state])
+    ]
+  }
+});
+
+export const { recipientPublicKeyAdded, recipientPublicKeyReseted } =
+  slice.actions;
+export const reducer = slice.reducer;

--- a/src/background/redux/recent-recipient-public-keys/selectors.ts
+++ b/src/background/redux/recent-recipient-public-keys/selectors.ts
@@ -1,6 +1,5 @@
-import { RootState } from 'typesafe-actions';
-
 import { RecentRecipientPublicKeysState } from '@background/redux/recent-recipient-public-keys/types';
+import { RootState } from '@background/redux/store-types';
 
 export const selectRecentRecipientPublicKeys = (
   state: RootState

--- a/src/background/redux/redux-action.ts
+++ b/src/background/redux/redux-action.ts
@@ -1,5 +1,3 @@
-import { ActionType } from 'typesafe-actions';
-
 import * as accountInfo from './account-info/actions';
 import * as activeOriginFavicon from './active-origin-favicon/actions';
 import * as activeOrigin from './active-origin/actions';
@@ -42,7 +40,15 @@ const reduxAction = {
   trustedWasm
 };
 
-export type ReduxAction = ActionType<typeof reduxAction>;
+type Creators = typeof reduxAction;
+
+type ActionsOf<NS> = {
+  [K in keyof NS]: NS[K] extends (...args: never[]) => infer A ? A : never;
+}[keyof NS];
+
+export type ReduxAction = {
+  [NS in keyof Creators]: ActionsOf<Creators[NS]>;
+}[keyof Creators];
 
 export function isReduxAction(action?: {
   type?: unknown;

--- a/src/background/redux/sagas/actions.ts
+++ b/src/background/redux/sagas/actions.ts
@@ -1,34 +1,25 @@
 /**
  * USE CASES ACTIONS - don't update state in reducer, invoke state reducer events (imperative mode)
  */
-import { createAction } from 'typesafe-actions';
+import { createAction } from '@reduxjs/toolkit';
 
 import { UnlockVault } from '@background/redux/sagas/types';
 
 import { SecretPhrase } from '@libs/crypto';
 import { Account } from '@libs/types/account';
 
-export const startBackground = createAction('START_BACKGROUND_SAGA')<void>();
-
-export const resetVault = createAction('RESET_VAULT_SAGA')<void>();
-
-export const lockVault = createAction('LOCK_VAULT_SAGA')<void>();
-
-export const unlockVault = createAction('UNLOCK_VAULT_SAGA')<UnlockVault>();
-
-export const initKeys = createAction('INIT_KEYS_SAGA')<{
-  password: string;
-}>();
-
-export const initVault = createAction('INIT_VAULT_SAGA')<{
-  secretPhrase: SecretPhrase;
-}>();
-
-export const recoverVault = createAction('RECOVER_VAULT_SAGA')<{
+export const startBackground = createAction('START_BACKGROUND_SAGA');
+export const resetVault = createAction('RESET_VAULT_SAGA');
+export const lockVault = createAction('LOCK_VAULT_SAGA');
+export const unlockVault = createAction<UnlockVault>('UNLOCK_VAULT_SAGA');
+export const initKeys = createAction<{ password: string }>('INIT_KEYS_SAGA');
+export const initVault = createAction<{ secretPhrase: SecretPhrase }>(
+  'INIT_VAULT_SAGA'
+);
+export const recoverVault = createAction<{
   secretPhrase: SecretPhrase;
   accounts: Account[];
-}>();
-
-export const createAccount = createAction('CREATE_ACCOUNT_SAGA')<{
-  name?: string;
-}>();
+}>('RECOVER_VAULT_SAGA');
+export const createAccount = createAction<{ name?: string }>(
+  'CREATE_ACCOUNT_SAGA'
+);

--- a/src/background/redux/sagas/check-casper2-network-saga.ts
+++ b/src/background/redux/sagas/check-casper2-network-saga.ts
@@ -1,6 +1,5 @@
 import { HttpHandler, InfoGetStatusResult, RpcClient } from 'casper-js-sdk';
 import { call, put, select, takeLatest } from 'redux-saga/effects';
-import { getType } from 'typesafe-actions';
 
 import { REFERRER_URL } from '@src/constants';
 
@@ -14,7 +13,7 @@ import { unlockVault } from './actions';
 
 export function* watchCasper2NetworkSaga() {
   yield takeLatest(
-    [getType(unlockVault), activeNetworkSettingChanged.type],
+    [unlockVault.type, activeNetworkSettingChanged.type],
     checkCasper2NetworkSaga
   );
 }

--- a/src/background/redux/sagas/check-casper2-network-saga.ts
+++ b/src/background/redux/sagas/check-casper2-network-saga.ts
@@ -14,7 +14,7 @@ import { unlockVault } from './actions';
 
 export function* watchCasper2NetworkSaga() {
   yield takeLatest(
-    [getType(unlockVault), getType(activeNetworkSettingChanged)],
+    [getType(unlockVault), activeNetworkSettingChanged.type],
     checkCasper2NetworkSaga
   );
 }

--- a/src/background/redux/sagas/onboarding-sagas.ts
+++ b/src/background/redux/sagas/onboarding-sagas.ts
@@ -1,5 +1,4 @@
 import { put, takeLatest } from 'redux-saga/effects';
-import { getType } from 'typesafe-actions';
 import { storage } from 'webextension-polyfill';
 
 import { ErrorMessages } from '@src/constants';
@@ -39,10 +38,10 @@ import {
 import { initKeys, initVault, recoverVault, resetVault } from './actions';
 
 export function* onboardingSagas() {
-  yield takeLatest(getType(resetVault), resetVaultSaga);
-  yield takeLatest(getType(initKeys), initKeysSage);
-  yield takeLatest(getType(initVault), initVaultSaga);
-  yield takeLatest(getType(recoverVault), recoverVaultSaga);
+  yield takeLatest(resetVault.type, resetVaultSaga);
+  yield takeLatest(initKeys.type, initKeysSage);
+  yield takeLatest(initVault.type, initVaultSaga);
+  yield takeLatest(recoverVault.type, recoverVaultSaga);
 }
 
 /**

--- a/src/background/redux/sagas/trusted-wasm-saga.ts
+++ b/src/background/redux/sagas/trusted-wasm-saga.ts
@@ -1,13 +1,12 @@
 import { put, select, takeLatest } from 'redux-saga/effects';
-import { getType } from 'typesafe-actions';
 
 import { removeAllWasmFromTrustedOrigin } from '../trusted-wasm/actions';
 import { accountDisconnected, siteDisconnected } from '../vault/actions';
 import { selectCountOfConnectedAccountsWithActiveOrigin } from '../vault/selectors';
 
 export function* trustedWasmSaga() {
-  yield takeLatest(getType(accountDisconnected), accountDisconnectedSaga);
-  yield takeLatest(getType(siteDisconnected), siteDisconnectedSaga);
+  yield takeLatest(accountDisconnected.type, accountDisconnectedSaga);
+  yield takeLatest(siteDisconnected.type, siteDisconnectedSaga);
 }
 
 function* accountDisconnectedSaga({

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -84,7 +84,7 @@ export function* vaultSagas() {
   yield takeLatest(
     [
       getType(startBackground),
-      getType(lastActivityTimeRefreshed),
+      lastActivityTimeRefreshed.type,
       getType(activeTimeoutDurationSettingChanged)
     ],
     timeoutCounterSaga

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -77,7 +77,7 @@ import {
 export function* vaultSagas() {
   yield takeLatest(getType(lockVault), lockVaultSaga);
   yield takeLatest(
-    [loginRetryLockoutTimeSet.type, getType(popupWindowInit)],
+    [loginRetryLockoutTimeSet.type, popupWindowInit.type],
     setDelayForLockoutVaultSaga
   );
   yield takeLatest(getType(unlockVault), unlockVaultSaga);

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -77,7 +77,7 @@ import {
 export function* vaultSagas() {
   yield takeLatest(getType(lockVault), lockVaultSaga);
   yield takeLatest(
-    [getType(loginRetryLockoutTimeSet), getType(popupWindowInit)],
+    [loginRetryLockoutTimeSet.type, getType(popupWindowInit)],
     setDelayForLockoutVaultSaga
   );
   yield takeLatest(getType(unlockVault), unlockVaultSaga);

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -85,7 +85,7 @@ export function* vaultSagas() {
     [
       getType(startBackground),
       lastActivityTimeRefreshed.type,
-      getType(activeTimeoutDurationSettingChanged)
+      activeTimeoutDurationSettingChanged.type
     ],
     timeoutCounterSaga
   );
@@ -102,7 +102,7 @@ export function* vaultSagas() {
       getType(accountDisconnected),
       getType(siteDisconnected),
       getType(activeAccountChanged),
-      getType(activeTimeoutDurationSettingChanged),
+      activeTimeoutDurationSettingChanged.type,
       getType(deployPayloadReceived),
       getType(eip712PayloadReceived),
       getType(hideAccountFromListChanged)

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -91,21 +91,21 @@ export function* vaultSagas() {
   );
   yield takeLatest(
     [
-      getType(accountAdded),
-      getType(accountsAdded),
-      getType(accountImported),
-      getType(accountsImported),
-      getType(accountRemoved),
-      getType(accountRenamed),
-      getType(siteConnected),
-      getType(anotherAccountConnected),
-      getType(accountDisconnected),
-      getType(siteDisconnected),
-      getType(activeAccountChanged),
+      accountAdded.type,
+      accountsAdded.type,
+      accountImported.type,
+      accountsImported.type,
+      accountRemoved.type,
+      accountRenamed.type,
+      siteConnected.type,
+      anotherAccountConnected.type,
+      accountDisconnected.type,
+      siteDisconnected.type,
+      activeAccountChanged.type,
       activeTimeoutDurationSettingChanged.type,
-      getType(deployPayloadReceived),
-      getType(eip712PayloadReceived),
-      getType(hideAccountFromListChanged)
+      deployPayloadReceived.type,
+      eip712PayloadReceived.type,
+      hideAccountFromListChanged.type
     ],
     updateVaultCipher
   );

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -1,5 +1,4 @@
 import { put, select, takeLatest } from 'redux-saga/effects';
-import { getType } from 'typesafe-actions';
 
 import { getActiveAccountSupports, getUrlOrigin } from '@src/utils';
 
@@ -75,15 +74,15 @@ import {
 } from './actions';
 
 export function* vaultSagas() {
-  yield takeLatest(getType(lockVault), lockVaultSaga);
+  yield takeLatest(lockVault.type, lockVaultSaga);
   yield takeLatest(
     [loginRetryLockoutTimeSet.type, popupWindowInit.type],
     setDelayForLockoutVaultSaga
   );
-  yield takeLatest(getType(unlockVault), unlockVaultSaga);
+  yield takeLatest(unlockVault.type, unlockVaultSaga);
   yield takeLatest(
     [
-      getType(startBackground),
+      startBackground.type,
       lastActivityTimeRefreshed.type,
       activeTimeoutDurationSettingChanged.type
     ],
@@ -109,7 +108,7 @@ export function* vaultSagas() {
     ],
     updateVaultCipher
   );
-  yield takeLatest(getType(createAccount), createAccountSaga);
+  yield takeLatest(createAccount.type, createAccountSaga);
 }
 
 /**

--- a/src/background/redux/session/actions.ts
+++ b/src/background/redux/session/actions.ts
@@ -1,19 +1,6 @@
-import { createAction } from 'typesafe-actions';
-
-export const sessionReseted = createAction('SESSION_RESETED')<void>();
-
-export const encryptionKeyHashCreated = createAction(
-  'ENCRYPTION_KEY_HASH_CREATED'
-)<{
-  encryptionKeyHash: string;
-}>();
-
-export const vaultUnlocked = createAction('VAULT_UNLOCKED', () => ({
-  lastActivityTime: Date.now()
-}))<{
-  lastActivityTime: number;
-}>();
-
-export const contactEditingPermissionChanged = createAction(
-  'CONTACT_EDITING_PERMISSION_CHANGED'
-)();
+export {
+  contactEditingPermissionChanged,
+  encryptionKeyHashCreated,
+  sessionReseted,
+  vaultUnlocked
+} from './reducer';

--- a/src/background/redux/session/reducer.test.ts
+++ b/src/background/redux/session/reducer.test.ts
@@ -1,0 +1,58 @@
+import {
+  contactEditingPermissionChanged,
+  encryptionKeyHashCreated,
+  sessionReseted,
+  vaultUnlocked
+} from './actions';
+import { reducer } from './reducer';
+
+describe('session reducer', () => {
+  it('starts locked with no encryption key and editing disallowed', () => {
+    const s = reducer(undefined, { type: '@@INIT' } as any);
+    expect(s.encryptionKeyHash).toBeNull();
+    expect(s.isLocked).toBe(true);
+    expect(s.isContactEditingAllowed).toBe(false);
+  });
+  it('unlocks on vaultUnlocked', () => {
+    const s = reducer(undefined as any, vaultUnlocked());
+    expect(s.isLocked).toBe(false);
+  });
+  it('stores the encryption key hash on encryptionKeyHashCreated', () => {
+    const s = reducer(
+      undefined as any,
+      encryptionKeyHashCreated({ encryptionKeyHash: 'ekh' })
+    );
+    expect(s.encryptionKeyHash).toBe('ekh');
+  });
+  it('allows contact editing on contactEditingPermissionChanged', () => {
+    const s = reducer(undefined as any, contactEditingPermissionChanged());
+    expect(s.isContactEditingAllowed).toBe(true);
+  });
+  it('resets to the initial state on sessionReseted', () => {
+    const unlocked = reducer(undefined as any, vaultUnlocked());
+    const s = reducer(unlocked, sessionReseted());
+    expect(s.isLocked).toBe(true);
+    expect(s.encryptionKeyHash).toBeNull();
+    expect(s.isContactEditingAllowed).toBe(false);
+  });
+
+  it('encryptionKeyDoesExist starts false', () => {
+    const s = reducer(undefined, { type: '@@INIT' } as any);
+    expect(s.encryptionKeyDoesExist).toBe(false);
+  });
+  it('encryptionKeyDoesExist is true after encryptionKeyHashCreated', () => {
+    const s = reducer(
+      undefined as any,
+      encryptionKeyHashCreated({ encryptionKeyHash: 'ekh' })
+    );
+    expect(s.encryptionKeyDoesExist).toBe(true);
+  });
+  it('encryptionKeyDoesExist is false again after sessionReseted', () => {
+    const created = reducer(
+      undefined as any,
+      encryptionKeyHashCreated({ encryptionKeyHash: 'ekh' })
+    );
+    const s = reducer(created, sessionReseted());
+    expect(s.encryptionKeyDoesExist).toBe(false);
+  });
+});

--- a/src/background/redux/session/reducer.ts
+++ b/src/background/redux/session/reducer.ts
@@ -1,32 +1,42 @@
-import { createReducer } from 'typesafe-actions';
+import { createSlice } from '@reduxjs/toolkit';
 
-import {
-  contactEditingPermissionChanged,
-  encryptionKeyHashCreated,
-  sessionReseted,
-  vaultUnlocked
-} from './actions';
 import { SessionState } from './types';
 
-type State = SessionState;
-
-const initialState: State = {
+const initialState: SessionState = {
   encryptionKeyHash: null,
+  encryptionKeyDoesExist: false,
   isLocked: true,
   isContactEditingAllowed: false
 };
 
-export const reducer = createReducer(initialState)
-  .handleAction(sessionReseted, (): State => initialState)
-  .handleAction(vaultUnlocked, (state): State => ({
-    ...state,
-    isLocked: false
-  }))
-  .handleAction(encryptionKeyHashCreated, (state, action): State => ({
-    ...state,
-    encryptionKeyHash: action.payload.encryptionKeyHash
-  }))
-  .handleAction(contactEditingPermissionChanged, (state): State => ({
-    ...state,
-    isContactEditingAllowed: true
-  }));
+const slice = createSlice({
+  name: 'session',
+  initialState,
+  reducers: {
+    sessionReseted: () => initialState,
+    vaultUnlocked: {
+      prepare: () => ({ payload: { lastActivityTime: Date.now() } }),
+      reducer: (state: SessionState) => ({ ...state, isLocked: false })
+    },
+    encryptionKeyHashCreated: (
+      state,
+      action: { payload: { encryptionKeyHash: string } }
+    ) => ({
+      ...state,
+      encryptionKeyHash: action.payload.encryptionKeyHash,
+      encryptionKeyDoesExist: true
+    }),
+    contactEditingPermissionChanged: state => ({
+      ...state,
+      isContactEditingAllowed: true
+    })
+  }
+});
+
+export const {
+  contactEditingPermissionChanged,
+  encryptionKeyHashCreated,
+  sessionReseted,
+  vaultUnlocked
+} = slice.actions;
+export const reducer = slice.reducer;

--- a/src/background/redux/session/selectors.ts
+++ b/src/background/redux/session/selectors.ts
@@ -1,4 +1,4 @@
-import { RootState } from 'typesafe-actions';
+import { RootState } from '@background/redux/store-types';
 
 export const selectEncryptionKeyHash = (state: RootState): string | null =>
   state.session.encryptionKeyHash;

--- a/src/background/redux/session/selectors.ts
+++ b/src/background/redux/session/selectors.ts
@@ -3,6 +3,9 @@ import { RootState } from 'typesafe-actions';
 export const selectEncryptionKeyHash = (state: RootState): string | null =>
   state.session.encryptionKeyHash;
 
+export const selectEncryptionKeyDoesExist = (state: RootState): boolean =>
+  state.session.encryptionKeyDoesExist;
+
 export const selectVaultIsLocked = (state: RootState): boolean =>
   state.session.isLocked;
 

--- a/src/background/redux/session/types.ts
+++ b/src/background/redux/session/types.ts
@@ -1,5 +1,7 @@
 export interface SessionState {
   encryptionKeyHash: string | null;
+  /** P0.1: public existence flag — the only session-secret fact the popup replica receives */
+  encryptionKeyDoesExist: boolean;
   isLocked: boolean;
   isContactEditingAllowed: boolean;
 }

--- a/src/background/redux/settings/actions.ts
+++ b/src/background/redux/settings/actions.ts
@@ -1,29 +1,8 @@
-import { createAction } from 'typesafe-actions';
-
-import { NetworkSetting } from '@src/constants';
-
-import { TimeoutDurationSetting } from '@popup/constants';
-
-import { ThemeMode } from '@background/redux/settings/types';
-
-export const activeTimeoutDurationSettingChanged = createAction(
-  'ACTIVE_TIMEOUT_DURATION_SETTING_CHANGED'
-)<TimeoutDurationSetting>();
-
-export const activeNetworkSettingChanged = createAction(
-  'ACTIVE_NETWORK_SETTING_CHANGED'
-)<NetworkSetting>();
-
-export const themeModeSettingChanged = createAction(
-  'THEME_MODE_SETTING_CHANGED'
-)<ThemeMode>();
-
-export const vaultSettingsReseted = createAction('VAULT_SETTINGS_RESETED')();
-
-export const casperNetworkApiVersionChanged = createAction(
-  'CASPER2_NETWORK_CHANGED'
-)<string>();
-
-export const systemColorSchemeChanged = createAction(
-  'SYSTEM_COLOR_SCHEME_CHANGED'
-)<'dark' | 'light'>();
+export {
+  activeNetworkSettingChanged,
+  activeTimeoutDurationSettingChanged,
+  casperNetworkApiVersionChanged,
+  systemColorSchemeChanged,
+  themeModeSettingChanged,
+  vaultSettingsReseted
+} from './reducer';

--- a/src/background/redux/settings/reducer.test.ts
+++ b/src/background/redux/settings/reducer.test.ts
@@ -56,4 +56,22 @@ describe('settings reducer', () => {
     const s = reducer(changed, vaultSettingsReseted());
     expect(s).toEqual(initial);
   });
+
+  it('defaults themeMode to SYSTEM on non-Safari builds', () => {
+    expect(initial.themeMode).toBe(ThemeMode.SYSTEM);
+  });
+
+  it('defaults themeMode to LIGHT on Safari builds', () => {
+    jest.isolateModules(() => {
+      jest.doMock('@src/utils', () => ({
+        ...jest.requireActual('@src/utils'),
+        isSafariBuild: true
+      }));
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- require is required to re-import the module under the mocked build flag
+      const { reducer: safariReducer } = require('./reducer');
+      const safariInitial = safariReducer(undefined, { type: '@@INIT' } as any);
+      expect(safariInitial.themeMode).toBe(ThemeMode.LIGHT);
+    });
+    jest.dontMock('@src/utils');
+  });
 });

--- a/src/background/redux/settings/reducer.test.ts
+++ b/src/background/redux/settings/reducer.test.ts
@@ -1,0 +1,59 @@
+import { NetworkSetting } from '@src/constants';
+
+import { TimeoutDurationSetting } from '@popup/constants';
+
+import {
+  activeNetworkSettingChanged,
+  activeTimeoutDurationSettingChanged,
+  casperNetworkApiVersionChanged,
+  systemColorSchemeChanged,
+  themeModeSettingChanged,
+  vaultSettingsReseted
+} from './actions';
+import { reducer } from './reducer';
+import { ThemeMode } from './types';
+
+const initial = reducer(undefined, { type: '@@INIT' } as any);
+
+describe('settings reducer', () => {
+  it('sets the active timeout duration', () => {
+    const s = reducer(
+      undefined as any,
+      activeTimeoutDurationSettingChanged(TimeoutDurationSetting['1 hour'])
+    );
+    expect(s.activeTimeoutDuration).toBe(TimeoutDurationSetting['1 hour']);
+  });
+  it('sets the active network', () => {
+    const s = reducer(
+      undefined as any,
+      activeNetworkSettingChanged(NetworkSetting.Testnet)
+    );
+    expect(s.activeNetwork).toBe(NetworkSetting.Testnet);
+  });
+  it('sets the theme mode', () => {
+    const s = reducer(
+      undefined as any,
+      themeModeSettingChanged(ThemeMode.DARK)
+    );
+    expect(s.themeMode).toBe(ThemeMode.DARK);
+  });
+  it('sets the casper network api version', () => {
+    const s = reducer(
+      undefined as any,
+      casperNetworkApiVersionChanged('2.0.0')
+    );
+    expect(s.casperNetworkApiVersion).toBe('2.0.0');
+  });
+  it('sets the system color scheme', () => {
+    const s = reducer(undefined as any, systemColorSchemeChanged('dark'));
+    expect(s.systemColorScheme).toBe('dark');
+  });
+  it('resets to the initial state on vaultSettingsReseted', () => {
+    const changed = reducer(
+      undefined as any,
+      activeNetworkSettingChanged(NetworkSetting.Testnet)
+    );
+    const s = reducer(changed, vaultSettingsReseted());
+    expect(s).toEqual(initial);
+  });
+});

--- a/src/background/redux/settings/reducer.ts
+++ b/src/background/redux/settings/reducer.ts
@@ -1,18 +1,10 @@
-import { createReducer } from 'typesafe-actions';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import { NetworkSetting } from '@src/constants';
 import { isSafariBuild } from '@src/utils';
 
 import { TimeoutDurationSetting } from '@popup/constants';
 
-import {
-  activeNetworkSettingChanged,
-  activeTimeoutDurationSettingChanged,
-  casperNetworkApiVersionChanged,
-  systemColorSchemeChanged,
-  themeModeSettingChanged,
-  vaultSettingsReseted
-} from './actions';
 import { SettingsState, ThemeMode } from './types';
 
 const initialState: SettingsState = {
@@ -24,40 +16,40 @@ const initialState: SettingsState = {
   systemColorScheme: null
 };
 
-export const reducer = createReducer(initialState)
-  .handleAction(vaultSettingsReseted, (): SettingsState => initialState)
-  .handleAction(
-    activeTimeoutDurationSettingChanged,
-    (state, { payload }): SettingsState => ({
-      ...state,
-      activeTimeoutDuration: payload
-    })
-  )
-  .handleAction(
-    activeNetworkSettingChanged,
-    (state, { payload }): SettingsState => ({
-      ...state,
-      activeNetwork: payload
-    })
-  )
-  .handleAction(
-    themeModeSettingChanged,
-    (state, { payload }): SettingsState => ({
-      ...state,
-      themeMode: payload
-    })
-  )
-  .handleAction(
-    casperNetworkApiVersionChanged,
-    (state, action): SettingsState => ({
-      ...state,
-      casperNetworkApiVersion: action.payload
-    })
-  )
-  .handleAction(
-    systemColorSchemeChanged,
-    (state, { payload }): SettingsState => ({
-      ...state,
-      systemColorScheme: payload
-    })
-  );
+const slice = createSlice({
+  name: 'settings',
+  initialState,
+  reducers: {
+    vaultSettingsReseted: () => initialState,
+    activeTimeoutDurationSettingChanged: (
+      state,
+      { payload }: PayloadAction<TimeoutDurationSetting>
+    ) => ({ ...state, activeTimeoutDuration: payload }),
+    activeNetworkSettingChanged: (
+      state,
+      { payload }: PayloadAction<NetworkSetting>
+    ) => ({ ...state, activeNetwork: payload }),
+    themeModeSettingChanged: (
+      state,
+      { payload }: PayloadAction<ThemeMode>
+    ) => ({ ...state, themeMode: payload }),
+    casperNetworkApiVersionChanged: (
+      state,
+      { payload }: PayloadAction<string>
+    ) => ({ ...state, casperNetworkApiVersion: payload }),
+    systemColorSchemeChanged: (
+      state,
+      { payload }: PayloadAction<'dark' | 'light'>
+    ) => ({ ...state, systemColorScheme: payload })
+  }
+});
+
+export const {
+  activeNetworkSettingChanged,
+  activeTimeoutDurationSettingChanged,
+  casperNetworkApiVersionChanged,
+  systemColorSchemeChanged,
+  themeModeSettingChanged,
+  vaultSettingsReseted
+} = slice.actions;
+export const reducer = slice.reducer;

--- a/src/background/redux/settings/selectors.ts
+++ b/src/background/redux/settings/selectors.ts
@@ -1,5 +1,4 @@
 import { createSelector } from 'reselect';
-import { RootState } from 'typesafe-actions';
 
 import {
   AssociatedKeysContractHash,
@@ -11,6 +10,8 @@ import {
   NetworkName,
   NetworkSetting
 } from '@src/constants';
+
+import { RootState } from '@background/redux/store-types';
 
 export const selectTimeoutDurationSetting = (state: RootState) =>
   state.settings.activeTimeoutDuration;

--- a/src/background/redux/store-types.ts
+++ b/src/background/redux/store-types.ts
@@ -1,0 +1,6 @@
+import rootReducer from './root-reducer';
+
+export type RootState = ReturnType<typeof rootReducer>;
+export type RootStateKey = Extract<keyof RootState, string>;
+
+export type { ReduxAction as RootAction } from './redux-action';

--- a/src/background/redux/trusted-wasm/actions.ts
+++ b/src/background/redux/trusted-wasm/actions.ts
@@ -1,19 +1,6 @@
-import { createAction } from 'typesafe-actions';
-
-export const addWasmToTrusted = createAction('ADD_WASM_TO_TRUSTED')<{
-  origin: string;
-  wasmHash: string;
-}>();
-
-export const removeWasmFromTrusted = createAction('REMOVE_WASM_FROM_TRUSTED')<{
-  origin: string;
-  wasmHash: string;
-}>();
-
-export const removeAllWasmFromTrustedOrigin = createAction(
-  'REMOVE_ALL_WASM_FROM_TRUSTED_ORIGIN'
-)<{
-  origin: string;
-}>();
-
-export const resetTrustedWasmState = createAction('RESET_TRUSTED_WASM_STATE')();
+export {
+  addWasmToTrusted,
+  removeAllWasmFromTrustedOrigin,
+  removeWasmFromTrusted,
+  resetTrustedWasmState
+} from './reducer';

--- a/src/background/redux/trusted-wasm/reducer.test.ts
+++ b/src/background/redux/trusted-wasm/reducer.test.ts
@@ -1,0 +1,113 @@
+import {
+  addWasmToTrusted,
+  removeAllWasmFromTrustedOrigin,
+  removeWasmFromTrusted,
+  resetTrustedWasmState
+} from './actions';
+import { reducer } from './reducer';
+
+describe('trustedWasm reducer', () => {
+  const initialState = { hashesByOriginDict: {} };
+
+  it('has the expected initial state', () => {
+    expect(reducer(undefined, { type: '@@INIT' } as any)).toEqual(initialState);
+  });
+
+  it('adds a wasm hash for an origin', () => {
+    const state = reducer(
+      initialState,
+      addWasmToTrusted({ origin: 'https://app.example', wasmHash: 'hash1' })
+    );
+    expect(state).toEqual({
+      hashesByOriginDict: { 'https://app.example': ['hash1'] }
+    });
+  });
+
+  it('dedupes hashes added twice for the same origin', () => {
+    const withOne = reducer(
+      initialState,
+      addWasmToTrusted({ origin: 'https://app.example', wasmHash: 'hash1' })
+    );
+    const withDupe = reducer(
+      withOne,
+      addWasmToTrusted({ origin: 'https://app.example', wasmHash: 'hash1' })
+    );
+    expect(withDupe).toEqual({
+      hashesByOriginDict: { 'https://app.example': ['hash1'] }
+    });
+  });
+
+  it('keeps per-origin hash lists separate', () => {
+    const withA = reducer(
+      initialState,
+      addWasmToTrusted({ origin: 'https://a.example', wasmHash: 'hashA' })
+    );
+    const withB = reducer(
+      withA,
+      addWasmToTrusted({ origin: 'https://b.example', wasmHash: 'hashB' })
+    );
+    expect(withB).toEqual({
+      hashesByOriginDict: {
+        'https://a.example': ['hashA'],
+        'https://b.example': ['hashB']
+      }
+    });
+  });
+
+  it('removes a wasm hash from an origin via isKeysEqual (case-insensitive)', () => {
+    const seeded = {
+      hashesByOriginDict: { 'https://app.example': ['0xDEADBEEF'] }
+    };
+    const state = reducer(
+      seeded,
+      removeWasmFromTrusted({
+        origin: 'https://app.example',
+        wasmHash: '0xdeadbeef'
+      })
+    );
+    expect(state).toEqual({
+      hashesByOriginDict: { 'https://app.example': [] }
+    });
+  });
+
+  it('leaves state untouched when removing from an origin with no entry', () => {
+    const seeded = { hashesByOriginDict: {} };
+    const state = reducer(
+      seeded,
+      removeWasmFromTrusted({
+        origin: 'https://app.example',
+        wasmHash: 'hash1'
+      })
+    );
+    expect(state).toEqual(seeded);
+  });
+
+  it('removeAllWasmFromTrustedOrigin removes the origin key and other origins survive', () => {
+    const seeded = {
+      hashesByOriginDict: {
+        'https://a.example': ['hashA'],
+        'https://b.example': ['hashB']
+      }
+    };
+    const state = reducer(
+      seeded,
+      removeAllWasmFromTrustedOrigin({ origin: 'https://a.example' })
+    );
+    expect(state).toEqual({
+      hashesByOriginDict: { 'https://b.example': ['hashB'] }
+    });
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        state.hashesByOriginDict,
+        'https://a.example'
+      )
+    ).toBe(false);
+  });
+
+  it('resets to initial state on resetTrustedWasmState', () => {
+    const seeded = {
+      hashesByOriginDict: { 'https://app.example': ['hash1'] }
+    };
+    expect(reducer(seeded, resetTrustedWasmState())).toEqual(initialState);
+  });
+});

--- a/src/background/redux/trusted-wasm/reducer.test.ts
+++ b/src/background/redux/trusted-wasm/reducer.test.ts
@@ -104,6 +104,33 @@ describe('trustedWasm reducer', () => {
     ).toBe(false);
   });
 
+  it('falls back to an empty dict when state has no hashesByOriginDict (addWasmToTrusted)', () => {
+    const state = reducer(
+      {} as any,
+      addWasmToTrusted({ origin: 'https://app.example', wasmHash: 'hash1' })
+    );
+    expect(state).toEqual({
+      hashesByOriginDict: { 'https://app.example': ['hash1'] }
+    });
+  });
+
+  it('falls back to an empty dict when state has no hashesByOriginDict (removeWasmFromTrusted else-branch)', () => {
+    const state = reducer(
+      {} as any,
+      removeWasmFromTrusted({ origin: 'https://app.example', wasmHash: 'h' })
+    );
+    // else-branch returns `{ ...state }`; the ?? fallback still fires for the guard read
+    expect(state).toEqual({});
+  });
+
+  it('falls back to an empty dict when state has no hashesByOriginDict (removeAllWasmFromTrustedOrigin)', () => {
+    const state = reducer(
+      {} as any,
+      removeAllWasmFromTrustedOrigin({ origin: 'https://app.example' })
+    );
+    expect(state).toEqual({ hashesByOriginDict: {} });
+  });
+
   it('resets to initial state on resetTrustedWasmState', () => {
     const seeded = {
       hashesByOriginDict: { 'https://app.example': ['hash1'] }

--- a/src/background/redux/trusted-wasm/reducer.ts
+++ b/src/background/redux/trusted-wasm/reducer.ts
@@ -25,7 +25,7 @@ const slice = createSlice({
         hashesByOriginDict: {
           ...currentTrustedWasm,
           [origin]: [
-            ...new Set([...(currentTrustedWasm?.[origin] ?? []), wasmHash])
+            ...new Set([...(currentTrustedWasm[origin] ?? []), wasmHash])
           ]
         }
       };
@@ -38,7 +38,7 @@ const slice = createSlice({
       const currentTrustedWasm =
         state.hashesByOriginDict ?? initialState.hashesByOriginDict;
 
-      if (currentTrustedWasm?.[origin]) {
+      if (currentTrustedWasm[origin]) {
         return {
           ...state,
           hashesByOriginDict: {
@@ -57,9 +57,15 @@ const slice = createSlice({
       action: PayloadAction<{ origin: string }>
     ) => {
       const { origin } = action.payload;
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructuring omit: drops `origin`'s key while collecting the rest
-      const { [origin]: _removed, ...rest } =
-        state.hashesByOriginDict ?? initialState.hashesByOriginDict;
+      // Copy-then-delete instead of computed-key rest destructuring: the latter
+      // compiles to TS's `__rest` helper, which contains a `typeof key ===
+      // 'symbol'` branch that is unreachable for a string origin (dead branch,
+      // and ts-jest strips inline istanbul-ignore comments). Behaviour is
+      // identical: drop `origin`'s key while keeping the rest.
+      const rest = {
+        ...(state.hashesByOriginDict ?? initialState.hashesByOriginDict)
+      };
+      delete rest[origin];
 
       return { ...state, hashesByOriginDict: rest };
     }

--- a/src/background/redux/trusted-wasm/reducer.ts
+++ b/src/background/redux/trusted-wasm/reducer.ts
@@ -1,25 +1,21 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 import { isKeysEqual } from 'casper-wallet-core';
-import { createReducer } from 'typesafe-actions';
 
-import {
-  addWasmToTrusted,
-  removeAllWasmFromTrustedOrigin,
-  removeWasmFromTrusted,
-  resetTrustedWasmState
-} from './actions';
 import { TrustedWasmState } from './types';
 
-type State = TrustedWasmState;
-
-const initialState: State = {
+const initialState: TrustedWasmState = {
   hashesByOriginDict: {}
 };
 
-export const reducer = createReducer(initialState)
-  .handleAction(resetTrustedWasmState, () => initialState)
-  .handleAction(
-    addWasmToTrusted,
-    (state, action: ReturnType<typeof addWasmToTrusted>): State => {
+const slice = createSlice({
+  name: 'trustedWasm',
+  initialState,
+  reducers: {
+    resetTrustedWasmState: () => initialState,
+    addWasmToTrusted: (
+      state,
+      action: PayloadAction<{ origin: string; wasmHash: string }>
+    ) => {
       const { wasmHash, origin } = action.payload;
       const currentTrustedWasm =
         state.hashesByOriginDict ?? initialState.hashesByOriginDict;
@@ -33,11 +29,11 @@ export const reducer = createReducer(initialState)
           ]
         }
       };
-    }
-  )
-  .handleAction(
-    removeWasmFromTrusted,
-    (state, action: ReturnType<typeof removeWasmFromTrusted>): State => {
+    },
+    removeWasmFromTrusted: (
+      state,
+      action: PayloadAction<{ origin: string; wasmHash: string }>
+    ) => {
       const { wasmHash, origin } = action.payload;
       const currentTrustedWasm =
         state.hashesByOriginDict ?? initialState.hashesByOriginDict;
@@ -55,22 +51,25 @@ export const reducer = createReducer(initialState)
       } else {
         return { ...state };
       }
-    }
-  )
-  .handleAction(
-    removeAllWasmFromTrustedOrigin,
-    (
+    },
+    removeAllWasmFromTrustedOrigin: (
       state,
-      action: ReturnType<typeof removeAllWasmFromTrustedOrigin>
-    ): State => {
+      action: PayloadAction<{ origin: string }>
+    ) => {
       const { origin } = action.payload;
-      const currentTrustedWasm =
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructuring omit: drops `origin`'s key while collecting the rest
+      const { [origin]: _removed, ...rest } =
         state.hashesByOriginDict ?? initialState.hashesByOriginDict;
 
-      if (currentTrustedWasm?.[origin]) {
-        delete currentTrustedWasm[origin];
-      }
-
-      return { ...state, hashesByOriginDict: { ...currentTrustedWasm } };
+      return { ...state, hashesByOriginDict: rest };
     }
-  );
+  }
+});
+
+export const {
+  addWasmToTrusted,
+  removeAllWasmFromTrustedOrigin,
+  removeWasmFromTrusted,
+  resetTrustedWasmState
+} = slice.actions;
+export const reducer = slice.reducer;

--- a/src/background/redux/trusted-wasm/selectors.ts
+++ b/src/background/redux/trusted-wasm/selectors.ts
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
-import { RootState } from 'typesafe-actions';
+
+import { RootState } from '@background/redux/store-types';
 
 import { selectActiveOrigin } from '../active-origin/selectors';
 

--- a/src/background/redux/types.d.ts
+++ b/src/background/redux/types.d.ts
@@ -15,7 +15,6 @@ import { RecentRecipientPublicKeysState } from '@background/redux/recent-recipie
 import { SessionState } from '@background/redux/session/types';
 import { SettingsState } from '@background/redux/settings/types';
 import { TrustedWasmState } from '@background/redux/trusted-wasm/types';
-import { VaultCipherState } from '@background/redux/vault-cipher/types';
 import { VaultState } from '@background/redux/vault/types';
 import { WindowManagementState } from '@background/redux/windowManagement/types';
 
@@ -42,7 +41,6 @@ export type PopupState = {
   loginRetryCount: LoginRetryCountState;
   vault: VaultState;
   windowManagement: WindowManagementState;
-  vaultCipher: VaultCipherState;
   loginRetryLockoutTime: LoginRetryLockoutTimeState;
   lastActivityTime: LastActivityTimeState;
   settings: SettingsState;

--- a/src/background/redux/types.d.ts
+++ b/src/background/redux/types.d.ts
@@ -1,5 +1,3 @@
-import { ActionType, StateType } from 'typesafe-actions';
-
 import { AccountInfoState } from '@background/redux/account-info/types';
 import { ActiveOriginFaviconState } from '@background/redux/active-origin-favicon/types';
 import { ActiveOriginState } from '@background/redux/active-origin/types';
@@ -18,23 +16,6 @@ import { TrustedWasmState } from '@background/redux/trusted-wasm/types';
 import { VaultState } from '@background/redux/vault/types';
 import { WindowManagementState } from '@background/redux/windowManagement/types';
 
-declare module 'typesafe-actions' {
-  export type Store = StateType<typeof import('./index').default>;
-  export type RootAction = ActionType<typeof import('./redux-action').default>;
-  export type RootStateKey = Extract<
-    keyof StateType<typeof import('./root-reducer').default>,
-    string
-  >;
-  export type RootState = Pick<
-    StateType<typeof import('./root-reducer').default>,
-    RootStateKey
-  >;
-  export type Services = typeof import('@libs/services');
-
-  interface Types {
-    RootAction: RootAction;
-  }
-}
 export type PopupState = {
   keys: KeysState;
   session: SessionState;

--- a/src/background/redux/utils.ts
+++ b/src/background/redux/utils.ts
@@ -1,6 +1,7 @@
 import { call, select } from 'redux-saga/effects';
-import { RootState } from 'typesafe-actions';
 import { runtime } from 'webextension-polyfill';
+
+import { RootState } from '@background/redux/store-types';
 
 import { ReduxAction } from './redux-action';
 

--- a/src/background/redux/vault-cipher/actions.ts
+++ b/src/background/redux/vault-cipher/actions.ts
@@ -1,7 +1,1 @@
-import { createAction } from 'typesafe-actions';
-
-export const vaultCipherReseted = createAction('VAULT_CIPHER_RESETED')<void>();
-
-export const vaultCipherCreated = createAction('VAULT_CIPHER_CREATED')<{
-  vaultCipher: string;
-}>();
+export { vaultCipherCreated, vaultCipherReseted } from './reducer';

--- a/src/background/redux/vault-cipher/reducer.test.ts
+++ b/src/background/redux/vault-cipher/reducer.test.ts
@@ -1,0 +1,16 @@
+import { vaultCipherCreated, vaultCipherReseted } from './actions';
+import { reducer } from './reducer';
+
+describe('vault-cipher reducer', () => {
+  it('has null initial state', () => {
+    expect(reducer(undefined, { type: '@@INIT' } as any)).toBeNull();
+  });
+  it('stores the cipher blob', () => {
+    expect(
+      reducer(null, vaultCipherCreated({ vaultCipher: 'AAECbase64' }))
+    ).toBe('AAECbase64');
+  });
+  it('resets to null', () => {
+    expect(reducer('AAECbase64', vaultCipherReseted())).toBeNull();
+  });
+});

--- a/src/background/redux/vault-cipher/reducer.ts
+++ b/src/background/redux/vault-cipher/reducer.ts
@@ -1,13 +1,20 @@
-import { createReducer } from 'typesafe-actions';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import { vaultCipherCreated, vaultCipherReseted } from './actions';
 import { VaultCipherState } from './types';
 
 const initialState = null as VaultCipherState;
 
-export const reducer = createReducer(initialState)
-  .handleAction(vaultCipherReseted, (): VaultCipherState => initialState)
-  .handleAction(
-    vaultCipherCreated,
-    (state, action): VaultCipherState => action.payload.vaultCipher
-  );
+const slice = createSlice({
+  name: 'vaultCipher',
+  initialState,
+  reducers: {
+    vaultCipherReseted: () => initialState,
+    vaultCipherCreated: (
+      _state,
+      action: PayloadAction<{ vaultCipher: string }>
+    ) => action.payload.vaultCipher
+  }
+});
+
+export const { vaultCipherCreated, vaultCipherReseted } = slice.actions;
+export const reducer = slice.reducer;

--- a/src/background/redux/vault-cipher/selectors.ts
+++ b/src/background/redux/vault-cipher/selectors.ts
@@ -1,4 +1,4 @@
-import { RootState } from 'typesafe-actions';
+import { RootState } from '@background/redux/store-types';
 
 export const selectVaultCipherDoesExist = (state: RootState): boolean =>
   state.vaultCipher != null;

--- a/src/background/redux/vault/actions.ts
+++ b/src/background/redux/vault/actions.ts
@@ -1,85 +1,22 @@
-import { createAction } from 'typesafe-actions';
-
-import { VaultState } from '@background/redux/vault/types';
-
-import { CasperWalletSupports } from '@content/sdk-types';
-
-import { SecretPhrase } from '@libs/crypto';
-import { Account } from '@libs/types/account';
-
-export const vaultReseted = createAction('VAULT_RESETED')<void>();
-
-export const vaultLoaded = createAction('VAULT_LOADED')<VaultState>();
-
-export const secretPhraseCreated = createAction(
-  'SECRET_PHRASE_CREATED'
-)<SecretPhrase>();
-
-export const accountImported = createAction('ACCOUNT_IMPORTED')<Account>();
-
-export const accountAdded = createAction('ACCOUNT_ADDED')<Account>();
-
-export const accountsAdded = createAction('ACCOUNTS_ADDED')<Account[]>();
-
-export const accountsImported = createAction('ACCOUNTS_IMPORTED')<Account[]>();
-
-export const accountRemoved = createAction('ACCOUNT_REMOVED')<{
-  accountName: string;
-}>();
-
-export const accountRenamed = createAction('ACCOUNT_RENAMED')<{
-  oldName: string;
-  newName: string;
-}>();
-
-export const siteConnected = createAction('SITE_CONNECTED')<{
-  siteOrigin: string;
-  accountNames: string[];
-  siteTitle: string;
-}>();
-
-export const anotherAccountConnected = createAction(
-  'ANOTHER_ACCOUNT_CONNECTED'
-)<{
-  siteOrigin: string;
-  accountName: string;
-}>();
-
-export const accountDisconnected = createAction('ACCOUNT_DISCONNECTED')<{
-  accountName: string;
-  siteOrigin: string;
-}>();
-
-export const siteDisconnected = createAction('SITE_DISCONNECTED')<{
-  siteOrigin: string;
-}>();
-
-export const activeAccountChanged = createAction(
-  'ACTIVE_ACCOUNT_CHANGED'
-)<string>();
-
-export const activeAccountSupportsChanged = createAction(
-  'ACTIVE_ACCOUNT_SUPPORTS_CHANGED'
-)<CasperWalletSupports[]>();
-
-export const deploysReseted = createAction('DEPLOYS_RESETED')<void>();
-
-export const deployPayloadReceived = createAction('DEPLOY_PAYLOAD_RECEIVED')<{
-  id: string;
-  json: string;
-}>();
-
-export const eip712PayloadReceived = createAction('EIP712_PAYLOAD_RECEIVED')<{
-  id: string;
-  json: string;
-}>();
-
-export const hideAccountFromListChanged = createAction(
-  'HIDE_ACCOUNT_FROM_LIST_CHANGED'
-)<{
-  accountName: string;
-}>();
-
-export const addWatchingAccount = createAction(
-  'ADD_WATCHING_ACCOUNT'
-)<Account>();
+export {
+  accountAdded,
+  accountDisconnected,
+  accountImported,
+  accountRemoved,
+  accountRenamed,
+  accountsAdded,
+  accountsImported,
+  activeAccountChanged,
+  activeAccountSupportsChanged,
+  addWatchingAccount,
+  anotherAccountConnected,
+  deployPayloadReceived,
+  deploysReseted,
+  eip712PayloadReceived,
+  hideAccountFromListChanged,
+  secretPhraseCreated,
+  siteConnected,
+  siteDisconnected,
+  vaultLoaded,
+  vaultReseted
+} from './reducer';

--- a/src/background/redux/vault/reducer.test.ts
+++ b/src/background/redux/vault/reducer.test.ts
@@ -1,0 +1,478 @@
+import {
+  accountAdded,
+  accountDisconnected,
+  accountImported,
+  accountRemoved,
+  accountRenamed,
+  accountsAdded,
+  accountsImported,
+  activeAccountChanged,
+  activeAccountSupportsChanged,
+  addWatchingAccount,
+  anotherAccountConnected,
+  deployPayloadReceived,
+  deploysReseted,
+  eip712PayloadReceived,
+  hideAccountFromListChanged,
+  secretPhraseCreated,
+  siteConnected,
+  siteDisconnected,
+  vaultLoaded,
+  vaultReseted
+} from './actions';
+import { reducer } from './reducer';
+import { VaultState } from './types';
+
+// Compact fixture — never real key material.
+const acc = (name: string, publicKey = `01${name}`) =>
+  ({ name, publicKey, secretKey: `sk-${name}`, hidden: false }) as any;
+
+const initialState: VaultState = {
+  secretPhrase: null,
+  accounts: [],
+  accountNamesByOriginDict: {},
+  siteNameByOriginDict: {},
+  activeAccountName: null,
+  jsonById: {},
+  eip712ById: {}
+};
+
+describe('vault reducer', () => {
+  // 1
+  it('has the expected initial state (@@INIT)', () => {
+    expect(reducer(undefined, { type: '@@INIT' } as any)).toEqual(initialState);
+  });
+
+  // vaultReseted resets to initial state
+  it('resets to initial state on vaultReseted', () => {
+    const seeded: VaultState = {
+      ...initialState,
+      accounts: [acc('a')],
+      activeAccountName: 'a',
+      secretPhrase: ['w1', 'w2']
+    };
+    expect(reducer(seeded, vaultReseted())).toEqual(initialState);
+  });
+
+  // 2
+  describe('vaultLoaded', () => {
+    const payload: VaultState = {
+      secretPhrase: ['w1', 'w2'],
+      accounts: [acc('a')],
+      accountNamesByOriginDict: { o1: ['a'] },
+      siteNameByOriginDict: { o1: 'Title' },
+      activeAccountName: 'a',
+      jsonById: { pj: 'payload-json' },
+      eip712ById: { pe: 'payload-eip' }
+    };
+
+    it('replaces state and takes payload dicts when existing dicts are empty', () => {
+      expect(reducer(initialState, vaultLoaded(payload))).toEqual({
+        secretPhrase: ['w1', 'w2'],
+        accounts: [acc('a')],
+        accountNamesByOriginDict: { o1: ['a'] },
+        siteNameByOriginDict: { o1: 'Title' },
+        activeAccountName: 'a',
+        jsonById: { pj: 'payload-json' },
+        eip712ById: { pe: 'payload-eip' }
+      });
+    });
+
+    it('keeps existing non-empty jsonById / eip712ById', () => {
+      const state: VaultState = {
+        ...initialState,
+        jsonById: { existing: 'keep-json' },
+        eip712ById: { existing: 'keep-eip' }
+      };
+      expect(reducer(state, vaultLoaded(payload))).toEqual({
+        secretPhrase: ['w1', 'w2'],
+        accounts: [acc('a')],
+        accountNamesByOriginDict: { o1: ['a'] },
+        siteNameByOriginDict: { o1: 'Title' },
+        activeAccountName: 'a',
+        jsonById: { existing: 'keep-json' },
+        eip712ById: { existing: 'keep-eip' }
+      });
+    });
+  });
+
+  // 3
+  it('sets the secret phrase on secretPhraseCreated', () => {
+    const s = reducer(initialState, secretPhraseCreated(['a', 'b'] as any));
+    expect(s).toEqual({ ...initialState, secretPhrase: ['a', 'b'] });
+  });
+
+  // 4
+  it('appends and activates on accountAdded', () => {
+    const s1 = reducer(initialState, accountAdded(acc('a')));
+    expect(s1).toEqual({
+      ...initialState,
+      accounts: [acc('a')],
+      activeAccountName: 'a'
+    });
+    const s2 = reducer(s1, accountAdded(acc('b')));
+    expect(s2.accounts).toEqual([acc('a'), acc('b')]);
+    expect(s2.activeAccountName).toBe('b');
+  });
+
+  // 5
+  describe('accountImported', () => {
+    it('activates only when it is the first account', () => {
+      const s = reducer(initialState, accountImported(acc('a')));
+      expect(s).toEqual({
+        ...initialState,
+        accounts: [acc('a')],
+        activeAccountName: 'a'
+      });
+    });
+
+    it('appends without changing active when not the first', () => {
+      const state: VaultState = {
+        ...initialState,
+        accounts: [acc('a')],
+        activeAccountName: 'a'
+      };
+      const s = reducer(state, accountImported(acc('b')));
+      expect(s.accounts).toEqual([acc('a'), acc('b')]);
+      expect(s.activeAccountName).toBe('a');
+    });
+  });
+
+  // 6
+  describe('accountsAdded / accountsImported', () => {
+    it('accountsAdded activates the first only when list was empty', () => {
+      const empty = reducer(initialState, accountsAdded([acc('a'), acc('b')]));
+      expect(empty.accounts).toEqual([acc('a'), acc('b')]);
+      expect(empty.activeAccountName).toBe('a');
+
+      const state: VaultState = {
+        ...initialState,
+        accounts: [acc('x')],
+        activeAccountName: 'x'
+      };
+      const nonEmpty = reducer(state, accountsAdded([acc('a'), acc('b')]));
+      expect(nonEmpty.accounts).toEqual([acc('x'), acc('a'), acc('b')]);
+      expect(nonEmpty.activeAccountName).toBe('x');
+    });
+
+    it('accountsImported activates the first only when list was empty', () => {
+      const empty = reducer(
+        initialState,
+        accountsImported([acc('a'), acc('b')])
+      );
+      expect(empty.accounts).toEqual([acc('a'), acc('b')]);
+      expect(empty.activeAccountName).toBe('a');
+
+      const state: VaultState = {
+        ...initialState,
+        accounts: [acc('x')],
+        activeAccountName: 'x'
+      };
+      const nonEmpty = reducer(state, accountsImported([acc('a'), acc('b')]));
+      expect(nonEmpty.accounts).toEqual([acc('x'), acc('a'), acc('b')]);
+      expect(nonEmpty.activeAccountName).toBe('x');
+    });
+  });
+
+  // 7
+  describe('accountRemoved', () => {
+    it('reassigns active to first remaining, drops single-member groups, filters name from remaining groups', () => {
+      const state: VaultState = {
+        ...initialState,
+        accounts: [acc('a'), acc('b'), acc('c')],
+        activeAccountName: 'b',
+        accountNamesByOriginDict: { o1: ['b'], o2: ['a', 'b'] }
+      };
+      const s = reducer(state, accountRemoved({ accountName: 'b' }));
+      expect(s).toEqual({
+        ...initialState,
+        accounts: [acc('a'), acc('c')],
+        activeAccountName: 'a',
+        accountNamesByOriginDict: { o2: ['a'] }
+      });
+    });
+
+    it('sets active to null when removing the only account', () => {
+      const state: VaultState = {
+        ...initialState,
+        accounts: [acc('a')],
+        activeAccountName: 'a'
+      };
+      const s = reducer(state, accountRemoved({ accountName: 'a' }));
+      expect(s.accounts).toEqual([]);
+      expect(s.activeAccountName).toBeNull();
+    });
+
+    it('leaves active unchanged when removing a non-active account', () => {
+      const state: VaultState = {
+        ...initialState,
+        accounts: [acc('a'), acc('b')],
+        activeAccountName: 'a'
+      };
+      const s = reducer(state, accountRemoved({ accountName: 'b' }));
+      expect(s.accounts).toEqual([acc('a')]);
+      expect(s.activeAccountName).toBe('a');
+    });
+
+    it('defaults an undefined origin group to an empty list', () => {
+      const state: VaultState = {
+        ...initialState,
+        accounts: [acc('a'), acc('b')],
+        activeAccountName: 'a',
+        accountNamesByOriginDict: { oUndef: undefined }
+      };
+      const s = reducer(state, accountRemoved({ accountName: 'b' }));
+      expect(s.accountNamesByOriginDict).toEqual({ oUndef: [] });
+    });
+  });
+
+  // 8
+  it('renames across accounts, activeAccountName and origin groups on accountRenamed', () => {
+    const state: VaultState = {
+      ...initialState,
+      accounts: [acc('a'), acc('b')],
+      activeAccountName: 'a',
+      accountNamesByOriginDict: { o1: ['a', 'b'], o2: ['a'] }
+    };
+    const s = reducer(state, accountRenamed({ oldName: 'a', newName: 'z' }));
+    expect(s).toEqual({
+      ...initialState,
+      accounts: [{ ...acc('a'), name: 'z' }, acc('b')],
+      activeAccountName: 'z',
+      accountNamesByOriginDict: { o1: ['z', 'b'], o2: ['z'] }
+    });
+  });
+
+  it('accountRenamed keeps active when the renamed account is not active and defaults undefined groups', () => {
+    const state: VaultState = {
+      ...initialState,
+      accounts: [acc('a'), acc('b')],
+      activeAccountName: 'b',
+      accountNamesByOriginDict: { o1: ['a'], oUndef: undefined }
+    };
+    const s = reducer(state, accountRenamed({ oldName: 'a', newName: 'z' }));
+    expect(s.activeAccountName).toBe('b');
+    expect(s.accountNamesByOriginDict).toEqual({ o1: ['z'], oUndef: [] });
+  });
+
+  // 9
+  describe('siteConnected', () => {
+    it('records the site title and sets the account names for a fresh origin', () => {
+      const s = reducer(
+        initialState,
+        siteConnected({
+          siteOrigin: 'o1',
+          accountNames: ['a', 'b'],
+          siteTitle: 'Title'
+        })
+      );
+      expect(s).toEqual({
+        ...initialState,
+        siteNameByOriginDict: { o1: 'Title' },
+        accountNamesByOriginDict: { o1: ['a', 'b'] }
+      });
+    });
+
+    it('appends account names when the origin group already has members', () => {
+      const state: VaultState = {
+        ...initialState,
+        accountNamesByOriginDict: { o1: ['a'] }
+      };
+      const s = reducer(
+        state,
+        siteConnected({
+          siteOrigin: 'o1',
+          accountNames: ['b'],
+          siteTitle: 'Title'
+        })
+      );
+      expect(s.accountNamesByOriginDict).toEqual({ o1: ['a', 'b'] });
+      expect(s.siteNameByOriginDict).toEqual({ o1: 'Title' });
+    });
+  });
+
+  // 10
+  describe('anotherAccountConnected', () => {
+    it('appends a single name to an existing origin group', () => {
+      const state: VaultState = {
+        ...initialState,
+        accountNamesByOriginDict: { o1: ['a'] }
+      };
+      const s = reducer(
+        state,
+        anotherAccountConnected({ siteOrigin: 'o1', accountName: 'b' })
+      );
+      expect(s.accountNamesByOriginDict).toEqual({ o1: ['a', 'b'] });
+    });
+
+    it('creates the origin group when it did not exist', () => {
+      const s = reducer(
+        initialState,
+        anotherAccountConnected({ siteOrigin: 'o1', accountName: 'b' })
+      );
+      expect(s.accountNamesByOriginDict).toEqual({ o1: ['b'] });
+    });
+  });
+
+  // 11
+  describe('accountDisconnected', () => {
+    it('drops the group when the disconnected account was the last member', () => {
+      const state: VaultState = {
+        ...initialState,
+        accountNamesByOriginDict: { o1: ['a'], o2: ['a', 'b'] }
+      };
+      const s = reducer(
+        state,
+        accountDisconnected({ siteOrigin: 'o1', accountName: 'a' })
+      );
+      expect(s.accountNamesByOriginDict).toEqual({ o2: ['a', 'b'] });
+    });
+
+    it('removes only the name when the group has other members', () => {
+      const state: VaultState = {
+        ...initialState,
+        accountNamesByOriginDict: { o1: ['a', 'b'] }
+      };
+      const s = reducer(
+        state,
+        accountDisconnected({ siteOrigin: 'o1', accountName: 'a' })
+      );
+      expect(s.accountNamesByOriginDict).toEqual({ o1: ['b'] });
+    });
+
+    it('leaves other-origin groups untouched and defaults undefined groups', () => {
+      const state: VaultState = {
+        ...initialState,
+        accountNamesByOriginDict: { o1: ['a', 'b'], oUndef: undefined }
+      };
+      const s = reducer(
+        state,
+        accountDisconnected({ siteOrigin: 'oX', accountName: 'a' })
+      );
+      expect(s.accountNamesByOriginDict).toEqual({
+        o1: ['a', 'b'],
+        oUndef: []
+      });
+    });
+  });
+
+  // 12
+  it('drops the origin key entirely on siteDisconnected', () => {
+    const state: VaultState = {
+      ...initialState,
+      accountNamesByOriginDict: { o1: ['a'], o2: ['b'] }
+    };
+    const s = reducer(state, siteDisconnected({ siteOrigin: 'o1' }));
+    expect(s.accountNamesByOriginDict).toEqual({ o2: ['b'] });
+  });
+
+  // 13
+  it('sets the active account on activeAccountChanged', () => {
+    const s = reducer(initialState, activeAccountChanged('a'));
+    expect(s).toEqual({ ...initialState, activeAccountName: 'a' });
+  });
+
+  // 14
+  it('updates only the active account supports on activeAccountSupportsChanged', () => {
+    const state: VaultState = {
+      ...initialState,
+      accounts: [acc('a'), acc('b')],
+      activeAccountName: 'a'
+    };
+    const supports = ['SIGN_DEPLOY'] as any;
+    const s = reducer(state, activeAccountSupportsChanged(supports));
+    expect(s.accounts).toEqual([{ ...acc('a'), supports }, acc('b')]);
+  });
+
+  // 15
+  it('returns the FULL initial state on deploysReseted (wipes accounts)', () => {
+    const seeded: VaultState = {
+      secretPhrase: ['w1'],
+      accounts: [acc('a'), acc('b')],
+      accountNamesByOriginDict: { o1: ['a'] },
+      siteNameByOriginDict: { o1: 'Title' },
+      activeAccountName: 'a',
+      jsonById: { j: 'x' },
+      eip712ById: { e: 'y' }
+    };
+    expect(reducer(seeded, deploysReseted())).toEqual(initialState);
+  });
+
+  // 16
+  describe('deployPayloadReceived / eip712PayloadReceived', () => {
+    it('replaces the whole jsonById dict with a single-entry dict', () => {
+      const state: VaultState = {
+        ...initialState,
+        jsonById: { old: 'x' }
+      };
+      const s = reducer(state, deployPayloadReceived({ id: 'new', json: 'j' }));
+      expect(s.jsonById).toEqual({ new: 'j' });
+    });
+
+    it('replaces the whole eip712ById dict with a single-entry dict', () => {
+      const state: VaultState = {
+        ...initialState,
+        eip712ById: { old: 'x' }
+      };
+      const s = reducer(state, eip712PayloadReceived({ id: 'new', json: 'j' }));
+      expect(s.eip712ById).toEqual({ new: 'j' });
+    });
+  });
+
+  // 17
+  describe('hideAccountFromListChanged', () => {
+    it('toggles hidden and reassigns active when the hidden account was active', () => {
+      const state: VaultState = {
+        ...initialState,
+        accounts: [acc('a'), acc('b')],
+        activeAccountName: 'a'
+      };
+      const s = reducer(
+        state,
+        hideAccountFromListChanged({ accountName: 'a' })
+      );
+      expect(s.activeAccountName).toBe('b');
+      expect(s.accounts).toEqual([{ ...acc('a'), hidden: true }, acc('b')]);
+    });
+
+    it('sets active to null when hiding the only (active) account', () => {
+      const state: VaultState = {
+        ...initialState,
+        accounts: [acc('a')],
+        activeAccountName: 'a'
+      };
+      const s = reducer(
+        state,
+        hideAccountFromListChanged({ accountName: 'a' })
+      );
+      expect(s.activeAccountName).toBeNull();
+      expect(s.accounts).toEqual([{ ...acc('a'), hidden: true }]);
+    });
+
+    it('toggles hidden and keeps active when a non-active account is hidden', () => {
+      const state: VaultState = {
+        ...initialState,
+        accounts: [acc('a'), acc('b')],
+        activeAccountName: 'a'
+      };
+      const s = reducer(
+        state,
+        hideAccountFromListChanged({ accountName: 'b' })
+      );
+      expect(s.activeAccountName).toBe('a');
+      expect(s.accounts).toEqual([acc('a'), { ...acc('b'), hidden: true }]);
+    });
+  });
+
+  // 18
+  it('appends and activates on addWatchingAccount', () => {
+    const state: VaultState = {
+      ...initialState,
+      accounts: [acc('a')],
+      activeAccountName: 'a'
+    };
+    const s = reducer(state, addWatchingAccount(acc('w')));
+    expect(s.accounts).toEqual([acc('a'), acc('w')]);
+    expect(s.activeAccountName).toBe('w');
+  });
+});

--- a/src/background/redux/vault/reducer.ts
+++ b/src/background/redux/vault/reducer.ts
@@ -1,27 +1,10 @@
-import { createReducer } from 'typesafe-actions';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import {
-  accountAdded,
-  accountDisconnected,
-  accountImported,
-  accountRemoved,
-  accountRenamed,
-  accountsAdded,
-  accountsImported,
-  activeAccountChanged,
-  activeAccountSupportsChanged,
-  addWatchingAccount,
-  anotherAccountConnected,
-  deployPayloadReceived,
-  deploysReseted,
-  eip712PayloadReceived,
-  hideAccountFromListChanged,
-  secretPhraseCreated,
-  siteConnected,
-  siteDisconnected,
-  vaultLoaded,
-  vaultReseted
-} from './actions';
+import { CasperWalletSupports } from '@content/sdk-types';
+
+import { SecretPhrase } from '@libs/crypto';
+import { Account } from '@libs/types/account';
+
 import { VaultState } from './types';
 
 type State = VaultState;
@@ -36,11 +19,12 @@ const initialState: State = {
   eip712ById: {}
 };
 
-export const reducer = createReducer(initialState)
-  .handleAction(vaultReseted, () => initialState)
-  .handleAction(
-    vaultLoaded,
-    (
+const slice = createSlice({
+  name: 'vault',
+  initialState,
+  reducers: {
+    vaultReseted: () => initialState,
+    vaultLoaded: (
       state,
       {
         payload: {
@@ -52,7 +36,7 @@ export const reducer = createReducer(initialState)
           jsonById,
           eip712ById
         }
-      }: ReturnType<typeof vaultLoaded>
+      }: PayloadAction<VaultState>
     ) => ({
       accountNamesByOriginDict,
       siteNameByOriginDict,
@@ -65,18 +49,15 @@ export const reducer = createReducer(initialState)
         Object.keys(state.eip712ById).length === 0
           ? eip712ById
           : state.eip712ById
-    })
-  )
-  .handleAction(
-    secretPhraseCreated,
-    (state, action: ReturnType<typeof secretPhraseCreated>): State => ({
+    }),
+    secretPhraseCreated: (
+      state,
+      action: PayloadAction<SecretPhrase>
+    ): State => ({
       ...state,
       secretPhrase: action.payload
-    })
-  )
-  .handleAction(
-    accountAdded,
-    (state, action: ReturnType<typeof accountAdded>): State => {
+    }),
+    accountAdded: (state, action: PayloadAction<Account>): State => {
       const account = action.payload;
 
       return {
@@ -84,43 +65,37 @@ export const reducer = createReducer(initialState)
         accounts: [...state.accounts, account],
         activeAccountName: account.name
       };
-    }
-  )
-  .handleAction(
-    accountImported,
-    (
+    },
+    accountImported: (
       state,
-      { payload: account }: ReturnType<typeof accountImported>
+      { payload: account }: PayloadAction<Account>
     ): State => ({
       ...state,
       accounts: [...state.accounts, account],
       activeAccountName:
         state.accounts.length === 0 ? account.name : state.activeAccountName
-    })
-  )
-  .handleAction(
-    accountsAdded,
-    (state, { payload: accounts }: ReturnType<typeof accountsAdded>) => ({
-      ...state,
-      accounts: [...state.accounts, ...accounts],
-      activeAccountName:
-        state.accounts.length === 0 ? accounts[0].name : state.activeAccountName
-    })
-  )
-  .handleAction(
-    accountsImported,
-    (state, { payload: accounts }: ReturnType<typeof accountsImported>) => ({
-      ...state,
-      accounts: [...state.accounts, ...accounts],
-      activeAccountName:
-        state.accounts.length === 0 ? accounts[0].name : state.activeAccountName
-    })
-  )
-  .handleAction(
-    accountRemoved,
-    (
+    }),
+    accountsAdded: (
       state,
-      { payload: { accountName } }: ReturnType<typeof accountRemoved>
+      { payload: accounts }: PayloadAction<Account[]>
+    ) => ({
+      ...state,
+      accounts: [...state.accounts, ...accounts],
+      activeAccountName:
+        state.accounts.length === 0 ? accounts[0].name : state.activeAccountName
+    }),
+    accountsImported: (
+      state,
+      { payload: accounts }: PayloadAction<Account[]>
+    ) => ({
+      ...state,
+      accounts: [...state.accounts, ...accounts],
+      activeAccountName:
+        state.accounts.length === 0 ? accounts[0].name : state.activeAccountName
+    }),
+    accountRemoved: (
+      state,
+      { payload: { accountName } }: PayloadAction<{ accountName: string }>
     ): State => {
       const newAccounts = state.accounts.filter(
         account => account.name !== accountName
@@ -151,13 +126,12 @@ export const reducer = createReducer(initialState)
         activeAccountName: newActiveAccount,
         accountNamesByOriginDict: newAccountNamesByOriginDict
       };
-    }
-  )
-  .handleAction(
-    accountRenamed,
-    (
+    },
+    accountRenamed: (
       state,
-      { payload: { oldName, newName } }: ReturnType<typeof accountRenamed>
+      {
+        payload: { oldName, newName }
+      }: PayloadAction<{ oldName: string; newName: string }>
     ): State => {
       const newAccountNamesByOriginDict = Object.fromEntries(
         Object.keys(state.accountNamesByOriginDict).map(origin => [
@@ -185,61 +159,67 @@ export const reducer = createReducer(initialState)
             : state.activeAccountName,
         accountNamesByOriginDict: newAccountNamesByOriginDict
       };
-    }
-  )
-  .handleAction(
-    siteConnected,
-    (
+    },
+    siteConnected: (
       state,
       {
         payload: { siteOrigin, accountNames, siteTitle }
-      }: ReturnType<typeof siteConnected>
-    ) => ({
-      ...state,
-      siteNameByOriginDict: {
-        ...state?.siteNameByOriginDict,
-        [siteOrigin]: siteTitle
-      },
-      accountNamesByOriginDict: {
-        ...state.accountNamesByOriginDict,
-        [siteOrigin]:
-          (state.accountNamesByOriginDict[siteOrigin] || []).length > 0
-            ? [
-                ...(state.accountNamesByOriginDict[siteOrigin] || []),
-                ...accountNames
-              ]
-            : [...accountNames]
-      }
-    })
-  )
-  .handleAction(
-    anotherAccountConnected,
-    (
+      }: PayloadAction<{
+        siteOrigin: string;
+        accountNames: string[];
+        siteTitle: string;
+      }>
+    ) => {
+      // Behaviour-identical to the verbatim body: the original spread the same
+      // `... || []` expression twice, leaving a dead `|| []` branch inside the
+      // truthy path (and a defensive `state?.` that never short-circuits since
+      // `state` is always defined). Hoisting to a single const preserves
+      // semantics and lets the one remaining `|| []` branch be exercised.
+      // (ts-jest strips inline `istanbul ignore` comments, so annotation was
+      // not viable here.)
+      const existingNames = state.accountNamesByOriginDict[siteOrigin] || [];
+
+      return {
+        ...state,
+        siteNameByOriginDict: {
+          ...state.siteNameByOriginDict,
+          [siteOrigin]: siteTitle
+        },
+        accountNamesByOriginDict: {
+          ...state.accountNamesByOriginDict,
+          [siteOrigin]:
+            existingNames.length > 0
+              ? [...existingNames, ...accountNames]
+              : [...accountNames]
+        }
+      };
+    },
+    anotherAccountConnected: (
       state,
       {
         payload: { siteOrigin, accountName }
-      }: ReturnType<typeof anotherAccountConnected>
-    ) => ({
-      ...state,
-      accountNamesByOriginDict: {
-        ...state.accountNamesByOriginDict,
-        [siteOrigin]:
-          (state.accountNamesByOriginDict[siteOrigin] || []).length > 0
-            ? [
-                ...(state.accountNamesByOriginDict[siteOrigin] || []),
-                accountName
-              ]
-            : [accountName]
-      }
-    })
-  )
-  .handleAction(
-    accountDisconnected,
-    (
+      }: PayloadAction<{ siteOrigin: string; accountName: string }>
+    ) => {
+      // See siteConnected: hoist the duplicated `... || []` to eliminate the
+      // dead second `|| []` branch while preserving behaviour.
+      const existingNames = state.accountNamesByOriginDict[siteOrigin] || [];
+
+      return {
+        ...state,
+        accountNamesByOriginDict: {
+          ...state.accountNamesByOriginDict,
+          [siteOrigin]:
+            existingNames.length > 0
+              ? [...existingNames, accountName]
+              : [accountName]
+        }
+      };
+    },
+    accountDisconnected: (
       state,
       {
         payload: { siteOrigin, accountName }
-      }: ReturnType<typeof accountDisconnected>
+      }: PayloadAction<{ accountName: string; siteOrigin: string }>
     ) => {
       const newAccountNamesByOriginDict = Object.fromEntries(
         Object.entries(state.accountNamesByOriginDict)
@@ -264,13 +244,10 @@ export const reducer = createReducer(initialState)
         ...state,
         accountNamesByOriginDict: newAccountNamesByOriginDict
       };
-    }
-  )
-  .handleAction(
-    siteDisconnected,
-    (
+    },
+    siteDisconnected: (
       state,
-      { payload: { siteOrigin } }: ReturnType<typeof siteDisconnected>
+      { payload: { siteOrigin } }: PayloadAction<{ siteOrigin: string }>
     ) => ({
       ...state,
       accountNamesByOriginDict: Object.fromEntries(
@@ -278,18 +255,15 @@ export const reducer = createReducer(initialState)
           ([origin]) => origin !== siteOrigin
         )
       )
-    })
-  )
-  .handleAction(
-    activeAccountChanged,
-    (state, { payload }: ReturnType<typeof activeAccountChanged>) => ({
+    }),
+    activeAccountChanged: (state, { payload }: PayloadAction<string>) => ({
       ...state,
       activeAccountName: payload
-    })
-  )
-  .handleAction(
-    activeAccountSupportsChanged,
-    (state, { payload }: ReturnType<typeof activeAccountSupportsChanged>) => ({
+    }),
+    activeAccountSupportsChanged: (
+      state,
+      { payload }: PayloadAction<CasperWalletSupports[]>
+    ) => ({
       ...state,
       accounts: state.accounts.map(account => {
         if (account.name === state.activeAccountName) {
@@ -301,30 +275,25 @@ export const reducer = createReducer(initialState)
           return account;
         }
       })
-    })
-  )
-  .handleAction(deploysReseted, (): State => initialState)
-  .handleAction(
-    deployPayloadReceived,
-    (state, { payload }: ReturnType<typeof deployPayloadReceived>): State => ({
+    }),
+    deploysReseted: (): State => initialState,
+    deployPayloadReceived: (
+      state,
+      { payload }: PayloadAction<{ id: string; json: string }>
+    ): State => ({
       ...state,
       jsonById: { [payload.id]: payload.json }
-    })
-  )
-  .handleAction(
-    eip712PayloadReceived,
-    (state, { payload }: ReturnType<typeof eip712PayloadReceived>): State => ({
+    }),
+    eip712PayloadReceived: (
+      state,
+      { payload }: PayloadAction<{ id: string; json: string }>
+    ): State => ({
       ...state,
       eip712ById: { [payload.id]: payload.json }
-    })
-  )
-  .handleAction(
-    hideAccountFromListChanged,
-    (
+    }),
+    hideAccountFromListChanged: (
       state,
-      {
-        payload: { accountName }
-      }: ReturnType<typeof hideAccountFromListChanged>
+      { payload: { accountName } }: PayloadAction<{ accountName: string }>
     ) => {
       const visibleAccounts = state.accounts.filter(
         account => !account.hidden && account.name !== accountName
@@ -349,11 +318,8 @@ export const reducer = createReducer(initialState)
           return account;
         })
       };
-    }
-  )
-  .handleAction(
-    addWatchingAccount,
-    (state, action: ReturnType<typeof addWatchingAccount>): State => {
+    },
+    addWatchingAccount: (state, action: PayloadAction<Account>): State => {
       const account = action.payload;
 
       return {
@@ -362,4 +328,29 @@ export const reducer = createReducer(initialState)
         activeAccountName: account.name
       };
     }
-  );
+  }
+});
+
+export const {
+  accountAdded,
+  accountDisconnected,
+  accountImported,
+  accountRemoved,
+  accountRenamed,
+  accountsAdded,
+  accountsImported,
+  activeAccountChanged,
+  activeAccountSupportsChanged,
+  addWatchingAccount,
+  anotherAccountConnected,
+  deployPayloadReceived,
+  deploysReseted,
+  eip712PayloadReceived,
+  hideAccountFromListChanged,
+  secretPhraseCreated,
+  siteConnected,
+  siteDisconnected,
+  vaultLoaded,
+  vaultReseted
+} = slice.actions;
+export const reducer = slice.reducer;

--- a/src/background/redux/vault/selectors.ts
+++ b/src/background/redux/vault/selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
-import { RootState } from 'typesafe-actions';
 
+import { RootState } from '@background/redux/store-types';
 import { VaultState } from '@background/redux/vault/types';
 
 import { SecretPhrase } from '@libs/crypto';

--- a/src/background/redux/windowManagement/actions.ts
+++ b/src/background/redux/windowManagement/actions.ts
@@ -1,9 +1,9 @@
-import { createAction } from 'typesafe-actions';
-
-export const windowIdChanged = createAction('WINDOW_ID_CHANGED')<number>();
-export const windowIdCleared = createAction('WINDOW_ID_CLEARED')<void>();
-export const onboardingAppInit = createAction('ONBOARDING_APP_INIT')<void>();
-export const popupWindowInit = createAction('POPUP_WINDOW_INIT')<void>();
-export const connectWindowInit = createAction('CONNECT_WINDOW_INIT')<void>();
-export const importWindowInit = createAction('IMPORT_WINDOW_INIT')<void>();
-export const signWindowInit = createAction('SIGN_WINDOW_INIT')<void>();
+export {
+  connectWindowInit,
+  importWindowInit,
+  onboardingAppInit,
+  popupWindowInit,
+  signWindowInit,
+  windowIdChanged,
+  windowIdCleared
+} from './reducer';

--- a/src/background/redux/windowManagement/reducer.test.ts
+++ b/src/background/redux/windowManagement/reducer.test.ts
@@ -1,0 +1,20 @@
+import { popupWindowInit, windowIdChanged, windowIdCleared } from './actions';
+import { reducer } from './reducer';
+
+describe('windowManagement reducer', () => {
+  it('has null windowId initially', () => {
+    expect(reducer(undefined, { type: '@@INIT' } as any)).toEqual({
+      windowId: null
+    });
+  });
+  it('sets and clears windowId', () => {
+    const s = reducer({ windowId: null }, windowIdChanged(7));
+    expect(s).toEqual({ windowId: 7 });
+    expect(reducer(s, windowIdCleared())).toEqual({ windowId: null });
+  });
+  it('window-init actions do not change state', () => {
+    expect(reducer({ windowId: 7 }, popupWindowInit())).toEqual({
+      windowId: 7
+    });
+  });
+});

--- a/src/background/redux/windowManagement/reducer.test.ts
+++ b/src/background/redux/windowManagement/reducer.test.ts
@@ -1,4 +1,12 @@
-import { popupWindowInit, windowIdChanged, windowIdCleared } from './actions';
+import {
+  connectWindowInit,
+  importWindowInit,
+  onboardingAppInit,
+  popupWindowInit,
+  signWindowInit,
+  windowIdChanged,
+  windowIdCleared
+} from './actions';
 import { reducer } from './reducer';
 
 describe('windowManagement reducer', () => {
@@ -13,8 +21,11 @@ describe('windowManagement reducer', () => {
     expect(reducer(s, windowIdCleared())).toEqual({ windowId: null });
   });
   it('window-init actions do not change state', () => {
-    expect(reducer({ windowId: 7 }, popupWindowInit())).toEqual({
-      windowId: 7
-    });
+    const state = { windowId: 7 };
+    expect(reducer(state, onboardingAppInit())).toEqual({ windowId: 7 });
+    expect(reducer(state, popupWindowInit())).toEqual({ windowId: 7 });
+    expect(reducer(state, connectWindowInit())).toEqual({ windowId: 7 });
+    expect(reducer(state, importWindowInit())).toEqual({ windowId: 7 });
+    expect(reducer(state, signWindowInit())).toEqual({ windowId: 7 });
   });
 });

--- a/src/background/redux/windowManagement/reducer.ts
+++ b/src/background/redux/windowManagement/reducer.ts
@@ -1,20 +1,33 @@
-import { createReducer } from 'typesafe-actions';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import { windowIdChanged, windowIdCleared } from './actions';
 import { WindowManagementState } from './types';
 
-type State = WindowManagementState;
+const initialState: WindowManagementState = { windowId: null };
 
-const initialState: State = {
-  windowId: null
-};
+const slice = createSlice({
+  name: 'windowManagement',
+  initialState,
+  reducers: {
+    windowIdChanged: (state, action: PayloadAction<number>) => ({
+      ...state,
+      windowId: action.payload
+    }),
+    windowIdCleared: state => ({ ...state, windowId: null }),
+    onboardingAppInit: state => state,
+    popupWindowInit: state => state,
+    connectWindowInit: state => state,
+    importWindowInit: state => state,
+    signWindowInit: state => state
+  }
+});
 
-export const reducer = createReducer(initialState)
-  .handleAction(windowIdChanged, (state, { payload }): State => ({
-    ...state,
-    windowId: payload
-  }))
-  .handleAction(windowIdCleared, (state): State => ({
-    ...state,
-    windowId: null
-  }));
+export const {
+  connectWindowInit,
+  importWindowInit,
+  onboardingAppInit,
+  popupWindowInit,
+  signWindowInit,
+  windowIdChanged,
+  windowIdCleared
+} = slice.actions;
+export const reducer = slice.reducer;

--- a/src/background/redux/windowManagement/selectors.ts
+++ b/src/background/redux/windowManagement/selectors.ts
@@ -1,4 +1,4 @@
-import { RootState } from 'typesafe-actions';
+import { RootState } from '@background/redux/store-types';
 
 export const selectWindowId = (state: RootState): number | null =>
   state.windowManagement.windowId;

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,4 +1,3 @@
-import { getType } from 'typesafe-actions';
 import { runtime } from 'webextension-polyfill';
 
 import { initBringScript } from '@content/bring';
@@ -11,21 +10,21 @@ async function handleSdkMessage(message: unknown) {
   // delayed sdk request response
   if (isSDKMethod(message)) {
     switch (message.type) {
-      case getType(sdkMethod.connectResponse):
-      case getType(sdkMethod.connectError):
-      case getType(sdkMethod.switchAccountResponse):
-      case getType(sdkMethod.switchAccountError):
-      case getType(sdkMethod.signError):
-      case getType(sdkMethod.signResponse):
-      case getType(sdkMethod.signMessageError):
-      case getType(sdkMethod.signMessageResponse):
-      case getType(sdkMethod.signTypedDataResponse):
-      case getType(sdkMethod.signTypedDataError):
-      case getType(sdkMethod.decryptMessageResponse):
-      case getType(sdkMethod.decryptMessageError):
-      case getType(sdkMethod.encryptMessageResponse):
-      case getType(sdkMethod.encryptMessageError):
-      case getType(sdkMethod.getActivePublicKeySupportsResponse):
+      case sdkMethod.connectResponse.type:
+      case sdkMethod.connectError.type:
+      case sdkMethod.switchAccountResponse.type:
+      case sdkMethod.switchAccountError.type:
+      case sdkMethod.signError.type:
+      case sdkMethod.signResponse.type:
+      case sdkMethod.signMessageError.type:
+      case sdkMethod.signMessageResponse.type:
+      case sdkMethod.signTypedDataResponse.type:
+      case sdkMethod.signTypedDataError.type:
+      case sdkMethod.decryptMessageResponse.type:
+      case sdkMethod.decryptMessageError.type:
+      case sdkMethod.encryptMessageResponse.type:
+      case sdkMethod.encryptMessageError.type:
+      case sdkMethod.getActivePublicKeySupportsResponse.type:
         window.dispatchEvent(
           new CustomEvent(SdkMethodEventType.Response, {
             detail: JSON.stringify(message)
@@ -48,31 +47,31 @@ async function handleSdkMessage(message: unknown) {
 function emitSdkEvent(message: SdkEvent) {
   let eventType: string;
   switch (message.type) {
-    case getType(sdkEvent.connectedAccountEvent):
+    case sdkEvent.connectedAccountEvent.type:
       eventType = CasperWalletEventType.Connected;
       break;
 
-    case getType(sdkEvent.disconnectedAccountEvent):
+    case sdkEvent.disconnectedAccountEvent.type:
       eventType = CasperWalletEventType.Disconnected;
       break;
 
-    case getType(sdkEvent.changedConnectedAccountEvent):
+    case sdkEvent.changedConnectedAccountEvent.type:
       eventType = CasperWalletEventType.ActiveKeyChanged;
       break;
 
-    case getType(sdkEvent.changedTab):
+    case sdkEvent.changedTab.type:
       eventType = CasperWalletEventType.TabChanged;
       break;
 
-    case getType(sdkEvent.lockedEvent):
+    case sdkEvent.lockedEvent.type:
       eventType = CasperWalletEventType.Locked;
       break;
 
-    case getType(sdkEvent.unlockedEvent):
+    case sdkEvent.unlockedEvent.type:
       eventType = CasperWalletEventType.Unlocked;
       break;
 
-    case getType(sdkEvent.changedActiveAccountSupportsEvent):
+    case sdkEvent.changedActiveAccountSupportsEvent.type:
       eventType = CasperWalletEventType.ActiveKeySupportsChanged;
       break;
 

--- a/src/content/sdk-event.ts
+++ b/src/content/sdk-event.ts
@@ -1,25 +1,25 @@
-import { ActionType, createAction } from 'typesafe-actions';
+import { createAction } from '@reduxjs/toolkit';
 
 import { CasperWalletState } from './sdk-types';
 
 // Event emitted to connected sites
 
 export const sdkEvent = {
-  connectedAccountEvent: createAction(
+  connectedAccountEvent: createAction<CasperWalletState>(
     'connectedAccountEvent'
-  )<CasperWalletState>(),
-  disconnectedAccountEvent: createAction(
+  ),
+  disconnectedAccountEvent: createAction<CasperWalletState>(
     'disconnectedAccountEvent'
-  )<CasperWalletState>(),
-  changedTab: createAction('changedTabEvent')<CasperWalletState>(),
-  changedConnectedAccountEvent: createAction(
+  ),
+  changedTab: createAction<CasperWalletState>('changedTabEvent'),
+  changedConnectedAccountEvent: createAction<CasperWalletState>(
     'changedConnectedAccountEvent'
-  )<CasperWalletState>(),
-  lockedEvent: createAction('lockedEvent')<CasperWalletState>(),
-  unlockedEvent: createAction('unlockedEvent')<CasperWalletState>(),
-  changedActiveAccountSupportsEvent: createAction(
+  ),
+  lockedEvent: createAction<CasperWalletState>('lockedEvent'),
+  unlockedEvent: createAction<CasperWalletState>('unlockedEvent'),
+  changedActiveAccountSupportsEvent: createAction<CasperWalletState>(
     'changedActiveAccountSupportsEvent'
-  )<CasperWalletState>()
+  )
 };
 
-export type SdkEvent = ActionType<typeof sdkEvent>;
+export type SdkEvent = ReturnType<(typeof sdkEvent)[keyof typeof sdkEvent]>;

--- a/src/content/sdk-method.ts
+++ b/src/content/sdk-method.ts
@@ -1,4 +1,4 @@
-import { ActionType, createAction, createCustomAction } from 'typesafe-actions';
+import { createAction } from '@reduxjs/toolkit';
 
 import { SdkError } from './sdk-errors';
 import type { SignTypedDataParams, SignTypedDataResult } from './sdk-types';
@@ -10,157 +10,121 @@ export const SdkMethodEventType = {
 
 type Meta = { requestId: string };
 
+/** FSA-compatible (payload, meta) creator with exact type string */
+const createSdkAction = <P, T extends string = string>(type: T) =>
+  createAction(type, (payload: P, meta: Meta) => ({ payload, meta }));
+
+/** FSA error envelope: {payload, meta, error: true} — wire shape must not change */
+const createSdkErrorAction = <T extends string>(type: T) =>
+  createAction(type, (payload: SdkError | Error, meta: Meta) => ({
+    payload,
+    meta,
+    error: true as const
+  }));
+
 export const sdkMethod = {
-  connectRequest: createAction('CasperWalletProvider:Connect')<
-    { title: string },
-    Meta
-  >(),
-  connectResponse: createAction('CasperWalletProvider:Connect:Response')<
-    boolean,
-    Meta
-  >(),
-  connectError: createAction('CasperWalletProvider:Connect:Error')<
-    Error,
-    Meta
-  >(),
-  switchAccountRequest: createAction('CasperWalletProvider:SwitchAccount')<
-    { title: string },
-    Meta
-  >(),
-  switchAccountResponse: createAction(
+  connectRequest: createSdkAction<{ title: string }>(
+    'CasperWalletProvider:Connect'
+  ),
+  connectResponse: createSdkAction<boolean>(
+    'CasperWalletProvider:Connect:Response'
+  ),
+  connectError: createSdkAction<Error>('CasperWalletProvider:Connect:Error'),
+  switchAccountRequest: createSdkAction<{ title: string }>(
+    'CasperWalletProvider:SwitchAccount'
+  ),
+  switchAccountResponse: createSdkAction<boolean>(
     'CasperWalletProvider:SwitchAccount:Response'
-  )<boolean, Meta>(),
-  switchAccountError: createAction('CasperWalletProvider:SwitchAccount:Error')<
-    Error,
-    Meta
-  >(),
-  signRequest: createAction('CasperWalletProvider:Sign')<
-    {
-      deployJson: string;
-      signingPublicKeyHex: string;
-    },
-    Meta
-  >(),
-  signResponse: createAction('CasperWalletProvider:Sign:Response')<
+  ),
+  switchAccountError: createSdkAction<Error>(
+    'CasperWalletProvider:SwitchAccount:Error'
+  ),
+  signRequest: createSdkAction<{
+    deployJson: string;
+    signingPublicKeyHex: string;
+  }>('CasperWalletProvider:Sign'),
+  signResponse: createSdkAction<
     | { cancelled: true; message?: string }
-    | { cancelled: false; signatureHex: string },
-    Meta
-  >(),
-  signError: createAction('CasperWalletProvider:Sign:Error')<Error, Meta>(),
-  signMessageRequest: createAction('CasperWalletProvider:SignMessage')<
-    {
-      message: string;
-      signingPublicKeyHex: string;
-    },
-    Meta
-  >(),
-  signMessageResponse: createAction(
-    'CasperWalletProvider:SignMessage:Response'
-  )<{ cancelled: true } | { cancelled: false; signatureHex: string }, Meta>(),
-  signMessageError: createAction('CasperWalletProvider:SignMessage:Error')<
-    Error,
-    Meta
-  >(),
-  signTypedDataRequest: createAction('CasperWalletProvider:SignTypedData')<
-    {
-      typedData: SignTypedDataParams['typedData'];
-      options?: SignTypedDataParams['options'];
-      signingPublicKeyHex: string;
-    },
-    Meta
-  >(),
-  signTypedDataResponse: createAction(
+    | { cancelled: false; signatureHex: string }
+  >('CasperWalletProvider:Sign:Response'),
+  signError: createSdkAction<Error>('CasperWalletProvider:Sign:Error'),
+  signMessageRequest: createSdkAction<{
+    message: string;
+    signingPublicKeyHex: string;
+  }>('CasperWalletProvider:SignMessage'),
+  signMessageResponse: createSdkAction<
+    { cancelled: true } | { cancelled: false; signatureHex: string }
+  >('CasperWalletProvider:SignMessage:Response'),
+  signMessageError: createSdkAction<Error>(
+    'CasperWalletProvider:SignMessage:Error'
+  ),
+  signTypedDataRequest: createSdkAction<{
+    typedData: SignTypedDataParams['typedData'];
+    options?: SignTypedDataParams['options'];
+    signingPublicKeyHex: string;
+  }>('CasperWalletProvider:SignTypedData'),
+  signTypedDataResponse: createSdkAction<SignTypedDataResult>(
     'CasperWalletProvider:SignTypedData:Response'
-  )<SignTypedDataResult, Meta>(),
-  signTypedDataError: createAction('CasperWalletProvider:SignTypedData:Error')<
-    Error,
-    Meta
-  >(),
-  encryptMessageRequest: createAction('CasperWalletProvider:EncryptMessage')<
-    {
-      message: string;
-      signingPublicKeyHex: string;
-    },
-    Meta
-  >(),
-  encryptMessageResponse: createAction(
+  ),
+  signTypedDataError: createSdkAction<Error>(
+    'CasperWalletProvider:SignTypedData:Error'
+  ),
+  encryptMessageRequest: createSdkAction<{
+    message: string;
+    signingPublicKeyHex: string;
+  }>('CasperWalletProvider:EncryptMessage'),
+  encryptMessageResponse: createSdkAction<{ encryptedMessage: string }>(
     'CasperWalletProvider:EncryptMessage:Response'
-  )<
-    {
-      encryptedMessage: string;
-    },
-    Meta
-  >(),
-  encryptMessageError: createCustomAction(
-    'CasperWalletProvider:EncryptMessage:Error',
-    (payload: SdkError, meta: Meta) => ({ payload, meta, error: true })
   ),
-  decryptMessageRequest: createAction('CasperWalletProvider:DecryptMessage')<
-    {
-      message: string;
-      signingPublicKeyHex: string;
-    },
-    Meta
-  >(),
-  decryptMessageResponse: createAction(
-    'CasperWalletProvider:DecryptMessage:Response'
-  )<
-    { cancelled: true } | { cancelled: false; decryptedMessage: string },
-    Meta
-  >(),
-  decryptMessageError: createAction(
+  encryptMessageError: createSdkErrorAction(
+    'CasperWalletProvider:EncryptMessage:Error'
+  ),
+  decryptMessageRequest: createSdkAction<{
+    message: string;
+    signingPublicKeyHex: string;
+  }>('CasperWalletProvider:DecryptMessage'),
+  decryptMessageResponse: createSdkAction<
+    { cancelled: true } | { cancelled: false; decryptedMessage: string }
+  >('CasperWalletProvider:DecryptMessage:Response'),
+  decryptMessageError: createSdkAction<Error>(
     'CasperWalletProvider:DecryptMessage:Error'
-  )<Error, Meta>(),
-  disconnectRequest: createAction('CasperWalletProvider:Disconnect')<
-    void,
-    Meta
-  >(),
-  disconnectResponse: createAction('CasperWalletProvider:Disconnect:Response')<
-    boolean,
-    Meta
-  >(),
-  isConnectedRequest: createAction('CasperWalletProvider:IsConnected')<
-    void,
-    Meta
-  >(),
-  isConnectedResponse: createAction(
+  ),
+  disconnectRequest: createSdkAction<void>('CasperWalletProvider:Disconnect'),
+  disconnectResponse: createSdkAction<boolean>(
+    'CasperWalletProvider:Disconnect:Response'
+  ),
+  isConnectedRequest: createSdkAction<void>('CasperWalletProvider:IsConnected'),
+  isConnectedResponse: createSdkAction<boolean>(
     'CasperWalletProvider:IsConnected:Response'
-  )<boolean, Meta>(),
-  isConnectedError: createCustomAction(
-    'CasperWalletProvider:IsConnected:Error',
-    (payload: SdkError, meta: Meta) => ({ payload, meta, error: true })
   ),
-  getActivePublicKeyRequest: createAction(
+  isConnectedError: createSdkErrorAction(
+    'CasperWalletProvider:IsConnected:Error'
+  ),
+  getActivePublicKeyRequest: createSdkAction<void>(
     'CasperWalletProvider:GetActivePublicKey'
-  )<void, Meta>(),
-  getActivePublicKeyResponse: createAction(
-    'CasperWalletProvider:GetActivePublicKey:Response'
-  )<string, Meta>(),
-  getActivePublicKeyError: createCustomAction(
-    'CasperWalletProvider:GetActivePublicKey:Error',
-    (payload: SdkError, meta: Meta) => ({ payload, meta, error: true })
   ),
-  getVersionRequest: createAction('CasperWalletProvider:GetVersion')<
-    void,
-    Meta
-  >(),
-  getVersionResponse: createAction('CasperWalletProvider:GetVersion:Response')<
-    string,
-    Meta
-  >(),
-  getActivePublicKeySupportsRequest: createAction(
+  getActivePublicKeyResponse: createSdkAction<string>(
+    'CasperWalletProvider:GetActivePublicKey:Response'
+  ),
+  getActivePublicKeyError: createSdkErrorAction(
+    'CasperWalletProvider:GetActivePublicKey:Error'
+  ),
+  getVersionRequest: createSdkAction<void>('CasperWalletProvider:GetVersion'),
+  getVersionResponse: createSdkAction<string>(
+    'CasperWalletProvider:GetVersion:Response'
+  ),
+  getActivePublicKeySupportsRequest: createSdkAction<void>(
     'CasperWalletProvider:GetActivePublicKeySupports'
-  )<void, Meta>(),
-  getActivePublicKeySupportsResponse: createAction(
+  ),
+  getActivePublicKeySupportsResponse: createSdkAction<string[]>(
     'CasperWalletProvider:GetActivePublicKeySupports:Response'
-  )<string[], Meta>(),
-  getActivePublicKeySupportsError: createCustomAction(
-    'CasperWalletProvider:GetActivePublicKeySupports:Error',
-    (payload: SdkError, meta: Meta) => ({ payload, meta, error: true })
+  ),
+  getActivePublicKeySupportsError: createSdkErrorAction(
+    'CasperWalletProvider:GetActivePublicKeySupports:Error'
   )
 };
 
-export type SdkMethod = ActionType<typeof sdkMethod>;
+export type SdkMethod = ReturnType<(typeof sdkMethod)[keyof typeof sdkMethod]>;
 
 export function isSDKMethod(action?: unknown): action is SdkMethod {
   const candidate = action as { type?: unknown; meta?: Meta } | undefined;

--- a/src/fixtures/initial-state-for-popup-tests.ts
+++ b/src/fixtures/initial-state-for-popup-tests.ts
@@ -13,12 +13,14 @@ export const initialStateForPopupTests: RootState = {
     passwordSaltHash:
       '088da9fc6cc474e408acfc9a2d4a2f83776332d53008b1c3ee0b9f52f10c8201',
     keyDerivationSaltHash:
-      '5a92932f02799e90c2e6b994b6b8b23220dd3022570c43837f318e1d0379f1e2'
+      '5a92932f02799e90c2e6b994b6b8b23220dd3022570c43837f318e1d0379f1e2',
+    keysDoesExist: true
   },
   loginRetryCount: 0,
   session: {
     encryptionKeyHash:
       '7b55663cb7cd7d96765373ce0ee8d6901244de1ed241d20f9afe18a81149ea71',
+    encryptionKeyDoesExist: true,
     isLocked: true,
     isContactEditingAllowed: false
   },

--- a/src/fixtures/initial-state-for-popup-tests.ts
+++ b/src/fixtures/initial-state-for-popup-tests.ts
@@ -1,10 +1,9 @@
-import { RootState } from 'typesafe-actions';
-
 import { NetworkSetting } from '@src/constants';
 
 import { TimeoutDurationSetting } from '@popup/constants';
 
 import { ThemeMode } from '@background/redux/settings/types';
+import { RootState } from '@background/redux/store-types';
 
 export const initialStateForPopupTests: RootState = {
   keys: {

--- a/src/hooks/use-private-state.test.ts
+++ b/src/hooks/use-private-state.test.ts
@@ -1,0 +1,97 @@
+import { fetchPrivateState } from '@background/handlers/private-state';
+
+import {
+  PRIVATE_STATE_RETRY_DELAYS_MS,
+  loadPrivateStateWithRetry
+} from './use-private-state';
+
+jest.mock('@background/handlers/private-state', () => ({
+  fetchPrivateState: jest.fn()
+}));
+
+const fetchMock = fetchPrivateState as jest.MockedFunction<
+  typeof fetchPrivateState
+>;
+
+const privateState = {
+  passwordHash: 'password-hash',
+  passwordSaltHash: 'password-salt-hash',
+  keyDerivationSaltHash: 'key-derivation-salt-hash',
+  vaultCipher: 'vault-cipher'
+};
+
+describe('loadPrivateStateWithRetry', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('resolves with the fetched state on first success and leaves no pending timers', async () => {
+    fetchMock.mockResolvedValue(privateState);
+
+    await expect(loadPrivateStateWithRetry()).resolves.toEqual(privateState);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('recovers when the first attempt rejects and a retry succeeds (SW-restart race)', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('Could not establish connection'))
+      .mockResolvedValueOnce(privateState);
+
+    const result = loadPrivateStateWithRetry();
+    await jest.runAllTimersAsync();
+
+    await expect(result).resolves.toEqual(privateState);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('waits the backoff delay before re-attempting', async () => {
+    fetchMock.mockRejectedValue(new Error('Could not establish connection'));
+
+    const result = loadPrivateStateWithRetry();
+    result.catch(() => undefined);
+
+    await jest.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(PRIVATE_STATE_RETRY_DELAYS_MS[0] - 1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    await jest.runAllTimersAsync();
+  });
+
+  it('rejects with the last error after all attempts reject', async () => {
+    fetchMock.mockRejectedValue(new Error('Could not establish connection'));
+
+    const result = loadPrivateStateWithRetry();
+    result.catch(() => undefined);
+    await jest.runAllTimersAsync();
+
+    await expect(result).rejects.toThrow('Could not establish connection');
+    expect(fetchMock).toHaveBeenCalledTimes(
+      1 + PRIVATE_STATE_RETRY_DELAYS_MS.length
+    );
+  });
+
+  it('times out an attempt whose promise never settles (untrusted-sender no-response path)', async () => {
+    fetchMock.mockImplementation(() => new Promise(() => undefined));
+
+    const result = loadPrivateStateWithRetry();
+    result.catch(() => undefined);
+    await jest.runAllTimersAsync();
+
+    await expect(result).rejects.toThrow('timed out');
+    expect(fetchMock).toHaveBeenCalledTimes(
+      1 + PRIVATE_STATE_RETRY_DELAYS_MS.length
+    );
+  });
+});

--- a/src/hooks/use-private-state.ts
+++ b/src/hooks/use-private-state.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+import {
+  PrivateState,
+  fetchPrivateState
+} from '@background/handlers/private-state';
+
+export function usePrivateState(): PrivateState | null {
+  const [privateState, setPrivateState] = useState<PrivateState | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    fetchPrivateState()
+      .then(ps => {
+        if (mounted) {
+          setPrivateState(ps);
+        }
+      })
+      .catch(error => console.error('fetch private state:', error));
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return privateState;
+}

--- a/src/hooks/use-private-state.ts
+++ b/src/hooks/use-private-state.ts
@@ -1,26 +1,92 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import {
   PrivateState,
   fetchPrivateState
 } from '@background/handlers/private-state';
 
-export function usePrivateState(): PrivateState | null {
+export const PRIVATE_STATE_FETCH_TIMEOUT_MS = 5000;
+/** Targets the MV3 SW-restart race: a rejected sendMessage usually succeeds on re-send */
+export const PRIVATE_STATE_RETRY_DELAYS_MS = [250, 500];
+
+interface UsePrivateStateResult {
+  privateState: PrivateState | null;
+  error: boolean;
+  retry: () => void;
+}
+
+function fetchWithTimeout(): Promise<PrivateState> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error('Private state request timed out')),
+      PRIVATE_STATE_FETCH_TIMEOUT_MS
+    );
+
+    fetchPrivateState().then(
+      state => {
+        clearTimeout(timer);
+        resolve(state);
+      },
+      error => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+}
+
+export async function loadPrivateStateWithRetry(): Promise<PrivateState> {
+  let lastError: unknown;
+
+  for (
+    let attempt = 0;
+    attempt <= PRIVATE_STATE_RETRY_DELAYS_MS.length;
+    attempt++
+  ) {
+    if (attempt > 0) {
+      await new Promise(resolve =>
+        setTimeout(resolve, PRIVATE_STATE_RETRY_DELAYS_MS[attempt - 1])
+      );
+    }
+
+    try {
+      return await fetchWithTimeout();
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError;
+}
+
+export function usePrivateState(): UsePrivateStateResult {
   const [privateState, setPrivateState] = useState<PrivateState | null>(null);
+  const [error, setError] = useState(false);
+  const [fetchAttemptId, setFetchAttemptId] = useState(0);
 
   useEffect(() => {
     let mounted = true;
-    fetchPrivateState()
-      .then(ps => {
+    setError(false);
+
+    loadPrivateStateWithRetry()
+      .then(state => {
         if (mounted) {
-          setPrivateState(ps);
+          setPrivateState(state);
         }
       })
-      .catch(error => console.error('fetch private state:', error));
+      .catch(error => {
+        console.error('fetch private state:', error);
+        if (mounted) {
+          setError(true);
+        }
+      });
+
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [fetchAttemptId]);
 
-  return privateState;
+  const retry = useCallback(() => setFetchAttemptId(id => id + 1), []);
+
+  return { privateState, error, retry };
 }

--- a/src/hooks/use-subscribe-to-redux.ts
+++ b/src/hooks/use-subscribe-to-redux.ts
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect } from 'react';
-import { isActionOf } from 'typesafe-actions';
 import { runtime } from 'webextension-polyfill';
 
 import {
@@ -21,7 +20,7 @@ export const useSubscribeToRedux = ({
   const handleStateUpdate = useCallback(
     (message: unknown) => {
       const event = message as BackgroundEvent;
-      if (isActionOf(backgroundEvent.popupStateUpdated)(event)) {
+      if (backgroundEvent.popupStateUpdated.match(event)) {
         setPopupState(event.payload);
       }
     },

--- a/src/hooks/use-subscribe-to-redux.ts
+++ b/src/hooks/use-subscribe-to-redux.ts
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { getType, isActionOf } from 'typesafe-actions';
+import { isActionOf } from 'typesafe-actions';
 import { runtime } from 'webextension-polyfill';
 
 import {
@@ -34,7 +34,7 @@ export const useSubscribeToRedux = ({
     }
 
     runtime.sendMessage((windowInitAction as any)()).catch(() => {
-      console.error('window init: ' + getType(windowInitAction));
+      console.error('window init: ' + String(windowInitAction));
     });
 
     return () => {

--- a/src/libs/layout/error/index.ts
+++ b/src/libs/layout/error/index.ts
@@ -19,6 +19,7 @@ export function createErrorLocationState({
 }
 
 export * from './error-boundary';
+export * from './private-state-error-page';
 export * from './tab-page';
 export * from './types';
 export * from './window-page';

--- a/src/libs/layout/error/private-state-error-page.tsx
+++ b/src/libs/layout/error/private-state-error-page.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import {
+  FooterButtonsContainer,
+  HeaderPopup,
+  LayoutTab,
+  LayoutWindow,
+  PopupLayout
+} from '@libs/layout';
+import { Button } from '@libs/ui/components';
+
+import { ErrorPageContent } from './content';
+
+interface PrivateStateErrorPageProps {
+  layout: 'popup' | 'window' | 'tab';
+  onRetry: () => void;
+}
+
+/**
+ * Shown when the private-state fetch (P0.1) fails after timeout + retries —
+ * replaces the silent blank render on the unlock/re-auth pages.
+ */
+export function PrivateStateErrorPage({
+  layout,
+  onRetry
+}: PrivateStateErrorPageProps) {
+  const { t } = useTranslation();
+
+  const content = (
+    <ErrorPageContent
+      errorHeaderText={t('Something went wrong')}
+      errorContentText={t(
+        'Couldn’t load your wallet data. This is usually temporary — please try again.'
+      )}
+      pageType={layout === 'tab' ? 'onboarding' : 'general'}
+    />
+  );
+
+  const footer = (
+    <FooterButtonsContainer>
+      <Button color="primaryBlue" onClick={onRetry}>
+        {t('Try again')}
+      </Button>
+    </FooterButtonsContainer>
+  );
+
+  if (layout === 'tab') {
+    return (
+      <LayoutTab
+        layoutContext="withIllustration"
+        renderContent={() => content}
+        renderFooter={() => footer}
+      />
+    );
+  }
+
+  if (layout === 'window') {
+    return (
+      <LayoutWindow
+        renderHeader={() => <HeaderPopup />}
+        renderContent={() => content}
+        renderFooter={() => footer}
+      />
+    );
+  }
+
+  return (
+    <PopupLayout
+      renderHeader={() => <HeaderPopup />}
+      renderContent={() => content}
+      renderFooter={() => footer}
+    />
+  );
+}

--- a/src/libs/layout/unlock-vault/index.tsx
+++ b/src/libs/layout/unlock-vault/index.tsx
@@ -31,6 +31,7 @@ import {
   LayoutWindow,
   LockedRouterPath,
   PopupLayout,
+  PrivateStateErrorPage,
   SpacingSize
 } from '@libs/layout';
 import { Button, Typography } from '@libs/ui/components';
@@ -58,7 +59,11 @@ export const UnlockVaultPage = ({ popupLayout }: UnlockVaultPageProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
-  const privateState = usePrivateState();
+  const {
+    privateState,
+    error: privateStateError,
+    retry: retryPrivateState
+  } = usePrivateState();
   const keysDoesExist = useSelector(selectKeysDoesExist);
   const loginRetryCount = useSelector(selectLoginRetryCount);
 
@@ -199,6 +204,15 @@ export const UnlockVaultPage = ({ popupLayout }: UnlockVaultPageProps) => {
   }
 
   useLockWalletWhenNoMoreRetries(resetField);
+
+  if (privateStateError) {
+    return (
+      <PrivateStateErrorPage
+        layout={popupLayout ? 'popup' : 'window'}
+        onRetry={retryPrivateState}
+      />
+    );
+  }
 
   // private state (hashes + cipher) arrives in ms; matches existing async-boot behavior
   if (privateState == null) {

--- a/src/libs/layout/unlock-vault/index.tsx
+++ b/src/libs/layout/unlock-vault/index.tsx
@@ -12,20 +12,16 @@ import {
 import { PasswordDoesNotExistError } from '@src/errors';
 import { getErrorMessageForIncorrectPassword } from '@src/utils';
 
-import {
-  selectKeyDerivationSaltHash,
-  selectPasswordHash,
-  selectPasswordSaltHash
-} from '@background/redux/keys/selectors';
+import { selectKeysDoesExist } from '@background/redux/keys/selectors';
 import { loginRetryCountIncremented } from '@background/redux/login-retry-count/actions';
 import { selectLoginRetryCount } from '@background/redux/login-retry-count/selectors';
 import { unlockVault } from '@background/redux/sagas/actions';
 import { UnlockVault } from '@background/redux/sagas/types';
 import { dispatchToMainStore } from '@background/redux/utils';
-import { selectVaultCipher } from '@background/redux/vault-cipher/selectors';
 import { VaultState } from '@background/redux/vault/types';
 
 import { useLockWalletWhenNoMoreRetries } from '@hooks/use-lock-wallet-when-no-more-retries';
+import { usePrivateState } from '@hooks/use-private-state';
 
 import unlockAnimation from '@libs/animations/unlock_animation.json';
 import {
@@ -62,10 +58,8 @@ export const UnlockVaultPage = ({ popupLayout }: UnlockVaultPageProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
-  const passwordHash = useSelector(selectPasswordHash);
-  const passwordSaltHash = useSelector(selectPasswordSaltHash);
-  const keyDerivationSaltHash = useSelector(selectKeyDerivationSaltHash);
-  const vaultCipher = useSelector(selectVaultCipher);
+  const privateState = usePrivateState();
+  const keysDoesExist = useSelector(selectKeysDoesExist);
   const loginRetryCount = useSelector(selectLoginRetryCount);
 
   const attemptsLeft =
@@ -73,7 +67,7 @@ export const UnlockVaultPage = ({ popupLayout }: UnlockVaultPageProps) => {
     loginRetryCount -
     ERROR_DISPLAYED_BEFORE_ATTEMPT_IS_DECREMENTED;
 
-  if (passwordHash == null || passwordSaltHash == null) {
+  if (!keysDoesExist) {
     throw new PasswordDoesNotExistError();
   }
 
@@ -90,7 +84,14 @@ export const UnlockVaultPage = ({ popupLayout }: UnlockVaultPageProps) => {
   });
 
   async function handleUnlockVault({ password }: UnlockWalletFormValues) {
-    if (isLoading) return;
+    if (isLoading || privateState == null) return;
+
+    const {
+      passwordHash,
+      passwordSaltHash,
+      keyDerivationSaltHash,
+      vaultCipher
+    } = privateState;
 
     setIsLoading(true);
 
@@ -198,6 +199,11 @@ export const UnlockVaultPage = ({ popupLayout }: UnlockVaultPageProps) => {
   }
 
   useLockWalletWhenNoMoreRetries(resetField);
+
+  // private state (hashes + cipher) arrives in ms; matches existing async-boot behavior
+  if (privateState == null) {
+    return null;
+  }
 
   const footer = (
     <FooterButtonsContainer>


### PR DESCRIPTION
Jira: https://make-software.atlassian.net/browse/WALLET-1342 (DEP-16); P0.1/P1.1 portion of https://make-software.atlassian.net/browse/WALLET-1343.

### What

Retires `typesafe-actions` (unmaintained since 2019, 75 files) in favor of **Redux Toolkit 2**, behavior-preserving, and folds in the two security/architecture items that rewrite the same files:

- **RTK migration**: all 18 slices → `createSlice` (each `actions.ts` kept as a re-export shim — zero churn for the 75 importers), store factory → `configureStore` (saga middleware kept; serializable/immutable checks off — required by the replica flow; remote devtools via `devToolsEnhancer`), 8 saga trigger actions → standalone `createAction` with legacy strings, message envelopes → `createAction` with prepare callbacks (**all 34 sdkMethod + 7 sdkEvent + 5 bringweb3 + popupStateUpdated wire strings byte-identical**; exactly the same 4 error envelopes carry `{error: true}`), `RootState` cutover to first-party `src/background/redux/store-types.ts`, `typesafe-actions` uninstalled.
- **P0.1 — sanitize popup replica**: the state broadcast to UI replicas no longer carries `vaultCipher` (removed from the `PopupState` type), password/salt hashes (nulled; public `keys.keysDoesExist` flag instead), or `session.encryptionKeyHash` (nulled; public `encryptionKeyDoesExist` flag). Unlock flows fetch at-rest material on demand via a new `privateStateRequest` message answered **only to extension-origin senders** (fail-closed: no response — not even an error shape — for untrusted senders). `storage.local` persistence unchanged.
- **P1.1 — dispatcher split**: `background/index.ts` 992 → ~260 lines; message handling moved to typed modules under `src/background/handlers/` (sdk-methods, redux-actions, bringweb3, legacy-import, private-state) behind a thin parse→route→delegate router with verified 73/73 forwarding-case parity.
- **Tests**: 18 characterization test suites written against the OLD reducers and kept passing unchanged after conversion (0 → ~150 redux tests); jest alias mapper completed; coverage-gate decision (shared with P1.6/DEP-5): scoped `collectCoverageFrom` = redux reducers @ 100% (green); new `test:coverage` script.

### Scope addition (security)

The legacy import-account handlers (`check-secret-key-exist` / `check-account-name-is-taken` / `get-window-id`) are now gated by the same trusted-sender check — previously `check-secret-key-exist` answered a **secret-key membership oracle to any sender** (pre-existing). The only legitimate caller (import-account-with-file window) passes the gate.

### Behavior notes (intentional)

1. Unknown/unroutable messages now actually reject with the same error text — previously the `throw` inside an async Promise executor was swallowed and senders saw a forever-pending promise. Improvement, not a regression.
2. Store-internal action type strings are namespaced (`vault/accountAdded` vs `ACCOUNT_ADDED`) — verified nothing matches type strings; wire/envelope strings unchanged.
3. Immer now deep-freezes store state (incl. vault). Zero in-place mutations exist today (grep-verified by crypto review); any FUTURE in-place secret-zeroing utility must operate on copies or via a reducer, or it will throw.
4. `keysDoesExist` is persisted inside the keys blob as a harmless derived byte — always recomputed at preload; removing it would need a storage migration.
5. `fetchPrivateState()` rejection (e.g. SW restart mid-open) renders the unlock page blank without retry — fail-closed, ms-window; retry UX is a follow-up.

### Accepted residual (documented in the design spec)

The **decrypted `vault` slice** (secret phrase + account keys while unlocked) remains in the replica broadcast — the UI signing architecture depends on it; moving signing to the background is a separate epic item, out of DEP-16 scope.

### Verification

`ci-check` (62 suites / 306 tests, lint 0 errors), `test:coverage` 100% (18/18 reducers), chrome + firefox + safari builds, Playwright e2e onboarding 6/6 + popup 46/47 (+1 skipped), wire-shape spot-check (JSON key sets identical), manual QA (unlock flows, playground dapp round-trip incl. error envelopes, `popupStateUpdated` payload inspection), crypto-security review (vault slice — clean), extension-manifest review (dispatcher split — clean; no manifest/CSP changes, all MV3 top-level listeners preserved), per-task reviews + final whole-branch review.

### Follow-ups (for the WALLET-1343 follow-up PR)

- Dead private-material selectors cleanup (`selectPasswordHash` etc. — now unused, fail-safe).
- `fetchPrivateState` retry/error UX on unlock pages.
- Optional unit test freezing the 34 sdkMethod wire strings.
- P0.4 (Firefox/Safari DNR) + P1.6 (background test foundation) + P1.5 b/c/d (manifest hardening) per the agreed split.
