### PR TITLE
fix: DEP-99 — manifest hardening + Firefox e2e smoke after DNR Referer audit (WALLET-1343)

### DIFF
--- a/e2e-tests/firefox/smoke.spec.ts
+++ b/e2e-tests/firefox/smoke.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test } from '@playwright/test';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { download as downloadGeckodriver } from 'geckodriver';
+import os from 'os';
+import path from 'path';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { Builder } from 'selenium-webdriver';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import {
+  Driver as FirefoxDriver,
+  Options,
+  ServiceBuilder
+} from 'selenium-webdriver/firefox';
+
+/**
+ * Firefox e2e smoke — the DNR Referer rewrite on a real Firefox build.
+ *
+ * Three assertions (per the Task 5.4 brief):
+ *   1. Firefox launches with the built extension loaded (temporary install).
+ *   2. An extension page (popup.html) opens under the moz-extension:// origin.
+ *   3. `fetch('https://node.cspr.cloud/rpc', …)` from that extension page
+ *      returns HTTP 200. It returns 401 if the extension's declarativeNetRequest
+ *      rule did NOT rewrite the Referer header — so a 200 proves the rewrite
+ *      fired on the real Firefox build (Task 5.1 audit: the API authenticates by
+ *      `Referer: https://casperwallet.io`).
+ */
+
+const FIREFOX_BINARY =
+  process.env.FIREFOX_BINARY ??
+  '/Applications/Firefox.app/Contents/MacOS/firefox';
+
+const BUILD_DIR = path.join(__dirname, '..', '..', 'build', 'firefox');
+
+// A fixed add-on id we inject into the *build copy's* manifest (never src/), so
+// that we can pre-seed a deterministic internal UUID for the extension origin.
+const ADDON_ID = 'casper-wallet-e2e@casperwallet.io';
+// Any fixed UUID works; Firefox reuses it from the pref instead of randomising.
+const EXTENSION_UUID = 'b6b1a2c0-4d3e-4f5a-8b7c-000000001343';
+
+const RPC_URL = 'https://node.cspr.cloud/rpc';
+
+let driver: FirefoxDriver | undefined;
+let tmpDir: string | undefined;
+
+/**
+ * Copy the built extension to a temp dir, inject a fixed gecko add-on id into
+ * its manifest.json, and zip it into an unsigned .xpi. A fixed id is required so
+ * the pre-seeded `extensions.webextensions.uuids` pref maps to it and the
+ * moz-extension origin becomes deterministic (avoids the random-UUID discovery
+ * problem after a temporary install).
+ */
+function buildXpi(): { xpiPath: string; tmpDir: string } {
+  if (!fs.existsSync(path.join(BUILD_DIR, 'manifest.json'))) {
+    throw new Error(
+      `Firefox build not found at ${BUILD_DIR}. Run \`npm run build:firefox\` first.`
+    );
+  }
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cw-firefox-smoke-'));
+  const stageDir = path.join(dir, 'ext');
+  fs.cpSync(BUILD_DIR, stageDir, { recursive: true });
+
+  const manifestPath = path.join(stageDir, 'manifest.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+  manifest.browser_specific_settings = manifest.browser_specific_settings ?? {};
+  manifest.browser_specific_settings.gecko = {
+    ...(manifest.browser_specific_settings.gecko ?? {}),
+    id: ADDON_ID
+  };
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+
+  const xpiPath = path.join(dir, 'casper-wallet-firefox.xpi');
+  // manifest.json must live at the archive root, so zip from inside stageDir.
+  execFileSync('zip', ['-r', '-X', '-q', xpiPath, '.'], { cwd: stageDir });
+
+  return { xpiPath, tmpDir: dir };
+}
+
+test.afterAll(async () => {
+  if (driver) {
+    await driver.quit();
+  }
+  if (tmpDir) {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('Firefox loads the extension and the DNR Referer rewrite makes RPC return 200', async () => {
+  const built = buildXpi();
+  tmpDir = built.tmpDir;
+
+  const geckodriverPath = await downloadGeckodriver();
+
+  const options = new Options();
+  options.setBinary(FIREFOX_BINARY);
+  options.addArguments('-headless');
+  // Pre-seed the internal UUID so the extension origin is known up-front.
+  options.setPreference(
+    'extensions.webextensions.uuids',
+    JSON.stringify({ [ADDON_ID]: EXTENSION_UUID })
+  );
+  // Reduce first-run noise / network chatter that could interfere.
+  options.setPreference('app.update.enabled', false);
+  options.setPreference('datareporting.policy.dataSubmissionEnabled', false);
+  options.setPreference('toolkit.telemetry.enabled', false);
+  options.setPreference('extensions.getAddons.cache.enabled', false);
+
+  const service = new ServiceBuilder(geckodriverPath);
+
+  // `Builder#build()` is typed to return the base `WebDriver`, but configuring
+  // `forBrowser('firefox')` with a Firefox `ServiceBuilder` makes it construct
+  // a `firefox.Driver` under the hood — the narrowing below reflects that
+  // runtime fact so `installAddon` (Firefox-only) type-checks honestly.
+  driver = (await new Builder()
+    .forBrowser('firefox')
+    .setFirefoxOptions(options)
+    .setFirefoxService(service)
+    .build()) as FirefoxDriver;
+
+  // Assertion 1: Firefox launched with the built extension loaded.
+  const installedId = await driver.installAddon(built.xpiPath, true);
+  expect(installedId).toBeTruthy();
+
+  // Assertion 2: an extension page opens under the pre-seeded origin.
+  const popupUrl = `moz-extension://${EXTENSION_UUID}/popup.html`;
+  await driver.get(popupUrl);
+  const currentUrl = await driver.getCurrentUrl();
+  expect(currentUrl).toBe(popupUrl);
+
+  // Assertion 3: RPC from the extension page returns 200 => DNR rewrite fired.
+  const result = (await driver.executeAsyncScript(
+    `
+      const done = arguments[arguments.length - 1];
+      fetch(${JSON.stringify(RPC_URL)}, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{"jsonrpc":"2.0","method":"info_get_status","id":1}'
+      })
+        .then(r => done({ status: r.status }))
+        .catch(e => done({ status: -1, error: String(e && e.message || e) }));
+    `
+  )) as { status: number; error?: string };
+
+  // eslint-disable-next-line no-console
+  console.log('[firefox-smoke] RPC result:', JSON.stringify(result));
+
+  expect(
+    result.error,
+    `fetch threw instead of completing: ${result.error}`
+  ).toBeUndefined();
+  expect(
+    result.status,
+    'RPC returned 401 => the DNR Referer rewrite did NOT apply on this Firefox build'
+  ).toBe(200);
+});

--- a/e2e-tests/tsconfig.json
+++ b/e2e-tests/tsconfig.json
@@ -3,5 +3,9 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["**/*.ts", "../playwright.config.ts"]
+  "include": [
+    "**/*.ts",
+    "../playwright.config.ts",
+    "../playwright.firefox.config.ts"
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "@types/node": "^22.0.0",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "@types/selenium-webdriver": "^4.35.6",
         "concurrently": "7.6.0",
         "confusing-browser-globals": "^1.0.11",
         "copy-webpack-plugin": "^14.0.0",
@@ -89,6 +90,7 @@
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "fs-extra": "11.3.4",
+        "geckodriver": "^6.1.0",
         "globals": "^15.15.0",
         "html-loader": "^5.1.0",
         "html-webpack-plugin": "^5.6.6",
@@ -101,6 +103,7 @@
         "markdownlint-cli": "0.49.0",
         "playwright": "^1.61.0",
         "prettier": "^3.9.3",
+        "selenium-webdriver": "^4.45.0",
         "style-loader": "^4.0.0",
         "terser-webpack-plugin": "^5.6.1",
         "ts-jest": "^29.4.11",
@@ -1286,6 +1289,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bazel/runfiles": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@bazel/runfiles/-/runfiles-6.5.0.tgz",
+      "integrity": "sha512-RzahvqTkfpY2jsDxo8YItPX+/iZ6hbiikw1YhE0bA9EKBR5Og8Pa6FHn9PO9M0zaXRVsr0GFQLKbB/0rzy9SzA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -6261,6 +6271,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/selenium-webdriver": {
+      "version": "4.35.6",
+      "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-4.35.6.tgz",
+      "integrity": "sha512-8nfyMRi4VvkY9QrQGyY/zkleAhnjnmE8YtdEeoCrWe3izp1P9vo9f5VTNRYF0up+l+kn+VuZah+je+bLddNV+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ws": "*"
+      }
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -7073,6 +7094,52 @@
         "weakmap-polyfill": "2.0.4"
       }
     },
+    "node_modules/@wdio/logger": {
+      "version": "9.29.1",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.29.1.tgz",
+      "integrity": "sha512-0ZAEIo6PNyMIJPlOGkIgyOJUjcd0pC8/QHlVAAe1c91/IcjZ1X+k0yidXHaboJdN7dq1XPUacmhRdtua0U5EZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/logger/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@wdio/logger/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -7230,6 +7297,18 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.8.26",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.26.tgz",
+      "integrity": "sha512-RQ4h9F6DOiHxpdocUDrOl6xBM+yOtz+LkUol47AVWcfebGBDpZ7w7Xvz9PS24JgXvLGiXXzSAfdCdVy1tPlaFA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@zondax/ledger-casper": {
       "version": "2.6.4",
@@ -13613,6 +13692,52 @@
         "node": ">=8"
       }
     },
+    "node_modules/geckodriver": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-6.1.0.tgz",
+      "integrity": "sha512-ZRXLa4ZaYTTgUO4Eefw+RsQCleugU2QLb1ME7qTYxxuRj51yAhfnXaItXNs5/vUzfIaDHuZ+YnSF005hfp07nQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/logger": "^9.18.0",
+        "@zip.js/zip.js": "^2.8.11",
+        "decamelize": "^6.0.1",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "modern-tar": "^0.7.2"
+      },
+      "bin": {
+        "geckodriver": "bin/geckodriver.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/geckodriver/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/geckodriver/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/generator-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -14592,6 +14717,30 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/http-proxy-middleware": {
@@ -19102,6 +19251,13 @@
         "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
+    "node_modules/loglevel-plugin-prefix": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
+      "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
@@ -20530,6 +20686,16 @@
       "license": "MIT",
       "engines": {
         "node": "20 || 22 || 24"
+      }
+    },
+    "node_modules/modern-tar": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
+      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/morgan": {
@@ -23364,6 +23530,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -23601,6 +23777,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -23672,6 +23871,32 @@
       "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/selenium-webdriver": {
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.45.0.tgz",
+      "integrity": "sha512-Cb2nqvJiwXVOtRTCYHX9D1FJR5+Ls7aL3Nev0t6n4CpXsQ//YGiiUmSCbvTDDeLtbV85SZ46qmLab4SIYKXWRw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/SeleniumHQ"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/selenium"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bazel/runfiles": "^6.5.0",
+        "jszip": "^3.10.1",
+        "tmp": "^0.2.7",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      }
     },
     "node_modules/selfsigned": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "e2e:chrome:headless:onboarding": "TEST_ENV=true npm run build:chrome && PLAYWRIGHT_BROWSER=chromium npx playwright test e2e-tests/onboarding-flow --project chromium",
     "e2e:chrome:ui:onboarding": "TEST_ENV=true npm run build:chrome && PLAYWRIGHT_BROWSER=chromium npx playwright test e2e-tests/onboarding-flow --ui --project chromium",
     "e2e:chrome:headless:popup": "TEST_ENV=true MOCK_STATE=true npm run build:chrome && PLAYWRIGHT_BROWSER=chromium npx playwright test e2e-tests/popup --project chromium",
-    "e2e:chrome:ui:popup": "TEST_ENV=true MOCK_STATE=true npm run build:chrome && PLAYWRIGHT_BROWSER=chromium npx playwright test e2e-tests/popup --ui --project chromium"
+    "e2e:chrome:ui:popup": "TEST_ENV=true MOCK_STATE=true npm run build:chrome && PLAYWRIGHT_BROWSER=chromium npx playwright test e2e-tests/popup --ui --project chromium",
+    "e2e:firefox:headless:smoke": "TEST_ENV=true npm run build:firefox && npx playwright test --config playwright.firefox.config.ts"
   },
   "lint-staged": {
     "*.md": "markdownlint",
@@ -139,6 +140,7 @@
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@types/selenium-webdriver": "^4.35.6",
     "concurrently": "7.6.0",
     "confusing-browser-globals": "^1.0.11",
     "copy-webpack-plugin": "^14.0.0",
@@ -152,6 +154,7 @@
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "fs-extra": "11.3.4",
+    "geckodriver": "^6.1.0",
     "globals": "^15.15.0",
     "html-loader": "^5.1.0",
     "html-webpack-plugin": "^5.6.6",
@@ -164,6 +167,7 @@
     "markdownlint-cli": "0.49.0",
     "playwright": "^1.61.0",
     "prettier": "^3.9.3",
+    "selenium-webdriver": "^4.45.0",
     "style-loader": "^4.0.0",
     "terser-webpack-plugin": "^5.6.1",
     "ts-jest": "^29.4.11",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './e2e-tests',
+  testIgnore: '**/firefox/**',
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright.firefox.config.ts
+++ b/playwright.firefox.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from '@playwright/test';
+
+/**
+ * Firefox e2e smoke harness (WALLET-1343 / DEP-99, Task 5.4 spike).
+ *
+ * This config does NOT use Playwright's browser automation. Playwright cannot
+ * install a temporary extension into its bundled Firefox and cannot attach to a
+ * system Firefox, so the smoke drives a real Firefox 152 via selenium-webdriver
+ * + geckodriver (see e2e-tests/firefox/smoke.spec.ts). We reuse the Playwright
+ * test runner purely for TypeScript execution, test structure and `expect`.
+ *
+ * Kept separate from the Chrome config (playwright.config.ts) so the two suites
+ * never share projects/fixtures.
+ */
+export default defineConfig({
+  testDir: './e2e-tests/firefox',
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: 'list',
+  // Firefox cold-start + geckodriver download + temporary install + a live RPC
+  // round-trip. Generous so a slow network doesn't produce a flaky failure.
+  timeout: 180_000
+});

--- a/src/manifest.v2.json
+++ b/src/manifest.v2.json
@@ -35,6 +35,11 @@
       }
     ]
   },
+  "browser_specific_settings": {
+    "gecko": {
+      "strict_min_version": "113.0"
+    }
+  },
   "background": {
     "scripts": ["./background.bundle.js"],
     "persistent": true

--- a/src/manifest.v2.safari.json
+++ b/src/manifest.v2.safari.json
@@ -13,6 +13,7 @@
     "tabs",
     "declarativeNetRequest",
     "https://image-proxy-cdn.make.services/*",
+    "https://casper-assets.s3.amazonaws.com/*",
     "https://api.testnet.casperwallet.io/*",
     "https://api.mainnet.casperwallet.io/*",
     "https://onramp-api.cspr.click/api/*",

--- a/src/manifest.v3.json
+++ b/src/manifest.v3.json
@@ -7,13 +7,13 @@
     "192": "logo192.png"
   },
   "permissions": [
-    "background",
     "management",
     "storage",
     "tabs",
     "declarativeNetRequest",
     "alarms"
   ],
+  "minimum_chrome_version": "92",
   "declarative_net_request": {
     "rule_resources": [
       {
@@ -36,6 +36,8 @@
     "https://cspr-api-gateway.dev.make.services/cspr-node-proxy-rpc-dev-condor/*",
     "https://api.integration.casperwallet.io/*",
     "https://node.integration.cspr.cloud/*",
+    "https://casper-assets.s3.amazonaws.com/*",
+    "https://onramp-api.cspr.click/api/*",
     "https://*.bringweb3.io/*"
   ],
   "background": {


### PR DESCRIPTION
## Summary

PR 5 of the DEP-99 security & architecture backlog ([WALLET-1343](https://make-software.atlassian.net/browse/WALLET-1343)): empirical audit of the DNR `Referer` rewrite (P0.4), manifest permission + version hardening (P1.5 b/c/d), and a Firefox e2e smoke harness that proves the rewrite on a real Firefox build.

**Scope change vs the appendix, driven by evidence:** the planned MV2 `webRequest` Referer listener was **not built**. The empirical audit below shows the DNR rules work on Firefox ≥ 113, so the fix is to keep DNR as the single cross-browser mechanism and pin browser version floors instead of adding a second header-rewrite path.

## Empirical DNR audit (P0.4)

**1. The API servers really do require `Referer: https://casperwallet.io`** (curl, 2026-07-08):

| Endpoint                                    | without Referer | with Referer                   |
| ------------------------------------------- | --------------- | ------------------------------ |
| `api.mainnet.casperwallet.io/accounts/<pk>` | 403             | 404 (auth passed, unknown key) |
| `api.testnet.casperwallet.io/accounts/<pk>` | 403             | 200                            |
| `api.casperwallet.io/accounts/<pk>`         | 403             | 404                            |
| `node.cspr.cloud/rpc` (`info_get_status`)   | 401             | 200                            |
| `node.testnet.cspr.cloud/rpc`               | 401             | 200                            |

The in-code attempts are both no-ops in a browser: `casper-js-sdk`'s `setReferrer()` sets the fetch `referrer` option (cross-origin value → dropped), and `casper-wallet-core`'s `CSPR_API_PROXY_HEADERS` passes `Referer` as a plain fetch header (forbidden header name → silently dropped). DNR is the only mechanism that works.

**2. DNR `modifyHeaders` is NOT dead on Firefox MV2** — it works on Firefox ≥ 113 (May 2023). Verified with a minimal MV2 extension declaring the wallet's exact rule, headless Firefox 152.0.4: with the rule → HTTP 200; control without the rule (same session) → 403. MDN BCD agrees: `declarative_net_request` + `RuleAction.requestHeaders` = Firefox 113, Safari 16.4.

**Verdict:** keep the DNR rules everywhere; pin the floors that make them guaranteed to apply. Firefox < 113 has no DNR at all, so every API call there already fails with 401/403 today — `strict_min_version` converts that silent breakage into an explicit install floor.

## Manifest changes

- **manifest.v3.json (Chrome):** removed invalid `"background"` permission; added `minimum_chrome_version: "92"`; added `https://casper-assets.s3.amazonaws.com/*` and `https://onramp-api.cspr.click/api/*` to `host_permissions` (parity with MV2 manifests and the prod CSP `connect-src`).
- **manifest.v2.json (Firefox):** added `browser_specific_settings.gecko.strict_min_version: "113.0"`.
- **manifest.v2.safari.json:** added `https://casper-assets.s3.amazonaws.com/*` (parity).

Audit decisions (recorded per the plan):

- `management` **kept** — real usage: `management?.onEnabled?.addListener(init)` in `src/background/index.ts:78`.
- `https://*.bringweb3.io/*` wildcard **kept** (v3-only, matching the Chrome-only bringweb3 feature): runtime code calls `api.bringweb3.io`; the vendor kit documents dynamic subdomains. The prod CSP `connect-src` remains the tighter runtime bound.
- `minimum_chrome_version: "92"` = highest floor of adopted APIs: MV3 (88), `chrome.alarms` (88), DNR `modifyHeaders` (86), plus `crypto.randomUUID` (92) arriving via #1395 on this release train. **If #1395 slips off 2.6.0, relax to "88".**
- Safari: BCD says DNR `modifyHeaders` needs Safari 16.4+; there is no manifest min-version mechanism for Safari — needs owner verification on hardware (Safari also has no blocking `webRequest`, so no alternative exists there).

## Firefox e2e smoke harness

`npm run e2e:firefox:headless:smoke` — builds the Firefox extension, then drives a real headless Firefox via `selenium-webdriver` + `geckodriver` (new devDependencies), wired through the Playwright runner (`playwright.firefox.config.ts`, spec in `e2e-tests/firefox/`). The plan's "web-ext + Playwright attach" guess was not viable (Playwright cannot attach to a non-Playwright Firefox or install extensions).

Asserts: extension installs as a temporary add-on → `popup.html` opens (deterministic `moz-extension://` origin via a fixed gecko id injected into a **build copy** + pre-seeded `extensions.webextensions.uuids`) → an RPC to `node.cspr.cloud/rpc` from the extension page returns **200**, which is only possible if the DNR Referer rewrite fired (the server 401s without it — see audit). Result: 1 passed.

Notes: the smoke hits the live `node.cspr.cloud` endpoint (CI needs outbound network); `geckodriver` downloads its binary on demand; Firefox path defaults to macOS with a `FIREFOX_BINARY` override; `zip` CLI assumed on PATH.

## Verification

- `npm run ci-check` green (format, lint, tsc, jest 158/158).
- `npx tsc -p e2e-tests --noEmit` exit 0 (kept the WALLET-1338 e2e type-checking intact; added `@types/selenium-webdriver`).
- `npm run build:chrome` / `npm run build:firefox` green; built manifests carry the changes.
- `npm run e2e:firefox:headless:smoke` → 1 passed (RPC 200 on Firefox 152).
- Reviews: `extension-manifest-reviewer` (no blockers), per-task + whole-branch code review, fix wave applied and re-verified.
- Owner gates: Safari build (Xcode) + Safari ≥ 16.4 DNR check on hardware; manual QA checklist.

## Follow-ups (out of scope, noted by reviews)

- `casper-assets.s3.amazonaws.com` has no directly greppable fetch caller (pre-existing in v2 + CSP; kept for parity) — candidate for a product-verified removal from manifests **and** CSP.
- Pre-existing drift: Safari-only `notifications` permission appears unused; `alarms` permission unused until PR 3 lands; `logo64.png` in MV2 `web_accessible_resources`.
- Smoke-harness polish: tmpdir cleanup on partial build failure, independent teardown steps, relax strict popup URL equality.

[WALLET-1343](https://make-software.atlassian.net/browse/WALLET-1343)


[WALLET-1343]: https://make-software.atlassian.net/browse/WALLET-1343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WALLET-1343]: https://make-software.atlassian.net/browse/WALLET-1343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ