### PR TITLE
refactor: DEP-99 — window state into Redux + duplicate-response root cause (WALLET-1343)

### DIFF
--- a/src/apps/signature-request/pages/decrypt-message/index.tsx
+++ b/src/apps/signature-request/pages/decrypt-message/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { shallowEqual, useSelector } from 'react-redux';
 
@@ -62,8 +62,6 @@ export function DecryptMessagePage() {
     );
   }
 
-  const responseSentRef = useRef(false);
-
   const accounts = useSelector(selectVaultAccounts, shallowEqual);
 
   const connectedAccountNames = useSelector(
@@ -117,8 +115,6 @@ export function DecryptMessagePage() {
   }, [requestOrigin, connectAnotherAccount, signingAccount.name]);
 
   const handleCancel = useCallback(() => {
-    if (responseSentRef.current) return;
-    responseSentRef.current = true;
     sendSdkResponseToSpecificTab(
       sdkMethod.decryptMessageResponse({ cancelled: true }, { requestId }),
       requestTabId
@@ -157,7 +153,6 @@ export function DecryptMessagePage() {
       return;
     }
 
-    responseSentRef.current = true;
     sendSdkResponseToSpecificTab(
       sdkMethod.decryptMessageResponse(
         { decryptedMessage, cancelled: false },

--- a/src/apps/signature-request/pages/sign-eip712/index.tsx
+++ b/src/apps/signature-request/pages/sign-eip712/index.tsx
@@ -3,13 +3,7 @@ import {
   IEIP712SignTypedDataOptions,
   IEIP712TypedData
 } from 'casper-wallet-core';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { shallowEqual, useSelector } from 'react-redux';
 
@@ -73,7 +67,6 @@ export function SignEip712Page() {
   }
 
   const [showRawJson, setShowRawJson] = useState(false);
-  const responseSentRef = useRef(false);
 
   const accounts = useSelector(selectVaultAccounts, shallowEqual);
   const eip712JsonById = useSelector(selectEip712JsonById, shallowEqual);
@@ -185,8 +178,6 @@ export function SignEip712Page() {
   }, [requestOrigin, connectAnotherAccount, signingAccount.name]);
 
   const handleCancel = useCallback(() => {
-    if (responseSentRef.current) return;
-    responseSentRef.current = true;
     sendSdkResponseToSpecificTab(
       sdkMethod.signTypedDataResponse(
         {
@@ -204,7 +195,7 @@ export function SignEip712Page() {
   }, [requestId, requestTabId]);
 
   const handleSign = useCallback(() => {
-    if (!typedData || responseSentRef.current) {
+    if (!typedData) {
       return;
     }
 
@@ -224,7 +215,6 @@ export function SignEip712Page() {
         options
       });
 
-      responseSentRef.current = true;
       sendSdkResponseToSpecificTab(
         sdkMethod.signTypedDataResponse(
           {
@@ -241,7 +231,6 @@ export function SignEip712Page() {
       );
       closeCurrentWindow();
     } catch {
-      responseSentRef.current = true;
       sendSdkResponseToSpecificTab(
         sdkMethod.signTypedDataError(
           Error(ErrorMessages.signTypedData.SIGNING_FAILED.description),

--- a/src/apps/signature-request/pages/sign-message/index.tsx
+++ b/src/apps/signature-request/pages/sign-message/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { shallowEqual, useSelector } from 'react-redux';
 
@@ -80,8 +80,6 @@ export function SignMessagePage() {
     );
   }
 
-  const responseSentRef = useRef(false);
-
   const accounts = useSelector(selectVaultAccounts, shallowEqual);
 
   const connectedAccountNames = useSelector(
@@ -159,7 +157,6 @@ export function SignMessagePage() {
       return;
     }
 
-    responseSentRef.current = true;
     sendSdkResponseToSpecificTab(
       sdkMethod.signMessageResponse(
         { signatureHex: convertBytesToHex(signature), cancelled: false },
@@ -255,8 +252,6 @@ export function SignMessagePage() {
   };
 
   const handleCancel = useCallback(() => {
-    if (responseSentRef.current) return;
-    responseSentRef.current = true;
     sendSdkResponseToSpecificTab(
       sdkMethod.signResponse({ cancelled: true }, { requestId }),
       requestTabId

--- a/src/apps/signature-request/pages/sign-transaction/index.tsx
+++ b/src/apps/signature-request/pages/sign-transaction/index.tsx
@@ -120,7 +120,6 @@ export function SignTransactionPage() {
     useState(false);
 
   const wasmApprovalInitialisedRef = useRef(false);
-  const responseSentRef = useRef(false);
 
   const [isSigningAccountFromLedger, setIsSigningAccountFromLedger] =
     useState(false);
@@ -253,7 +252,6 @@ export function SignTransactionPage() {
       return;
     }
 
-    responseSentRef.current = true;
     sendSdkResponseToSpecificTab(
       sdkMethod.signResponse(
         { signatureHex: convertBytesToHex(signature), cancelled: false },
@@ -274,8 +272,6 @@ export function SignTransactionPage() {
   ]);
 
   const handleCancel = useCallback(() => {
-    if (responseSentRef.current) return;
-    responseSentRef.current = true;
     sendSdkResponseToSpecificTab(
       sdkMethod.signResponse({ cancelled: true }, { requestId }),
       requestTabId

--- a/src/background/create-open-window.ts
+++ b/src/background/create-open-window.ts
@@ -142,12 +142,6 @@ export function createOpenWindow({
         return newWindow.then(newWindow => {
           if (newWindow.id) {
             setWindowId(newWindow.id);
-
-            const handleCloseWindow = () => {
-              windows.onRemoved.removeListener(handleCloseWindow);
-              clearWindowId();
-            };
-            windows.onRemoved.addListener(handleCloseWindow);
           }
           return newWindow;
         });

--- a/src/background/handlers/sdk-methods.ts
+++ b/src/background/handlers/sdk-methods.ts
@@ -74,7 +74,7 @@ export async function handleSdkMethod(
         response: sdkMethod.connectResponse(true, action.meta)
       };
     } else {
-      openWindow({
+      openWindow(store, {
         windowApp: WindowApp.ConnectToApp,
         searchParams: query
       });
@@ -102,7 +102,7 @@ export async function handleSdkMethod(
       query.title = action.payload.title;
     }
 
-    openWindow({
+    openWindow(store, {
       windowApp: WindowApp.SwitchAccount,
       searchParams: query
     });
@@ -155,7 +155,7 @@ export async function handleSdkMethod(
       })
     );
 
-    openWindow({
+    openWindow(store, {
       windowApp: WindowApp.SignatureRequestDeploy,
       searchParams: {
         requestId: action.meta.requestId,
@@ -180,7 +180,7 @@ export async function handleSdkMethod(
 
     const { signingPublicKeyHex, message } = action.payload;
 
-    openWindow({
+    openWindow(store, {
       windowApp: WindowApp.SignatureRequestMessage,
       searchParams: {
         requestId: action.meta.requestId,
@@ -213,7 +213,7 @@ export async function handleSdkMethod(
       })
     );
 
-    openWindow({
+    openWindow(store, {
       windowApp: WindowApp.SignatureRequestEip712,
       searchParams: {
         requestId: action.meta.requestId,
@@ -239,7 +239,7 @@ export async function handleSdkMethod(
 
     const { signingPublicKeyHex, message } = action.payload;
 
-    openWindow({
+    openWindow(store, {
       windowApp: WindowApp.DecryptMessageRequest,
       searchParams: {
         requestId: action.meta.requestId,

--- a/src/background/handlers/sdk-methods.ts
+++ b/src/background/handlers/sdk-methods.ts
@@ -25,6 +25,7 @@ import {
   selectIsAccountConnected,
   selectVaultActiveAccount
 } from '@background/redux/vault/selectors';
+import { windowRequestOpened } from '@background/redux/windowManagement/actions';
 import { emitSdkEventToActiveTabsWithOrigin } from '@background/utils';
 
 import { SiteNotConnectedError, WalletLockedError } from '@content/sdk-errors';
@@ -74,6 +75,7 @@ export async function handleSdkMethod(
         response: sdkMethod.connectResponse(true, action.meta)
       };
     } else {
+      store.dispatch(windowRequestOpened({ requestId: action.meta.requestId }));
       openWindow(store, {
         windowApp: WindowApp.ConnectToApp,
         searchParams: query
@@ -102,6 +104,7 @@ export async function handleSdkMethod(
       query.title = action.payload.title;
     }
 
+    store.dispatch(windowRequestOpened({ requestId: action.meta.requestId }));
     openWindow(store, {
       windowApp: WindowApp.SwitchAccount,
       searchParams: query
@@ -155,6 +158,7 @@ export async function handleSdkMethod(
       })
     );
 
+    store.dispatch(windowRequestOpened({ requestId: action.meta.requestId }));
     openWindow(store, {
       windowApp: WindowApp.SignatureRequestDeploy,
       searchParams: {
@@ -180,6 +184,7 @@ export async function handleSdkMethod(
 
     const { signingPublicKeyHex, message } = action.payload;
 
+    store.dispatch(windowRequestOpened({ requestId: action.meta.requestId }));
     openWindow(store, {
       windowApp: WindowApp.SignatureRequestMessage,
       searchParams: {
@@ -213,6 +218,7 @@ export async function handleSdkMethod(
       })
     );
 
+    store.dispatch(windowRequestOpened({ requestId: action.meta.requestId }));
     openWindow(store, {
       windowApp: WindowApp.SignatureRequestEip712,
       searchParams: {
@@ -239,6 +245,7 @@ export async function handleSdkMethod(
 
     const { signingPublicKeyHex, message } = action.payload;
 
+    store.dispatch(windowRequestOpened({ requestId: action.meta.requestId }));
     openWindow(store, {
       windowApp: WindowApp.DecryptMessageRequest,
       searchParams: {

--- a/src/background/handlers/sdk-response-to-tab.test.ts
+++ b/src/background/handlers/sdk-response-to-tab.test.ts
@@ -1,4 +1,4 @@
-import { tabs } from 'webextension-polyfill';
+import { Runtime, tabs } from 'webextension-polyfill';
 
 import { MainStore } from '@background/redux/get-main-store';
 import { RequestStatus } from '@background/redux/windowManagement/types';
@@ -14,7 +14,11 @@ import { handleSdkResponseToTab } from './sdk-response-to-tab';
 // `webextension-polyfill` throws outside a browser extension. Stub the only API
 // the handler touches so the module can load and we can spy delivery.
 jest.mock('webextension-polyfill', () => ({
-  tabs: { sendMessage: jest.fn() }
+  tabs: { sendMessage: jest.fn() },
+  runtime: {
+    id: 'ext-id',
+    getURL: (path: string) => `chrome-extension://ext-id/${path}`
+  }
 }));
 
 const sendMessageMock = tabs.sendMessage as jest.MockedFunction<
@@ -23,6 +27,13 @@ const sendMessageMock = tabs.sendMessage as jest.MockedFunction<
 
 const REQUEST_ID = 'req-1';
 const TAB_ID = 7;
+
+// Trusted extension-UI sender (id matches runtime.id, url under the extension
+// origin) — passes `isTrustedUiSender`.
+const UI_SENDER = {
+  id: 'ext-id',
+  url: 'chrome-extension://ext-id/popup.html'
+} as Runtime.MessageSender;
 
 // Build a fake store whose `requests` map carries the desired status for the
 // request under test, plus a spied dispatch.
@@ -79,7 +90,7 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
     const { store, dispatch } = makeStore(undefined);
     const message = makeMessage();
 
-    const result = await handleSdkResponseToTab(message, store);
+    const result = await handleSdkResponseToTab(message, UI_SENDER, store);
 
     expect(sendMessageMock).toHaveBeenCalledTimes(1);
     expect(sendMessageMock).toHaveBeenCalledWith(TAB_ID, message.action);
@@ -94,7 +105,11 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
   it("already 'responded' → drops the duplicate (no send, no dispatch)", async () => {
     const { store, dispatch } = makeStore('responded');
 
-    const result = await handleSdkResponseToTab(makeMessage(), store);
+    const result = await handleSdkResponseToTab(
+      makeMessage(),
+      UI_SENDER,
+      store
+    );
 
     expect(sendMessageMock).not.toHaveBeenCalled();
     expect(dispatch).not.toHaveBeenCalled();
@@ -104,7 +119,11 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
   it("'closed' (never responded) → still delivers (must NOT drop — beforeunload-cancel race)", async () => {
     const { store } = makeStore('closed');
 
-    const result = await handleSdkResponseToTab(makeMessage(), store);
+    const result = await handleSdkResponseToTab(
+      makeMessage(),
+      UI_SENDER,
+      store
+    );
 
     expect(sendMessageMock).toHaveBeenCalledTimes(1);
     expect(sendMessageMock).toHaveBeenCalledWith(TAB_ID, makeMessage().action);
@@ -114,7 +133,11 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
   it('invalid tabId → no delivery, no throw', async () => {
     const { store, dispatch } = makeStore(undefined);
 
-    const result = await handleSdkResponseToTab(makeMessage(-1), store);
+    const result = await handleSdkResponseToTab(
+      makeMessage(-1),
+      UI_SENDER,
+      store
+    );
 
     expect(sendMessageMock).not.toHaveBeenCalled();
     expect(dispatch).not.toHaveBeenCalled();
@@ -129,11 +152,15 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
 
     // Do NOT await — the first handler yields at `await tabs.sendMessage`, but
     // it has already dispatched `windowRequestResponded` synchronously.
-    const first = handleSdkResponseToTab(makeMessage(), store);
+    const first = handleSdkResponseToTab(makeMessage(), UI_SENDER, store);
 
     // Second message for the SAME requestId, processed during the first's
     // in-flight send. It must read status 'responded' and drop.
-    const secondResult = await handleSdkResponseToTab(makeMessage(), store);
+    const secondResult = await handleSdkResponseToTab(
+      makeMessage(),
+      UI_SENDER,
+      store
+    );
 
     expect(secondResult).toEqual({ handled: true, response: undefined });
     // Exactly ONE delivery reached the tab — the duplicate was deduped.
@@ -147,10 +174,29 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
 
     const result = await handleSdkResponseToTab(
       { type: 'SomethingElse' } as unknown as SdkResponseToTabMessage,
+      UI_SENDER,
       store
     );
 
     expect(result.handled).toBe(false);
     expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('untrusted sender → dropped (handled, no delivery, no dispatch)', async () => {
+    const { store, dispatch } = makeStore(undefined);
+    const untrustedSender = {
+      id: 'other-ext',
+      url: 'https://evil.example/page'
+    } as Runtime.MessageSender;
+
+    const result = await handleSdkResponseToTab(
+      makeMessage(),
+      untrustedSender,
+      store
+    );
+
+    expect(result).toEqual({ handled: true });
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
   });
 });

--- a/src/background/handlers/sdk-response-to-tab.test.ts
+++ b/src/background/handlers/sdk-response-to-tab.test.ts
@@ -1,0 +1,156 @@
+import { tabs } from 'webextension-polyfill';
+
+import { MainStore } from '@background/redux/get-main-store';
+import { RequestStatus } from '@background/redux/windowManagement/types';
+import {
+  SDK_RESPONSE_TO_TAB,
+  SdkResponseToTabMessage
+} from '@background/send-sdk-response-to-specific-tab';
+
+import { sdkMethod } from '@content/sdk-method';
+
+import { handleSdkResponseToTab } from './sdk-response-to-tab';
+
+// `webextension-polyfill` throws outside a browser extension. Stub the only API
+// the handler touches so the module can load and we can spy delivery.
+jest.mock('webextension-polyfill', () => ({
+  tabs: { sendMessage: jest.fn() }
+}));
+
+const sendMessageMock = tabs.sendMessage as jest.MockedFunction<
+  typeof tabs.sendMessage
+>;
+
+const REQUEST_ID = 'req-1';
+const TAB_ID = 7;
+
+// Build a fake store whose `requests` map carries the desired status for the
+// request under test, plus a spied dispatch.
+function makeStore(status?: RequestStatus) {
+  const dispatch = jest.fn();
+  const store = {
+    getState: () => ({
+      windowManagement: {
+        windowId: null,
+        requests: status ? { [REQUEST_ID]: status } : {}
+      }
+    }),
+    dispatch
+  } as unknown as MainStore;
+  return { store, dispatch };
+}
+
+// Stateful store: `dispatch` actually applies `windowRequestResponded` to the
+// `requests` map, so a subsequent `selectRequestStatus` reflects the optimistic
+// mark. Used to prove the dedupe is atomic across an in-flight (un-awaited) send.
+function makeStatefulStore() {
+  const requests: Record<string, RequestStatus> = {};
+  const dispatch = jest.fn((action: { payload?: { requestId?: string } }) => {
+    const id = action?.payload?.requestId;
+    if (id != null) {
+      requests[id] = 'responded';
+    }
+  });
+  const store = {
+    getState: () => ({ windowManagement: { windowId: null, requests } }),
+    dispatch
+  } as unknown as MainStore;
+  return { store, dispatch };
+}
+
+function makeMessage(tabId: number = TAB_ID): SdkResponseToTabMessage {
+  return {
+    type: SDK_RESPONSE_TO_TAB,
+    action: sdkMethod.signResponse(
+      { signatureHex: 'deadbeef', cancelled: false },
+      { requestId: REQUEST_ID }
+    ),
+    tabId
+  };
+}
+
+describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
+  beforeEach(() => {
+    sendMessageMock.mockReset();
+    sendMessageMock.mockResolvedValue(undefined);
+  });
+
+  it('fresh request (no prior status) → delivers to the tab AND marks responded', async () => {
+    const { store, dispatch } = makeStore(undefined);
+    const message = makeMessage();
+
+    const result = await handleSdkResponseToTab(message, store);
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageMock).toHaveBeenCalledWith(TAB_ID, message.action);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    // windowRequestResponded({ requestId })
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: { requestId: REQUEST_ID } })
+    );
+    expect(result.handled).toBe(true);
+  });
+
+  it("already 'responded' → drops the duplicate (no send, no dispatch)", async () => {
+    const { store, dispatch } = makeStore('responded');
+
+    const result = await handleSdkResponseToTab(makeMessage(), store);
+
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(result.handled).toBe(true);
+  });
+
+  it("'closed' (never responded) → still delivers (must NOT drop — beforeunload-cancel race)", async () => {
+    const { store } = makeStore('closed');
+
+    const result = await handleSdkResponseToTab(makeMessage(), store);
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageMock).toHaveBeenCalledWith(TAB_ID, makeMessage().action);
+    expect(result.handled).toBe(true);
+  });
+
+  it('invalid tabId → no delivery, no throw', async () => {
+    const { store, dispatch } = makeStore(undefined);
+
+    const result = await handleSdkResponseToTab(makeMessage(-1), store);
+
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(result.handled).toBe(true);
+  });
+
+  it('atomic dedupe: a second response arriving while the first send is still in-flight is dropped', async () => {
+    const { store } = makeStatefulStore();
+    // First send never resolves — simulates the delivery being in-flight while
+    // the second (beforeunload-cancel) message is processed by the router.
+    sendMessageMock.mockReturnValue(new Promise(() => {}));
+
+    // Do NOT await — the first handler yields at `await tabs.sendMessage`, but
+    // it has already dispatched `windowRequestResponded` synchronously.
+    const first = handleSdkResponseToTab(makeMessage(), store);
+
+    // Second message for the SAME requestId, processed during the first's
+    // in-flight send. It must read status 'responded' and drop.
+    const secondResult = await handleSdkResponseToTab(makeMessage(), store);
+
+    expect(secondResult).toEqual({ handled: true, response: undefined });
+    // Exactly ONE delivery reached the tab — the duplicate was deduped.
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+
+    void first; // keep the first (pending) invocation referenced
+  });
+
+  it('non-matching message.type → { handled: false } (passes to the next handler)', async () => {
+    const { store } = makeStore(undefined);
+
+    const result = await handleSdkResponseToTab(
+      { type: 'SomethingElse' } as unknown as SdkResponseToTabMessage,
+      store
+    );
+
+    expect(result.handled).toBe(false);
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/background/handlers/sdk-response-to-tab.ts
+++ b/src/background/handlers/sdk-response-to-tab.ts
@@ -1,0 +1,80 @@
+import { tabs } from 'webextension-polyfill';
+
+import { MainStore } from '@background/redux/get-main-store';
+import { windowRequestResponded } from '@background/redux/windowManagement/actions';
+import { selectRequestStatus } from '@background/redux/windowManagement/selectors';
+import {
+  SDK_RESPONSE_TO_TAB,
+  SdkResponseToTabMessage
+} from '@background/send-sdk-response-to-specific-tab';
+
+import { HandlerResult } from './types';
+
+// Server-side dedupe of SDK responses (P0.5 root cause). The signature UI pages
+// used to `tabs.sendMessage` the response to the dapp tab directly and guard
+// double-sends with a per-page `responseSentRef` (fragile: per instance, lost on
+// reload). Now every response is forwarded here and deduped by `requestId`: the
+// FIRST response for a request wins, later ones are dropped — atomically,
+// because the background store is the single writer.
+//
+// CRITICAL: drop ONLY when the request is already 'responded', NEVER on 'closed'.
+// `handleCancel` fires on `beforeunload` and sends its response just before the
+// window unloads; the `windows.onRemoved` listener then dispatches
+// `windowClosed()` (marking still-open requests 'closed'). These race. Dropping
+// on 'closed' would suppress a legitimate beforeunload-cancel for a window that
+// closed WITHOUT a prior response (dapp left hanging). Dropping only on
+// 'responded' kills the real duplicate (a cancel after a successful sign, where
+// the sign already set 'responded') without ever suppressing a first response.
+export async function handleSdkResponseToTab(
+  message: unknown,
+  store: MainStore
+): Promise<HandlerResult> {
+  const candidate = message as Partial<SdkResponseToTabMessage> | undefined;
+
+  if (candidate?.type !== SDK_RESPONSE_TO_TAB) {
+    return { handled: false };
+  }
+
+  const { action, tabId } = candidate as SdkResponseToTabMessage;
+  const requestId = action?.meta?.requestId;
+
+  // Dedupe: first response for this requestId wins. Drop ONLY on 'responded'
+  // (see the race rationale above) — never on 'closed'.
+  if (
+    requestId != null &&
+    selectRequestStatus(store.getState(), requestId) === 'responded'
+  ) {
+    // Drop the duplicate — it never reaches the tab. Respond so the forwarding
+    // UI's `runtime.sendMessage` promise still resolves (some callers await it
+    // before closing the window).
+    return { handled: true, response: undefined };
+  }
+
+  if (!Number.isInteger(tabId) || tabId < 0) {
+    // Nothing was sent — do NOT mark responded (a valid retry must still deliver).
+    console.error('handleSdkResponseToTab: invalid tabId', tabId);
+    return { handled: true, response: undefined };
+  }
+
+  // Mark responded OPTIMISTICALLY, BEFORE the await. `runtime.onMessage`
+  // handlers interleave at every `await`, so two near-simultaneous responses
+  // for the same requestId (the P0.5 repro: handleSign sends, then
+  // closeCurrentWindow → beforeunload → handleCancel sends) would BOTH read
+  // status `undefined` if we marked after the send — and both would reach the
+  // dapp. Dispatching synchronously here (before yielding the event loop) means
+  // a second message processed during the first's in-flight send reads
+  // 'responded' and drops. Trade-off: on a genuine delivery failure the request
+  // stays 'responded' and any retry is dropped — acceptable, since delivery
+  // failure is already terminal (no retry path) and deterministic dedup is the goal.
+  if (requestId != null) {
+    store.dispatch(windowRequestResponded({ requestId }));
+  }
+
+  try {
+    await tabs.sendMessage(tabId, action);
+  } catch (err) {
+    console.warn('handleSdkResponseToTab: delivery failed', err);
+  }
+
+  return { handled: true, response: undefined };
+}

--- a/src/background/handlers/sdk-response-to-tab.ts
+++ b/src/background/handlers/sdk-response-to-tab.ts
@@ -1,4 +1,4 @@
-import { tabs } from 'webextension-polyfill';
+import { Runtime, tabs } from 'webextension-polyfill';
 
 import { MainStore } from '@background/redux/get-main-store';
 import { windowRequestResponded } from '@background/redux/windowManagement/actions';
@@ -8,6 +8,7 @@ import {
   SdkResponseToTabMessage
 } from '@background/send-sdk-response-to-specific-tab';
 
+import { isTrustedUiSender } from './private-state';
 import { HandlerResult } from './types';
 
 // Server-side dedupe of SDK responses (P0.5 root cause). The signature UI pages
@@ -27,12 +28,23 @@ import { HandlerResult } from './types';
 // the sign already set 'responded') without ever suppressing a first response.
 export async function handleSdkResponseToTab(
   message: unknown,
+  sender: Runtime.MessageSender,
   store: MainStore
 ): Promise<HandlerResult> {
   const candidate = message as Partial<SdkResponseToTabMessage> | undefined;
 
   if (candidate?.type !== SDK_RESPONSE_TO_TAB) {
     return { handled: false };
+  }
+
+  // Defense-in-depth: this handler reroutes a response to an arbitrary dapp
+  // tab, so only the extension's own UI pages may originate it. With the
+  // private MessageChannel transport + SDK_REQUEST_TYPES allowlist (P0.2) this
+  // is already unreachable from a page, but gating on the sender guards against
+  // a future allowlist regression or a content-script-world compromise.
+  // Silently drop (no response), matching the private-state / legacy-import gate.
+  if (!isTrustedUiSender(sender)) {
+    return { handled: true };
   }
 
   const { action, tabId } = candidate as SdkResponseToTabMessage;

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -26,6 +26,7 @@ import {
 } from '@background/handlers/private-state';
 import { handleReduxAction } from '@background/handlers/redux-actions';
 import { handleSdkMethod } from '@background/handlers/sdk-methods';
+import { handleSdkResponseToTab } from '@background/handlers/sdk-response-to-tab';
 import { initKeepAlive } from '@background/keep-alive';
 import {
   disableOnboardingFlow,
@@ -245,7 +246,11 @@ runtime.onMessage.addListener(
         if (typeof action.type === 'string') {
           const typedAction = action as { type: string };
 
-          for (const handle of [handleReduxAction, handleBringWeb3] as const) {
+          for (const handle of [
+            handleReduxAction,
+            handleBringWeb3,
+            handleSdkResponseToTab
+          ] as const) {
             const result = await handle(typedAction, store);
             if (result.handled) {
               return respond(result);

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -37,6 +37,8 @@ import {
   selectIsAccountConnected,
   selectVaultActiveAccount
 } from '@background/redux/vault/selectors';
+import { windowClosed } from '@background/redux/windowManagement/actions';
+import { selectWindowId } from '@background/redux/windowManagement/selectors';
 
 import { sdkEvent } from '@content/sdk-event';
 import { isSDKMethod } from '@content/sdk-method';
@@ -164,6 +166,19 @@ tabs.onActivated.addListener(
 tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   if (changeInfo && changeInfo.url && tab.windowId) {
     updateOrigin(tab.windowId);
+  }
+});
+
+// Single init-time listener for the approval-window lifecycle. Replaces the
+// per-creation `windows.onRemoved` listeners that used to be added inside
+// `createOpenWindow` (one leaked per opened window). `windows.onRemoved` fires
+// for ANY window, so the id-match guard ensures we only react when the removed
+// window is the tracked approval window. `windowClosed()` nulls the slice
+// `windowId` AND marks any still-open requests as 'closed'.
+windows.onRemoved.addListener(async (removedWindowId: number) => {
+  const store = await getExistingMainStoreSingletonOrInit();
+  if (removedWindowId === selectWindowId(store.getState())) {
+    store.dispatch(windowClosed());
   }
 });
 

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -246,15 +246,22 @@ runtime.onMessage.addListener(
         if (typeof action.type === 'string') {
           const typedAction = action as { type: string };
 
-          for (const handle of [
-            handleReduxAction,
-            handleBringWeb3,
-            handleSdkResponseToTab
-          ] as const) {
+          for (const handle of [handleReduxAction, handleBringWeb3] as const) {
             const result = await handle(typedAction, store);
             if (result.handled) {
               return respond(result);
             }
+          }
+
+          // SDK-response reroute is gated on `sender` (only extension UI may
+          // originate it), so it is called outside the uniform loop above.
+          const sdkResponseResult = await handleSdkResponseToTab(
+            typedAction,
+            sender,
+            store
+          );
+          if (sdkResponseResult.handled) {
+            return respond(sdkResponseResult);
           }
 
           // Legacy import handler is gated on `sender` (P0.1), so it is called

--- a/src/background/open-window.test.ts
+++ b/src/background/open-window.test.ts
@@ -1,0 +1,107 @@
+import { WindowApp, createOpenWindow } from '@background/create-open-window';
+import { MainStore } from '@background/redux/get-main-store';
+import {
+  windowIdChanged,
+  windowIdCleared
+} from '@background/redux/windowManagement/actions';
+
+import { openWindow } from './open-window';
+
+// `create-open-window` imports `webextension-polyfill`, which throws outside a
+// browser extension. Stub it so the module can load under `requireActual`.
+jest.mock('webextension-polyfill', () => ({
+  windows: {
+    getAll: jest.fn(),
+    get: jest.fn(),
+    getCurrent: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn()
+  },
+  tabs: { update: jest.fn() }
+}));
+
+// Mock the window-creation factory so the test exercises ONLY the store-routing
+// wiring in `openWindow`, not the real `windows.create` browser call.
+jest.mock('@background/create-open-window', () => {
+  const actual = jest.requireActual('@background/create-open-window');
+  return {
+    ...actual,
+    createOpenWindow: jest.fn()
+  };
+});
+
+const createOpenWindowMock = createOpenWindow as jest.MockedFunction<
+  typeof createOpenWindow
+>;
+
+function makeStore(windowId: number | null) {
+  const dispatch = jest.fn();
+  const store = {
+    getState: () => ({ windowManagement: { windowId, requests: {} } }),
+    dispatch
+  } as unknown as MainStore;
+  return { store, dispatch };
+}
+
+describe('openWindow (background store routing)', () => {
+  beforeEach(() => {
+    createOpenWindowMock.mockReset();
+    // Return an inner opener so `openWindow` can invoke it fire-and-forget.
+    createOpenWindowMock.mockReturnValue(
+      jest.fn().mockResolvedValue(undefined)
+    );
+  });
+
+  it('passes the slice windowId from store.getState() into createOpenWindow', () => {
+    const { store } = makeStore(42);
+
+    openWindow(store, { windowApp: WindowApp.ConnectToApp });
+
+    expect(createOpenWindowMock).toHaveBeenCalledTimes(1);
+    const config = createOpenWindowMock.mock.calls[0][0];
+    expect(config.windowId).toBe(42);
+  });
+
+  it('passes null windowId when the slice has no tracked window', () => {
+    const { store } = makeStore(null);
+
+    openWindow(store, { windowApp: WindowApp.ConnectToApp });
+
+    const config = createOpenWindowMock.mock.calls[0][0];
+    expect(config.windowId).toBeNull();
+  });
+
+  it('invokes the returned opener with the forwarded props', () => {
+    const innerOpen = jest.fn().mockResolvedValue(undefined);
+    createOpenWindowMock.mockReturnValue(innerOpen);
+    const { store } = makeStore(1);
+
+    const props = {
+      windowApp: WindowApp.SignatureRequestDeploy,
+      searchParams: { requestId: 'r1' }
+    };
+    openWindow(store, props);
+
+    expect(innerOpen).toHaveBeenCalledWith(props);
+  });
+
+  it('setWindowId dispatches windowIdChanged with the new id', () => {
+    const { store, dispatch } = makeStore(null);
+
+    openWindow(store, { windowApp: WindowApp.ConnectToApp });
+
+    const config = createOpenWindowMock.mock.calls[0][0];
+    config.setWindowId(7);
+    expect(dispatch).toHaveBeenCalledWith(windowIdChanged(7));
+  });
+
+  it('clearWindowId dispatches windowIdCleared', () => {
+    const { store, dispatch } = makeStore(5);
+
+    openWindow(store, { windowApp: WindowApp.ConnectToApp });
+
+    const config = createOpenWindowMock.mock.calls[0][0];
+    config.clearWindowId();
+    expect(dispatch).toHaveBeenCalledWith(windowIdCleared());
+  });
+});

--- a/src/background/open-window.ts
+++ b/src/background/open-window.ts
@@ -1,15 +1,18 @@
-// TODO: Remake it after background store will be complete
 import {
   OpenWindowProps,
   createOpenWindow
 } from '@background/create-open-window';
+import { MainStore } from '@background/redux/get-main-store';
+import {
+  windowIdChanged,
+  windowIdCleared
+} from '@background/redux/windowManagement/actions';
+import { selectWindowId } from '@background/redux/windowManagement/selectors';
 
-let windowId: number | null = null;
-
-export function openWindow(openWindowProps: OpenWindowProps) {
+export function openWindow(store: MainStore, openWindowProps: OpenWindowProps) {
   createOpenWindow({
-    windowId,
-    setWindowId: (id: number) => (windowId = id),
-    clearWindowId: () => (windowId = null)
+    windowId: selectWindowId(store.getState()),
+    setWindowId: (id: number) => store.dispatch(windowIdChanged(id)),
+    clearWindowId: () => store.dispatch(windowIdCleared())
   })(openWindowProps);
 }

--- a/src/background/open-window.ts
+++ b/src/background/open-window.ts
@@ -14,5 +14,9 @@ export function openWindow(store: MainStore, openWindowProps: OpenWindowProps) {
     windowId: selectWindowId(store.getState()),
     setWindowId: (id: number) => store.dispatch(windowIdChanged(id)),
     clearWindowId: () => store.dispatch(windowIdCleared())
-  })(openWindowProps);
+  })(openWindowProps).catch(error => {
+    // Fire-and-forget: if `windows.create` rejects, surface it instead of an
+    // unhandled rejection. The slice's window id is left cleared (no id was set).
+    console.error('openWindow: failed to open approval window', error);
+  });
 }

--- a/src/background/redux/windowManagement/actions.ts
+++ b/src/background/redux/windowManagement/actions.ts
@@ -4,6 +4,9 @@ export {
   onboardingAppInit,
   popupWindowInit,
   signWindowInit,
+  windowClosed,
   windowIdChanged,
-  windowIdCleared
+  windowIdCleared,
+  windowRequestOpened,
+  windowRequestResponded
 } from './reducer';

--- a/src/background/redux/windowManagement/reducer.test.ts
+++ b/src/background/redux/windowManagement/reducer.test.ts
@@ -4,28 +4,76 @@ import {
   onboardingAppInit,
   popupWindowInit,
   signWindowInit,
+  windowClosed,
   windowIdChanged,
-  windowIdCleared
+  windowIdCleared,
+  windowRequestOpened,
+  windowRequestResponded
 } from './actions';
 import { reducer } from './reducer';
 
 describe('windowManagement reducer', () => {
-  it('has null windowId initially', () => {
+  it('has null windowId and no requests initially', () => {
     expect(reducer(undefined, { type: '@@INIT' } as any)).toEqual({
-      windowId: null
+      windowId: null,
+      requests: {}
     });
   });
   it('sets and clears windowId', () => {
-    const s = reducer({ windowId: null }, windowIdChanged(7));
-    expect(s).toEqual({ windowId: 7 });
-    expect(reducer(s, windowIdCleared())).toEqual({ windowId: null });
+    const s = reducer({ windowId: null, requests: {} }, windowIdChanged(7));
+    expect(s).toEqual({ windowId: 7, requests: {} });
+    expect(reducer(s, windowIdCleared())).toEqual({
+      windowId: null,
+      requests: {}
+    });
   });
   it('window-init actions do not change state', () => {
-    const state = { windowId: 7 };
-    expect(reducer(state, onboardingAppInit())).toEqual({ windowId: 7 });
-    expect(reducer(state, popupWindowInit())).toEqual({ windowId: 7 });
-    expect(reducer(state, connectWindowInit())).toEqual({ windowId: 7 });
-    expect(reducer(state, importWindowInit())).toEqual({ windowId: 7 });
-    expect(reducer(state, signWindowInit())).toEqual({ windowId: 7 });
+    const state = { windowId: 7, requests: {} };
+    expect(reducer(state, onboardingAppInit())).toEqual(state);
+    expect(reducer(state, popupWindowInit())).toEqual(state);
+    expect(reducer(state, connectWindowInit())).toEqual(state);
+    expect(reducer(state, importWindowInit())).toEqual(state);
+    expect(reducer(state, signWindowInit())).toEqual(state);
+  });
+
+  it('opens a request', () => {
+    const s = reducer(
+      { windowId: null, requests: {} },
+      windowRequestOpened({ requestId: 'r1' })
+    );
+    expect(s.requests.r1).toBe('open');
+  });
+
+  it('marks a request as responded, and is idempotent on a second respond', () => {
+    let s = reducer(
+      { windowId: null, requests: {} },
+      windowRequestOpened({ requestId: 'r1' })
+    );
+    s = reducer(s, windowRequestResponded({ requestId: 'r1' }));
+    expect(s.requests.r1).toBe('responded');
+
+    s = reducer(s, windowRequestResponded({ requestId: 'r1' }));
+    expect(s.requests.r1).toBe('responded');
+  });
+
+  it('closes open requests and clears windowId on windowClosed', () => {
+    let s = reducer(
+      { windowId: 7, requests: {} },
+      windowRequestOpened({ requestId: 'r2' })
+    );
+    s = reducer(s, windowClosed());
+    expect(s.requests.r2).toBe('closed');
+    expect(s.windowId).toBeNull();
+  });
+
+  it('leaves a responded request as responded on windowClosed', () => {
+    let s = reducer(
+      { windowId: 7, requests: {} },
+      windowRequestOpened({ requestId: 'r3' })
+    );
+    s = reducer(s, windowRequestResponded({ requestId: 'r3' }));
+    s = reducer(s, windowClosed());
+    expect(s.requests.r3).toBe('responded');
+    expect(s.windowId).toBeNull();
   });
 });

--- a/src/background/redux/windowManagement/reducer.ts
+++ b/src/background/redux/windowManagement/reducer.ts
@@ -1,8 +1,8 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import { WindowManagementState } from './types';
+import { RequestStatus, WindowManagementState } from './types';
 
-const initialState: WindowManagementState = { windowId: null };
+const initialState: WindowManagementState = { windowId: null, requests: {} };
 
 const slice = createSlice({
   name: 'windowManagement',
@@ -17,7 +17,37 @@ const slice = createSlice({
     popupWindowInit: state => state,
     connectWindowInit: state => state,
     importWindowInit: state => state,
-    signWindowInit: state => state
+    signWindowInit: state => state,
+    windowRequestOpened: (
+      state,
+      action: PayloadAction<{ requestId: string }>
+    ) => ({
+      ...state,
+      requests: {
+        ...state.requests,
+        [action.payload.requestId]: 'open'
+      }
+    }),
+    windowRequestResponded: (
+      state,
+      action: PayloadAction<{ requestId: string }>
+    ) => ({
+      ...state,
+      requests: {
+        ...state.requests,
+        [action.payload.requestId]: 'responded'
+      }
+    }),
+    windowClosed: state => ({
+      ...state,
+      windowId: null,
+      requests: Object.entries(state.requests).reduce<
+        Record<string, RequestStatus>
+      >((acc, [requestId, status]) => {
+        acc[requestId] = status === 'open' ? 'closed' : status;
+        return acc;
+      }, {})
+    })
   }
 });
 
@@ -27,7 +57,10 @@ export const {
   onboardingAppInit,
   popupWindowInit,
   signWindowInit,
+  windowClosed,
   windowIdChanged,
-  windowIdCleared
+  windowIdCleared,
+  windowRequestOpened,
+  windowRequestResponded
 } = slice.actions;
 export const reducer = slice.reducer;

--- a/src/background/redux/windowManagement/selectors.ts
+++ b/src/background/redux/windowManagement/selectors.ts
@@ -1,4 +1,11 @@
 import { RootState } from '@background/redux/store-types';
 
+import { RequestStatus } from './types';
+
 export const selectWindowId = (state: RootState): number | null =>
   state.windowManagement.windowId;
+
+export const selectRequestStatus = (
+  state: RootState,
+  requestId: string
+): RequestStatus | undefined => state.windowManagement.requests[requestId];

--- a/src/background/redux/windowManagement/types.ts
+++ b/src/background/redux/windowManagement/types.ts
@@ -1,3 +1,6 @@
+export type RequestStatus = 'open' | 'responded' | 'closed';
+
 export interface WindowManagementState {
   windowId: number | null;
+  requests: Record<string, RequestStatus>;
 }

--- a/src/background/send-sdk-response-to-specific-tab.test.ts
+++ b/src/background/send-sdk-response-to-specific-tab.test.ts
@@ -1,0 +1,54 @@
+import { runtime } from 'webextension-polyfill';
+
+import { sdkMethod } from '@content/sdk-method';
+
+import {
+  SDK_RESPONSE_TO_TAB,
+  sendSdkResponseToSpecificTab
+} from './send-sdk-response-to-specific-tab';
+
+// `webextension-polyfill` throws outside a browser extension. Stub the only API
+// the forwarder touches.
+jest.mock('webextension-polyfill', () => ({
+  runtime: { sendMessage: jest.fn() }
+}));
+
+const sendMessageMock = runtime.sendMessage as jest.MockedFunction<
+  typeof runtime.sendMessage
+>;
+
+const action = sdkMethod.signResponse(
+  { signatureHex: 'deadbeef', cancelled: false },
+  { requestId: 'req-1' }
+);
+
+describe('sendSdkResponseToSpecificTab (UI→background forwarder)', () => {
+  beforeEach(() => {
+    sendMessageMock.mockReset();
+  });
+
+  it('forwards the response to the background as an SDK_RESPONSE_TO_TAB message', async () => {
+    sendMessageMock.mockResolvedValue(undefined);
+
+    await sendSdkResponseToSpecificTab(action, 7);
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageMock).toHaveBeenCalledWith({
+      type: SDK_RESPONSE_TO_TAB,
+      action,
+      tabId: 7
+    });
+  });
+
+  it('always resolves even when runtime.sendMessage REJECTS (SW torn down mid-flight)', async () => {
+    // Regression: callers `await` this then closeCurrentWindow() with no
+    // try/catch, so a rejection must never propagate — else the window hangs.
+    sendMessageMock.mockRejectedValue(
+      new Error('Extension context invalidated')
+    );
+
+    await expect(
+      sendSdkResponseToSpecificTab(action, 7)
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/background/send-sdk-response-to-specific-tab.ts
+++ b/src/background/send-sdk-response-to-specific-tab.ts
@@ -1,21 +1,28 @@
-import { tabs } from 'webextension-polyfill';
+import { runtime } from 'webextension-polyfill';
 
 import { SdkMethod } from '@content/sdk-method';
 
-export async function sendSdkResponseToSpecificTab(
-  action: SdkMethod,
-  tabId: number
-) {
-  if (!Number.isInteger(tabId) || tabId < 0) {
-    console.error('sendSdkResponseToSpecificTab: invalid tabId', tabId);
-    return;
-  }
+// Message type for the UI→background forwarder. The UI no longer talks to the
+// dapp tab directly; it hands the response to the background, which dedupes by
+// `requestId` (first response for a request wins) and performs the actual
+// `tabs.sendMessage`. See `handlers/sdk-response-to-tab.ts`.
+export const SDK_RESPONSE_TO_TAB = 'CasperWallet:SdkResponseToTab';
 
-  try {
-    await tabs.sendMessage(tabId, action);
-  } catch (err) {
-    console.warn('sendSdkResponseToSpecificTab: delivery failed', err);
-  }
+export interface SdkResponseToTabMessage {
+  type: typeof SDK_RESPONSE_TO_TAB;
+  action: SdkMethod;
+  tabId: number;
+}
+
+export function sendSdkResponseToSpecificTab(action: SdkMethod, tabId: number) {
+  // Route through the background so it can dedupe by requestId atomically
+  // (the background store is the single writer). Returns the sendMessage
+  // promise so callers that `await` before closing the window still resolve.
+  return runtime.sendMessage({
+    type: SDK_RESPONSE_TO_TAB,
+    action,
+    tabId
+  } as SdkResponseToTabMessage);
 }
 
 export function parseRequestTabId(

--- a/src/background/send-sdk-response-to-specific-tab.ts
+++ b/src/background/send-sdk-response-to-specific-tab.ts
@@ -18,11 +18,21 @@ export function sendSdkResponseToSpecificTab(action: SdkMethod, tabId: number) {
   // Route through the background so it can dedupe by requestId atomically
   // (the background store is the single writer). Returns the sendMessage
   // promise so callers that `await` before closing the window still resolve.
-  return runtime.sendMessage({
-    type: SDK_RESPONSE_TO_TAB,
-    action,
-    tabId
-  } as SdkResponseToTabMessage);
+  //
+  // The `.catch` restores the always-resolves contract of the pre-reroute
+  // implementation: callers (approve-connection / switch-account /
+  // select-account) `await` this then `closeCurrentWindow()` with no try/catch,
+  // so a rejection (e.g. the service worker torn down mid-flight) must NOT
+  // propagate — otherwise the approval window would never close.
+  return runtime
+    .sendMessage({
+      type: SDK_RESPONSE_TO_TAB,
+      action,
+      tabId
+    } as SdkResponseToTabMessage)
+    .catch(err =>
+      console.warn('sendSdkResponseToSpecificTab: forward failed', err)
+    );
 }
 
 export function parseRequestTabId(

--- a/src/background/utils.test.ts
+++ b/src/background/utils.test.ts
@@ -1,0 +1,190 @@
+import { Tabs, tabs } from 'webextension-polyfill';
+
+import { SdkEvent, sdkEvent } from '@content/sdk-event';
+
+import {
+  emitSdkEventToActiveTabs,
+  emitSdkEventToActiveTabsWithOrigin
+} from './utils';
+
+jest.mock('webextension-polyfill', () => ({
+  tabs: {
+    query: jest.fn(),
+    sendMessage: jest.fn()
+  }
+}));
+
+const queryMock = tabs.query as jest.MockedFunction<typeof tabs.query>;
+const sendMessageMock = tabs.sendMessage as jest.MockedFunction<
+  typeof tabs.sendMessage
+>;
+
+function makeTab(overrides: Partial<Tabs.Tab>): Tabs.Tab {
+  return {
+    index: 0,
+    highlighted: false,
+    active: true,
+    pinned: false,
+    incognito: false,
+    ...overrides
+  } as Tabs.Tab;
+}
+
+const testAction: SdkEvent = sdkEvent.lockedEvent({
+  isLocked: true,
+  isConnected: undefined,
+  activeKey: undefined,
+  activeKeySupports: undefined
+});
+
+describe('emitSdkEventToActiveTabs', () => {
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    queryMock.mockReset();
+    sendMessageMock.mockReset();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('sends to every active http tab whose callback returns an action', async () => {
+    const tab1 = makeTab({ id: 1, url: 'https://foo.com' });
+    const tab2 = makeTab({ id: 2, url: 'https://bar.com' });
+    queryMock.mockResolvedValue([tab1, tab2]);
+    sendMessageMock.mockResolvedValue(undefined);
+
+    await emitSdkEventToActiveTabs(() => testAction);
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(2);
+    expect(sendMessageMock).toHaveBeenCalledWith(1, testAction);
+    expect(sendMessageMock).toHaveBeenCalledWith(2, testAction);
+  });
+
+  it('skips non-http tabs and tabs where callback returns null/undefined', async () => {
+    const httpTab = makeTab({ id: 1, url: 'https://foo.com' });
+    const nonHttpTab = makeTab({ id: 2, url: 'chrome-extension://abc' });
+    const noActionTab = makeTab({ id: 3, url: 'https://baz.com' });
+    queryMock.mockResolvedValue([httpTab, nonHttpTab, noActionTab]);
+    sendMessageMock.mockResolvedValue(undefined);
+
+    await emitSdkEventToActiveTabs(tab => {
+      if (tab.id === 3) return undefined;
+      return testAction;
+    });
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageMock).toHaveBeenCalledWith(1, testAction);
+  });
+
+  it('isolates a failing tab: second tab still receives its send and the function resolves', async () => {
+    const failingTab = makeTab({ id: 1, url: 'https://foo.com' });
+    const okTab = makeTab({ id: 2, url: 'https://bar.com' });
+    queryMock.mockResolvedValue([failingTab, okTab]);
+    sendMessageMock.mockImplementation(async tabId => {
+      if (tabId === 1) {
+        throw new Error('Receiving end does not exist');
+      }
+      return undefined;
+    });
+
+    await expect(
+      emitSdkEventToActiveTabs(() => testAction)
+    ).resolves.toBeUndefined();
+
+    expect(sendMessageMock).toHaveBeenCalledWith(1, testAction);
+    expect(sendMessageMock).toHaveBeenCalledWith(2, testAction);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('skips a tab without an id instead of throwing', async () => {
+    const noIdTab = makeTab({ url: 'https://foo.com' });
+    const okTab = makeTab({ id: 2, url: 'https://bar.com' });
+    queryMock.mockResolvedValue([noIdTab, okTab]);
+    sendMessageMock.mockResolvedValue(undefined);
+
+    await expect(
+      emitSdkEventToActiveTabs(() => testAction)
+    ).resolves.toBeUndefined();
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageMock).toHaveBeenCalledWith(2, testAction);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});
+
+describe('emitSdkEventToActiveTabsWithOrigin', () => {
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    queryMock.mockReset();
+    sendMessageMock.mockReset();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('sends only to tabs whose origin matches', async () => {
+    const matchingTab = makeTab({ id: 1, url: 'https://foo.com/page' });
+    const otherOriginTab = makeTab({ id: 2, url: 'https://bar.com/page' });
+    queryMock.mockResolvedValue([matchingTab, otherOriginTab]);
+    sendMessageMock.mockResolvedValue(undefined);
+
+    await emitSdkEventToActiveTabsWithOrigin('https://foo.com', testAction);
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageMock).toHaveBeenCalledWith(1, testAction);
+  });
+
+  it('does not query or send when origin is empty', async () => {
+    await emitSdkEventToActiveTabsWithOrigin('', testAction);
+
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('isolates a failing tab: second matching tab still receives its send and the function resolves', async () => {
+    const failingTab = makeTab({ id: 1, url: 'https://foo.com/a' });
+    const okTab = makeTab({ id: 2, url: 'https://foo.com/b' });
+    queryMock.mockResolvedValue([failingTab, okTab]);
+    sendMessageMock.mockImplementation(async tabId => {
+      if (tabId === 1) {
+        throw new Error('Receiving end does not exist');
+      }
+      return undefined;
+    });
+
+    await expect(
+      emitSdkEventToActiveTabsWithOrigin('https://foo.com', testAction)
+    ).resolves.toBeUndefined();
+
+    expect(sendMessageMock).toHaveBeenCalledWith(1, testAction);
+    expect(sendMessageMock).toHaveBeenCalledWith(2, testAction);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('skips a tab without an id instead of throwing', async () => {
+    const noIdTab = makeTab({ url: 'https://foo.com/a' });
+    const okTab = makeTab({ id: 2, url: 'https://foo.com/b' });
+    queryMock.mockResolvedValue([noIdTab, okTab]);
+    sendMessageMock.mockResolvedValue(undefined);
+
+    await expect(
+      emitSdkEventToActiveTabsWithOrigin('https://foo.com', testAction)
+    ).resolves.toBeUndefined();
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageMock).toHaveBeenCalledWith(2, testAction);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/src/background/utils.ts
+++ b/src/background/utils.ts
@@ -11,20 +11,27 @@ export async function emitSdkEventToActiveTabs(
     active: true
   });
 
-  tabsList.forEach(async tab => {
-    if (tab.id) {
-      // skip non http windows
-      if (tab.url && hasHttpPrefix(tab.url)) {
-        const action = callback(tab);
-        if (action == null) {
-          return;
+  await Promise.all(
+    tabsList.map(async tab => {
+      if (tab.id) {
+        // skip non http windows
+        if (tab.url && hasHttpPrefix(tab.url)) {
+          const action = callback(tab);
+          if (action == null) {
+            return;
+          }
+          try {
+            await tabs.sendMessage(tab.id, action);
+          } catch (error) {
+            console.warn('Failed to send SDK event to tab: ' + tab.id, error);
+          }
         }
-        tabs.sendMessage(tab.id, action);
+      } else {
+        console.error('Tab without id: ' + tab);
+        return;
       }
-    } else {
-      throw Error('Tab without id: ' + tab);
-    }
-  });
+    })
+  );
 }
 
 export async function emitSdkEventToActiveTabsWithOrigin(
@@ -39,18 +46,25 @@ export async function emitSdkEventToActiveTabsWithOrigin(
     active: true
   });
 
-  tabsList.forEach(async tab => {
-    if (tab.id) {
-      // skip non http windows
-      if (
-        tab.url &&
-        hasHttpPrefix(tab.url) &&
-        getUrlOrigin(tab.url) === origin
-      ) {
-        tabs.sendMessage(tab.id, action);
+  await Promise.all(
+    tabsList.map(async tab => {
+      if (tab.id) {
+        // skip non http windows
+        if (
+          tab.url &&
+          hasHttpPrefix(tab.url) &&
+          getUrlOrigin(tab.url) === origin
+        ) {
+          try {
+            await tabs.sendMessage(tab.id, action);
+          } catch (error) {
+            console.warn('Failed to send SDK event to tab: ' + tab.id, error);
+          }
+        }
+      } else {
+        console.error('Tab without id: ' + tab);
+        return;
       }
-    } else {
-      throw Error('Tab without id: ' + tab);
-    }
-  });
+    })
+  );
 }

--- a/src/background/utils.ts
+++ b/src/background/utils.ts
@@ -28,7 +28,6 @@ export async function emitSdkEventToActiveTabs(
         }
       } else {
         console.error('Tab without id: ' + tab);
-        return;
       }
     })
   );
@@ -63,7 +62,6 @@ export async function emitSdkEventToActiveTabsWithOrigin(
         }
       } else {
         console.error('Tab without id: ' + tab);
-        return;
       }
     })
   );

--- a/src/fixtures/initial-state-for-popup-tests.ts
+++ b/src/fixtures/initial-state-for-popup-tests.ts
@@ -74,7 +74,8 @@ export const initialStateForPopupTests: RootState = {
     eip712ById: {}
   },
   windowManagement: {
-    windowId: null
+    windowId: null,
+    requests: {}
   },
   ledger: {
     windowId: null,


### PR DESCRIPTION
## DEP-99 · PR 2 of 8 — P0.5: window state into Redux + duplicate-response root cause

Jira: [WALLET-1343](https://make-software.atlassian.net/browse/WALLET-1343)

Moves approval-window state into the Redux `windowManagement` slice (retiring a parallel module-level
closure) and fixes the duplicate SDK-response race at its root by deduplicating server-side, keyed by
`requestId`, instead of relying on fragile per-page UI guards.

### Commits

| Commit     | Change                                                                                                                                                                                                                                                                                                                                         |
| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `13f896c0` | `windowManagement` slice → request state machine: `requests: Record<requestId, 'open'\|'responded'\|'closed'>`, actions `windowRequestOpened`/`windowRequestResponded`/`windowClosed`, selector `selectRequestStatus`.                                                                                                                         |
| `f0c1ed2c` | Background `open-window.ts` sources/writes `windowId` through the slice (deletes the module-level `let windowId` closure — the second source of truth); the leaky per-creation `windows.onRemoved` listener (fired on _any_ window close) replaced by ONE init-time listener that dispatches `windowClosed()` only on id-match.                |
| `73060a62` | SDK responses rerouted UI→background→tab (`SDK_RESPONSE_TO_TAB`). The background dedupes by `requestId` — marks `responded` **optimistically before** the `await tabs.sendMessage`, so two interleaved responses (e.g. a sign followed by the `beforeunload` cancel) can't both deliver. `responseSentRef` removed from all 4 signature pages. |
| `9fda015e` | `emitSdkEventToActiveTabs`/`WithOrigin` now `await Promise.all` with per-tab error isolation (one tab lacking a content-script listener no longer aborts the broadcast).                                                                                                                                                                       |
| `9df9da11` | `sendSdkResponseToSpecificTab` restored to an always-resolves contract (a mid-flight SW teardown must not leave an approval window open on the `await` sites).                                                                                                                                                                                 |

### Dedupe design note

The guard drops a response **only when status is `'responded'`**, never on `'closed'`. A `beforeunload`
cancel and the `windows.onRemoved`→`windowClosed()` transition race; dropping on `'closed'` could
suppress a legitimate cancel for a window closed without a prior response. First-response-wins (drop on
`'responded'`, marked synchronously before the send) is the atomic, race-safe rule.

### Manifest / CSP / permissions

No change — this PR touches only `src/background/*` and the signature/connect UI pages; no manifest,
CSP, DNR, or content-script-entry edit. (extension-manifest-reviewer not required for this PR.)

### Verification

- ✅ `npm run ci-check` green (36 suites / 183 tests; tsc + lint clean).
- ✅ `npm run build:chrome` and `npm run build:firefox` (webpack prod) exit 0.
- ✅ Each task individually reviewed + a whole-branch review (Ready to merge).
- ⬜ **Manual QA (owner: reviewer)** — window lifecycle + dedupe are integration-level:
  1. **duplicate-cancel repro** — sign a deploy, let the approval window close → dapp gets EXACTLY ONE response (the signature), no trailing cancel.
  2. Cancel (close without signing) → exactly one cancel.
  3. All flows deliver: connect / sign / signMessage / signTypedData / decrypt / switchAccount.
  4. Approval window **reuse** (second sign while one is open reuses the window) and **fresh-after-close**; unrelated browser-window close does NOT clear tracking.
  5. Reload the approval window mid-flow → exactly one response reaches the dapp.
- ⬜ **Safari build** (`build:safari`) — needs Xcode, not run in CI here.

### Follow-up (non-blocking, from whole-branch review)

- `requests` map entries for connect/switch requests linger until SW restart (harmless — the slice is not persisted, so it resets each SW session). A future prune could drop terminal entries.
- **Dedupe is not restart-durable (acknowledged, low-likelihood residual).** Because `windowManagement` is not persisted, an MV3 service-worker restart in the millisecond gap between a sign response and the `beforeunload` cancel resets `requests` to `{}` — both responses then read status `undefined` and can be delivered, reintroducing the exact duplicate this PR removes. Same root cause as the linger note above (non-persisted slice). The old page-scoped `responseSentRef` survived SW restarts, so this is a slight robustness trade-off in that narrow window; keep-alive + the tiny sign→cancel gap make it unlikely in practice, and #1395's synthetic-error-on-send covers the request path, not this response path. Persisting terminal request statuses would close it if it ever surfaces.

### Review fixups (this branch, post-review)

- **Sender gate on the response reroute** (review #2, was optional): `handleSdkResponseToTab` now runs outside the uniform handler loop and is gated on `isTrustedUiSender(sender)` — mirroring `handleLegacyImport`. Belt-and-suspenders on top of the P0.2 private-channel + `SDK_REQUEST_TYPES` allowlist; an untrusted sender is silently dropped.
- **Nits** (review #3): `open-window.ts` fire-and-forget `createOpenWindow(...)(props)` now has a `.catch` (no unhandled rejection if `windows.create` fails); removed the dead trailing `return;` in both `emitSdkEventToActiveTabs*` `.map` callbacks in `utils.ts`.
- `npm run ci-check` green (36 suites / 184 tests; +1 untrusted-sender test).

### Base branch

Branches off `release/2.6.0` (DEP-16 already merged).

[WALLET-1343]: https://make-software.atlassian.net/browse/WALLET-1343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
