### PR TITLE
fix: DEP-99 — SW keep-alive on chrome.alarms + persisted security deadlines (WALLET-1343)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,7 @@
         "markdownlint-cli": "0.49.0",
         "playwright": "^1.61.0",
         "prettier": "^3.9.3",
+        "redux-saga-test-plan": "^4.0.6",
         "style-loader": "^4.0.0",
         "terser-webpack-plugin": "^5.6.1",
         "ts-jest": "^29.4.11",
@@ -13448,6 +13449,13 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/fsm-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fsm-iterator/-/fsm-iterator-1.1.0.tgz",
+      "integrity": "sha512-hg47CNYdIGJ5m9WSKh617LHRdvJo4PiF0VkncFLwPVxKvBEQfSPd1qx/xLV/eSusewEu0C8eUFrsLsWlBgIcOg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -18915,10 +18923,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.ismatch": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+      "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
       "dev": true,
       "license": "MIT"
     },
@@ -22973,6 +22996,23 @@
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@redux-saga/core": "^1.5.0"
+      }
+    },
+    "node_modules/redux-saga-test-plan": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/redux-saga-test-plan/-/redux-saga-test-plan-4.0.6.tgz",
+      "integrity": "sha512-ESdbFoDWCeJ/EiFdUNSCGtA2CC9tnuvHDm6k06gVFa98EIeR2hpzFkGk9kJ1/hpMUnYFp+OOEEITIrZeDYBfFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fsm-iterator": "^1.1.0",
+        "lodash.isequal": "^4.5.0",
+        "lodash.ismatch": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@redux-saga/is": "^1.0.1",
+        "@redux-saga/symbols": "^1.0.1",
+        "redux-saga": "^1.0.1"
       }
     },
     "node_modules/reflect-metadata": {

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "markdownlint-cli": "0.49.0",
     "playwright": "^1.61.0",
     "prettier": "^3.9.3",
+    "redux-saga-test-plan": "^4.0.6",
     "style-loader": "^4.0.0",
     "terser-webpack-plugin": "^5.6.1",
     "ts-jest": "^29.4.11",

--- a/src/background/keep-alive.test.ts
+++ b/src/background/keep-alive.test.ts
@@ -1,0 +1,119 @@
+import { alarms, runtime } from 'webextension-polyfill';
+
+import { startKeepAlive, stopKeepAlive } from '@background/keep-alive';
+
+jest.mock('webextension-polyfill', () => ({
+  alarms: {
+    create: jest.fn(),
+    clear: jest.fn(),
+    onAlarm: {
+      addListener: jest.fn()
+    }
+  },
+  runtime: {
+    sendMessage: jest.fn().mockResolvedValue(undefined)
+  }
+}));
+
+jest.mock('@src/utils', () => ({
+  isChromeBuild: true
+}));
+
+jest.mock('@background/redux/get-main-store', () => ({
+  getExistingMainStoreSingletonOrInit: jest.fn()
+}));
+
+jest.mock('@background/redux/keys/selectors', () => ({
+  selectKeysDoesExist: jest.fn()
+}));
+
+jest.mock('@background/redux/session/selectors', () => ({
+  selectVaultIsLocked: jest.fn()
+}));
+
+jest.mock('@background/redux/vault-cipher/selectors', () => ({
+  selectVaultCipherDoesExist: jest.fn()
+}));
+
+const mockAlarmsCreate = alarms.create as jest.Mock;
+const mockAlarmsClear = alarms.clear as jest.Mock;
+const mockAlarmsOnAlarmAddListener = alarms.onAlarm.addListener as jest.Mock;
+const mockRuntimeSendMessage = runtime.sendMessage as jest.Mock;
+
+beforeAll(() => {
+  jest.spyOn(console, 'log').mockImplementation(() => undefined);
+});
+
+afterAll(() => {
+  (console.log as jest.Mock).mockRestore();
+});
+
+describe('keep-alive', () => {
+  beforeEach(() => {
+    mockAlarmsCreate.mockClear();
+    mockAlarmsClear.mockClear();
+    mockRuntimeSendMessage.mockClear();
+  });
+
+  it('startKeepAlive creates the casper-keep-alive alarm with a 0.5 minute period', () => {
+    startKeepAlive();
+
+    expect(mockAlarmsCreate).toHaveBeenCalledWith('casper-keep-alive', {
+      periodInMinutes: 0.5
+    });
+  });
+
+  it('stopKeepAlive clears the casper-keep-alive alarm', () => {
+    stopKeepAlive();
+
+    expect(mockAlarmsClear).toHaveBeenCalledWith('casper-keep-alive');
+  });
+
+  it('registers an alarms.onAlarm listener at module load time', () => {
+    expect(mockAlarmsOnAlarmAddListener).toHaveBeenCalledWith(
+      expect.any(Function)
+    );
+  });
+
+  it('the registered onAlarm listener triggers the keepAlive ping only for the casper-keep-alive alarm', () => {
+    const listener = mockAlarmsOnAlarmAddListener.mock.calls[0][0];
+
+    listener({ name: 'some-other-alarm' });
+    expect(mockRuntimeSendMessage).not.toHaveBeenCalled();
+
+    listener({ name: 'casper-keep-alive' });
+    expect(mockRuntimeSendMessage).toHaveBeenCalledWith('keepAlive');
+  });
+});
+
+// This block resets the module registry, so it must stay the last describe in
+// the file — earlier tests rely on the module instance imported at the top.
+describe('keep-alive on non-Chrome builds', () => {
+  afterEach(() => {
+    // Drop the doMock overrides so they cannot leak into later requires
+    jest.dontMock('webextension-polyfill');
+    jest.dontMock('@src/utils');
+  });
+
+  it('module loads without throwing when the alarms API is unavailable (Firefox/Safari)', () => {
+    // resetModules (not isolateModules) is required here: the top-level import
+    // of @background/keep-alive already cached the module, and isolateModules
+    // would hand back that cached instance instead of re-evaluating it.
+    jest.resetModules();
+
+    // Firefox/Safari manifests do not declare the `alarms` permission, so
+    // webextension-polyfill exposes no `alarms` namespace there.
+    jest.doMock('webextension-polyfill', () => ({
+      alarms: undefined,
+      runtime: { sendMessage: jest.fn().mockResolvedValue(undefined) }
+    }));
+    jest.doMock('@src/utils', () => ({ isChromeBuild: false }));
+
+    expect(() =>
+      // A CJS require (not import) is deliberate: it re-evaluates the module
+      // synchronously through jest's reset registry with the doMocks above.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('@background/keep-alive')
+    ).not.toThrow();
+  });
+});

--- a/src/background/keep-alive.test.ts
+++ b/src/background/keep-alive.test.ts
@@ -86,6 +86,61 @@ describe('keep-alive', () => {
   });
 });
 
+// This block resets the module registry, so it must come after the
+// shared-instance describe above — the idempotency guard is module state, and
+// each test needs a freshly evaluated module (mirroring an SW cold start).
+describe('keep-alive idempotency guard', () => {
+  const loadFreshKeepAlive = () => {
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { alarms: freshAlarms } = require('webextension-polyfill');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const keepAliveModule = require('@background/keep-alive');
+    return { freshAlarms, keepAliveModule };
+  };
+
+  it('repeated startKeepAlive creates the alarm only once — store updates must not reset its schedule', () => {
+    const { freshAlarms, keepAliveModule } = loadFreshKeepAlive();
+
+    keepAliveModule.startKeepAlive();
+    keepAliveModule.startKeepAlive();
+    keepAliveModule.startKeepAlive();
+
+    expect(freshAlarms.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('repeated stopKeepAlive clears the alarm only once', () => {
+    const { freshAlarms, keepAliveModule } = loadFreshKeepAlive();
+
+    keepAliveModule.stopKeepAlive();
+    keepAliveModule.stopKeepAlive();
+
+    expect(freshAlarms.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('stopKeepAlive as the first call after SW start still clears a persisted stale alarm', () => {
+    // Alarms survive SW restarts: if the SW cold-starts locked while the
+    // previous life's alarm is still scheduled, the first stop must reach
+    // the alarms API even though this module instance never started it.
+    const { freshAlarms, keepAliveModule } = loadFreshKeepAlive();
+
+    keepAliveModule.stopKeepAlive();
+
+    expect(freshAlarms.clear).toHaveBeenCalledWith('casper-keep-alive');
+  });
+
+  it('start → stop → start transitions each reach the alarms API', () => {
+    const { freshAlarms, keepAliveModule } = loadFreshKeepAlive();
+
+    keepAliveModule.startKeepAlive();
+    keepAliveModule.stopKeepAlive();
+    keepAliveModule.startKeepAlive();
+
+    expect(freshAlarms.create).toHaveBeenCalledTimes(2);
+    expect(freshAlarms.clear).toHaveBeenCalledTimes(1);
+  });
+});
+
 // This block resets the module registry, so it must stay the last describe in
 // the file — earlier tests rely on the module instance imported at the top.
 describe('keep-alive on non-Chrome builds', () => {

--- a/src/background/keep-alive.ts
+++ b/src/background/keep-alive.ts
@@ -1,4 +1,4 @@
-import { runtime } from 'webextension-polyfill';
+import { alarms, runtime } from 'webextension-polyfill';
 
 import { isChromeBuild } from '@src/utils';
 
@@ -7,23 +7,32 @@ import { selectKeysDoesExist } from '@background/redux/keys/selectors';
 import { selectVaultIsLocked } from '@background/redux/session/selectors';
 import { selectVaultCipherDoesExist } from '@background/redux/vault-cipher/selectors';
 
-let keepAliveInterval: ReturnType<typeof setInterval> | null = null;
+const KEEP_ALIVE_ALARM_NAME = 'casper-keep-alive';
 
-// Function to start the keep-alive interval
-export function startKeepAlive() {
-  if (!keepAliveInterval) {
-    keepAliveInterval = setInterval(keepAlive, 15000); // 15 seconds
-    console.log('KeepAlive interval started.');
-  }
+// chrome.alarms.onAlarm must be registered synchronously at module load so it
+// re-registers on every service worker cold start (MV3 requirement). The
+// isChromeBuild gate is load-bearing: only the Chrome (MV3) manifest declares
+// the `alarms` permission, so on Firefox/Safari the polyfill exposes no
+// `alarms` namespace and an ungated registration would crash the background
+// entry at load.
+if (isChromeBuild) {
+  alarms.onAlarm.addListener(alarm => {
+    if (alarm.name === KEEP_ALIVE_ALARM_NAME) {
+      keepAlive();
+    }
+  });
 }
 
-// Function to stop the keep-alive interval
+// Function to start the keep-alive alarm
+export function startKeepAlive() {
+  alarms.create(KEEP_ALIVE_ALARM_NAME, { periodInMinutes: 0.5 });
+  console.log('KeepAlive alarm started.');
+}
+
+// Function to stop the keep-alive alarm
 export function stopKeepAlive() {
-  if (keepAliveInterval) {
-    clearInterval(keepAliveInterval);
-    keepAliveInterval = null;
-    console.log('KeepAlive interval stopped.');
-  }
+  alarms.clear(KEEP_ALIVE_ALARM_NAME);
+  console.log('KeepAlive alarm stopped.');
 }
 
 // Function to check and manage the keep-alive mechanism based on vault state

--- a/src/background/keep-alive.ts
+++ b/src/background/keep-alive.ts
@@ -23,15 +23,31 @@ if (isChromeBuild) {
   });
 }
 
+// Edge-triggered guard: manageKeepAlive runs on every store update, and an
+// unguarded alarms.create would reset the alarm's schedule on each dispatch,
+// pushing the next fire to ~30s after the last update — exactly Chrome's idle
+// deadline. `null` means "unknown" (fresh SW start): alarms persist across SW
+// restarts, so the first start/stop call must always reach the alarms API —
+// create refreshes the surviving alarm, clear kills a stale one.
+let alarmActive: boolean | null = null;
+
 // Function to start the keep-alive alarm
 export function startKeepAlive() {
+  if (alarmActive === true) {
+    return;
+  }
   alarms.create(KEEP_ALIVE_ALARM_NAME, { periodInMinutes: 0.5 });
+  alarmActive = true;
   console.log('KeepAlive alarm started.');
 }
 
 // Function to stop the keep-alive alarm
 export function stopKeepAlive() {
+  if (alarmActive === false) {
+    return;
+  }
   alarms.clear(KEEP_ALIVE_ALARM_NAME);
+  alarmActive = false;
   console.log('KeepAlive alarm stopped.');
 }
 

--- a/src/background/keep-alive.ts
+++ b/src/background/keep-alive.ts
@@ -36,6 +36,10 @@ export function startKeepAlive() {
   if (alarmActive === true) {
     return;
   }
+  // 0.5 min is the alarms-API minimum only on Chrome >= 120; older Chromes
+  // silently clamp sub-minute periods to 1 minute, and a 60s pulse loses the
+  // service worker at its ~30s idle deadline (silent session loss). The
+  // manifest pins `minimum_chrome_version: 120` for exactly this reason.
   alarms.create(KEEP_ALIVE_ALARM_NAME, { periodInMinutes: 0.5 });
   alarmActive = true;
   console.log('KeepAlive alarm started.');

--- a/src/background/redux/get-main-store.ts
+++ b/src/background/redux/get-main-store.ts
@@ -27,6 +27,18 @@ export const RATE_APP = 'p4cGYubbwnd9ke';
 export const APP_EVENTS = 'k4uL4wqkvCMoxB';
 export const TRUSTED_WASM = 'k1uC4wqkwCMwxL';
 
+// Absolute-timestamp deadlines (`Date.now() + remaining`, in ms) written
+// directly to `storage.local` by the vault sagas so the login-retry lockout and
+// the auto-lock inactivity timers survive MV3 service-worker restarts. These are
+// NOT part of the Redux state shape — they are standalone storage entries the
+// sagas read on `startBackground` to resume the residual delay.
+//
+// IMPORTANT: once shipped, these key strings are immutable. Existing installs
+// persist deadlines under exactly these strings; renaming them would strand the
+// old entries and break resume-after-restart for already-locked-out users.
+export const LOGIN_RETRY_LOCKOUT_DEADLINE_KEY = 'q9Tf3Lm4pRxVne';
+export const AUTO_LOCK_DEADLINE_KEY = 'r3Wj7Nc8vBhQyD';
+
 type StorageState = {
   [VAULT_CIPHER_KEY]: string;
   [KEYS_KEY]: KeysState;

--- a/src/background/redux/sagas/vault-sagas.test.ts
+++ b/src/background/redux/sagas/vault-sagas.test.ts
@@ -1,0 +1,218 @@
+import * as matchers from 'redux-saga-test-plan/matchers';
+import { expectSaga } from 'redux-saga-test-plan';
+import { storage } from 'webextension-polyfill';
+
+import {
+  LOCK_VAULT_TIMEOUT,
+  MapTimeoutDurationSettingToValue,
+  TimeoutDurationSetting
+} from '@popup/constants';
+
+import {
+  AUTO_LOCK_DEADLINE_KEY,
+  LOGIN_RETRY_LOCKOUT_DEADLINE_KEY
+} from '@background/redux/get-main-store';
+import { loginRetryLockoutTimeReseted } from '@background/redux/login-retry-lockout-time/actions';
+import { selectLoginRetryLockoutTime } from '@background/redux/login-retry-lockout-time/selectors';
+
+import { lastActivityTimeRefreshed } from '../last-activity-time/actions';
+import { selectVaultLastActivityTime } from '../last-activity-time/selectors';
+import { loginRetryCountReseted } from '../login-retry-count/actions';
+import { loginRetryLockoutTimeSet } from '../login-retry-lockout-time/reducer';
+import { selectVaultIsLocked } from '../session/selectors';
+import { selectTimeoutDurationSetting } from '../settings/selectors';
+import { selectVaultCipherDoesExist } from '../vault-cipher/selectors';
+import { lockVault, startBackground } from './actions';
+import {
+  delay,
+  lockVaultSaga,
+  setDelayForLockoutVaultSaga,
+  timeoutCounterSaga
+} from './vault-sagas';
+
+// Stub the storage-key module so importing it does not drag in the Redux store
+// (get-main-store -> redux/index -> @redux-devtools/remote -> nanoid ESM, which
+// jest cannot parse). The literals below MUST stay in lockstep with the real
+// keys in get-main-store.ts — they are immutable once shipped.
+jest.mock('@background/redux/get-main-store', () => ({
+  LOGIN_RETRY_LOCKOUT_DEADLINE_KEY: 'q9Tf3Lm4pRxVne',
+  AUTO_LOCK_DEADLINE_KEY: 'r3Wj7Nc8vBhQyD'
+}));
+
+jest.mock('webextension-polyfill', () => ({
+  storage: {
+    local: {
+      get: jest.fn().mockResolvedValue({}),
+      set: jest.fn().mockResolvedValue(undefined),
+      remove: jest.fn().mockResolvedValue(undefined)
+    }
+  },
+  runtime: { sendMessage: jest.fn().mockResolvedValue(undefined) },
+  tabs: { query: jest.fn().mockResolvedValue([]), sendMessage: jest.fn() }
+}));
+
+const mockStorageGet = storage.local.get as jest.Mock;
+const mockStorageSet = storage.local.set as jest.Mock;
+const mockStorageRemove = storage.local.remove as jest.Mock;
+
+const NOW = 1_700_000_000_000;
+const FIVE_SECONDS = 5000;
+
+// Instantly resolve the module's own delay helper so tests never wait on a real
+// timer, and so the `.call(delay, ms)` assertion can verify the exact residual.
+const instantDelay: [ReturnType<typeof matchers.call.fn>, undefined] = [
+  matchers.call.fn(delay),
+  undefined
+];
+
+beforeEach(() => {
+  jest.spyOn(Date, 'now').mockReturnValue(NOW);
+  mockStorageGet.mockReset().mockResolvedValue({});
+  mockStorageSet.mockReset().mockResolvedValue(undefined);
+  mockStorageRemove.mockReset().mockResolvedValue(undefined);
+  jest.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('setDelayForLockoutVaultSaga', () => {
+  it('resumes on startBackground with a future deadline: waits the residual, not the full duration', async () => {
+    const deadline = NOW + FIVE_SECONDS;
+    mockStorageGet.mockResolvedValue({
+      [LOGIN_RETRY_LOCKOUT_DEADLINE_KEY]: deadline
+    });
+
+    await expectSaga(setDelayForLockoutVaultSaga, startBackground())
+      .provide([
+        [matchers.select.selector(selectLoginRetryLockoutTime), NOW],
+        instantDelay
+      ])
+      .call(delay, FIVE_SECONDS)
+      .put(loginRetryCountReseted())
+      .put(loginRetryLockoutTimeReseted())
+      .run();
+
+    expect(mockStorageRemove).toHaveBeenCalledWith(
+      LOGIN_RETRY_LOCKOUT_DEADLINE_KEY
+    );
+  });
+
+  it('resumes on startBackground with an elapsed deadline: resets immediately without delaying', async () => {
+    mockStorageGet.mockResolvedValue({
+      [LOGIN_RETRY_LOCKOUT_DEADLINE_KEY]: NOW - 1000
+    });
+
+    await expectSaga(setDelayForLockoutVaultSaga, startBackground())
+      .provide([
+        [matchers.select.selector(selectLoginRetryLockoutTime), NOW],
+        instantDelay
+      ])
+      .not.call.fn(delay)
+      .put(loginRetryCountReseted())
+      .put(loginRetryLockoutTimeReseted())
+      .run();
+  });
+
+  it('arms a fresh lockout: persists deadline = start + LOCK_VAULT_TIMEOUT and waits the full duration', async () => {
+    await expectSaga(setDelayForLockoutVaultSaga, loginRetryLockoutTimeSet(NOW))
+      .provide([
+        [matchers.select.selector(selectLoginRetryLockoutTime), NOW],
+        instantDelay
+      ])
+      .call(delay, LOCK_VAULT_TIMEOUT)
+      .put(loginRetryCountReseted())
+      .put(loginRetryLockoutTimeReseted())
+      .run();
+
+    expect(mockStorageSet).toHaveBeenCalledWith({
+      [LOGIN_RETRY_LOCKOUT_DEADLINE_KEY]: NOW + LOCK_VAULT_TIMEOUT
+    });
+  });
+
+  it('does nothing and clears any stale deadline when there is no active lockout', async () => {
+    await expectSaga(setDelayForLockoutVaultSaga, startBackground())
+      .provide([
+        [matchers.select.selector(selectLoginRetryLockoutTime), null],
+        instantDelay
+      ])
+      .not.call.fn(delay)
+      .not.put(loginRetryCountReseted())
+      .run();
+
+    expect(mockStorageRemove).toHaveBeenCalledWith(
+      LOGIN_RETRY_LOCKOUT_DEADLINE_KEY
+    );
+  });
+});
+
+describe('timeoutCounterSaga', () => {
+  const unlockedVaultProvides = (
+    lastActivityTime: number | null,
+    isLocked = false
+  ): Array<[ReturnType<typeof matchers.select.selector>, unknown]> => [
+    [matchers.select.selector(selectVaultCipherDoesExist), true],
+    [matchers.select.selector(selectVaultIsLocked), isLocked],
+    [matchers.select.selector(selectVaultLastActivityTime), lastActivityTime],
+    [
+      matchers.select.selector(selectTimeoutDurationSetting),
+      TimeoutDurationSetting['5 min']
+    ]
+  ];
+
+  const fiveMin =
+    MapTimeoutDurationSettingToValue[TimeoutDurationSetting['5 min']];
+
+  it('resumes on startBackground with a future deadline: waits the residual then locks', async () => {
+    mockStorageGet.mockResolvedValue({
+      [AUTO_LOCK_DEADLINE_KEY]: NOW + FIVE_SECONDS
+    });
+
+    await expectSaga(timeoutCounterSaga, startBackground())
+      .provide([...unlockedVaultProvides(NOW), instantDelay])
+      .call(delay, FIVE_SECONDS)
+      .put(lockVault())
+      .run();
+  });
+
+  it('resumes on startBackground with an elapsed deadline: locks immediately without delaying', async () => {
+    mockStorageGet.mockResolvedValue({
+      [AUTO_LOCK_DEADLINE_KEY]: NOW - 1000
+    });
+
+    await expectSaga(timeoutCounterSaga, startBackground())
+      .provide([...unlockedVaultProvides(NOW), instantDelay])
+      .not.call.fn(delay)
+      .put(lockVault())
+      .run();
+  });
+
+  it('arms on activity refresh: persists deadline = lastActivity + timeout, delays the residual, then locks', async () => {
+    await expectSaga(timeoutCounterSaga, lastActivityTimeRefreshed())
+      .provide([...unlockedVaultProvides(NOW), instantDelay])
+      .call(delay, fiveMin)
+      .put(lockVault())
+      .run();
+
+    expect(mockStorageSet).toHaveBeenCalledWith({
+      [AUTO_LOCK_DEADLINE_KEY]: NOW + fiveMin
+    });
+  });
+
+  it('does nothing while the vault is locked', async () => {
+    await expectSaga(timeoutCounterSaga, startBackground())
+      .provide([...unlockedVaultProvides(NOW, true), instantDelay])
+      .not.call.fn(delay)
+      .not.put(lockVault())
+      .run();
+  });
+});
+
+describe('lockVaultSaga', () => {
+  it('clears the persisted auto-lock deadline on lock (covers both timeout-fired and manual lock)', async () => {
+    await expectSaga(lockVaultSaga).run();
+
+    expect(mockStorageRemove).toHaveBeenCalledWith(AUTO_LOCK_DEADLINE_KEY);
+  });
+});

--- a/src/background/redux/sagas/vault-sagas.test.ts
+++ b/src/background/redux/sagas/vault-sagas.test.ts
@@ -1,6 +1,6 @@
 import * as matchers from 'redux-saga-test-plan/matchers';
 import { expectSaga } from 'redux-saga-test-plan';
-import { storage } from 'webextension-polyfill';
+import { storage, tabs } from 'webextension-polyfill';
 
 import {
   LOCK_VAULT_TIMEOUT,
@@ -54,6 +54,7 @@ jest.mock('webextension-polyfill', () => ({
 const mockStorageGet = storage.local.get as jest.Mock;
 const mockStorageSet = storage.local.set as jest.Mock;
 const mockStorageRemove = storage.local.remove as jest.Mock;
+const mockTabsQuery = tabs.query as jest.Mock;
 
 const NOW = 1_700_000_000_000;
 const FIVE_SECONDS = 5000;
@@ -70,6 +71,7 @@ beforeEach(() => {
   mockStorageGet.mockReset().mockResolvedValue({});
   mockStorageSet.mockReset().mockResolvedValue(undefined);
   mockStorageRemove.mockReset().mockResolvedValue(undefined);
+  mockTabsQuery.mockClear();
   jest.spyOn(console, 'error').mockImplementation(() => undefined);
 });
 
@@ -130,6 +132,30 @@ describe('setDelayForLockoutVaultSaga', () => {
       [LOGIN_RETRY_LOCKOUT_DEADLINE_KEY]: NOW + LOCK_VAULT_TIMEOUT
     });
   });
+
+  it.each([
+    ['a string', 'garbage'],
+    ['NaN', NaN]
+  ])(
+    'falls back to recomputing the deadline when the persisted value is corrupt (%s) instead of resetting immediately',
+    async (_label, corruptValue) => {
+      mockStorageGet.mockResolvedValue({
+        [LOGIN_RETRY_LOCKOUT_DEADLINE_KEY]: corruptValue
+      });
+
+      await expectSaga(setDelayForLockoutVaultSaga, startBackground())
+        .provide([
+          [matchers.select.selector(selectLoginRetryLockoutTime), NOW],
+          instantDelay
+        ])
+        // Recomputed from loginRetryLockoutTime — waits the full duration
+        // rather than failing open into an immediate lockout reset.
+        .call(delay, LOCK_VAULT_TIMEOUT)
+        .put(loginRetryCountReseted())
+        .put(loginRetryLockoutTimeReseted())
+        .run();
+    }
+  );
 
   it('does nothing and clears any stale deadline when there is no active lockout', async () => {
     await expectSaga(setDelayForLockoutVaultSaga, startBackground())
@@ -200,12 +226,28 @@ describe('timeoutCounterSaga', () => {
     });
   });
 
-  it('does nothing while the vault is locked', async () => {
+  it('falls back to recomputing the deadline when the persisted value is corrupt', async () => {
+    mockStorageGet.mockResolvedValue({
+      [AUTO_LOCK_DEADLINE_KEY]: 'garbage'
+    });
+
+    await expectSaga(timeoutCounterSaga, startBackground())
+      .provide([...unlockedVaultProvides(NOW), instantDelay])
+      // Recomputed from lastActivityTime — waits the full residual rather
+      // than locking immediately off a garbage value.
+      .call(delay, fiveMin)
+      .put(lockVault())
+      .run();
+  });
+
+  it('neither delays nor locks while the vault is locked, but clears the stale persisted deadline', async () => {
     await expectSaga(timeoutCounterSaga, startBackground())
       .provide([...unlockedVaultProvides(NOW, true), instantDelay])
       .not.call.fn(delay)
       .not.put(lockVault())
       .run();
+
+    expect(mockStorageRemove).toHaveBeenCalledWith(AUTO_LOCK_DEADLINE_KEY);
   });
 });
 
@@ -214,5 +256,18 @@ describe('lockVaultSaga', () => {
     await expectSaga(lockVaultSaga).run();
 
     expect(mockStorageRemove).toHaveBeenCalledWith(AUTO_LOCK_DEADLINE_KEY);
+  });
+
+  it('emits the locked event to tabs before touching storage, so a storage failure cannot skip the emit', async () => {
+    await expectSaga(lockVaultSaga).run();
+
+    // tabs.query is the first thing emitSdkEventToActiveTabs does; asserting
+    // its global invocation order against storage.local.remove proves the
+    // emit is no longer sequenced behind the fallible storage call.
+    expect(mockTabsQuery).toHaveBeenCalled();
+    expect(mockStorageRemove).toHaveBeenCalledWith(AUTO_LOCK_DEADLINE_KEY);
+    expect(mockTabsQuery.mock.invocationCallOrder[0]).toBeLessThan(
+      mockStorageRemove.mock.invocationCallOrder[0]
+    );
   });
 });

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -1,4 +1,5 @@
 import { put, select, takeLatest } from 'redux-saga/effects';
+import { storage } from 'webextension-polyfill';
 
 import { getActiveAccountSupports, getUrlOrigin } from '@src/utils';
 
@@ -7,6 +8,10 @@ import {
   MapTimeoutDurationSettingToValue
 } from '@popup/constants';
 
+import {
+  AUTO_LOCK_DEADLINE_KEY,
+  LOGIN_RETRY_LOCKOUT_DEADLINE_KEY
+} from '@background/redux/get-main-store';
 import {
   loginRetryLockoutTimeReseted,
   loginRetryLockoutTimeSet
@@ -76,7 +81,7 @@ import {
 export function* vaultSagas() {
   yield takeLatest(lockVault.type, lockVaultSaga);
   yield takeLatest(
-    [loginRetryLockoutTimeSet.type, popupWindowInit.type],
+    [loginRetryLockoutTimeSet.type, popupWindowInit.type, startBackground.type],
     setDelayForLockoutVaultSaga
   );
   yield takeLatest(unlockVault.type, unlockVaultSaga);
@@ -114,12 +119,18 @@ export function* vaultSagas() {
 /**
  * on lock destroy session, vault and deploys
  */
-function* lockVaultSaga() {
+export function* lockVaultSaga() {
   try {
     yield put(sessionReseted());
     yield put(vaultReseted());
     yield put(deploysReseted());
     yield put(accountInfoReset());
+
+    // The vault is locked, so the persisted auto-lock deadline is spent —
+    // remove it so a stale value can never fire against a future session.
+    // `timeoutCounterSaga` locks by dispatching this same `lockVault` action,
+    // so this single site covers both the timeout and manual-lock paths.
+    yield* sagaCall(clearAutoLockDeadline);
 
     emitSdkEventToActiveTabs(() => {
       return sdkEvent.lockedEvent({
@@ -134,36 +145,75 @@ function* lockVaultSaga() {
   }
 }
 
-function* setDelayForLockoutVaultSaga() {
+/**
+ * Promise-based delay used as a saga `call` effect. Exported so tests can match
+ * `call(delay, ms)` and assert the exact residual without a real timer.
+ */
+export const delay = (ms: number) =>
+  new Promise(resolve => setTimeout(resolve, ms));
+
+// Absolute login-retry lockout deadline persisted to `storage.local` so the
+// reset timer can be re-armed with the residual after a service-worker restart.
+const readLockoutDeadline = () =>
+  storage.local.get(LOGIN_RETRY_LOCKOUT_DEADLINE_KEY);
+const writeLockoutDeadline = (deadline: number) =>
+  storage.local.set({ [LOGIN_RETRY_LOCKOUT_DEADLINE_KEY]: deadline });
+const clearLockoutDeadline = () =>
+  storage.local.remove(LOGIN_RETRY_LOCKOUT_DEADLINE_KEY);
+
+/**
+ * Re-arms the login-retry lockout reset timer.
+ *
+ * Triggered when a lockout is set (`loginRetryLockoutTimeSet`) and on resume
+ * points (`startBackground` after an MV3 service-worker restart, `popupWindowInit`).
+ *
+ * On arming we persist an absolute `start + LOCK_VAULT_TIMEOUT` deadline to
+ * `storage.local`; on resume we read that deadline back and wait only the
+ * residual (`deadline - now`), or reset immediately if it already elapsed. This
+ * survives the service worker being killed mid-lockout.
+ */
+export function* setDelayForLockoutVaultSaga(
+  action: ReturnType<
+    | typeof loginRetryLockoutTimeSet
+    | typeof startBackground
+    | typeof popupWindowInit
+  >
+) {
   const loginRetryLockoutTime: number | null = yield select(
     selectLoginRetryLockoutTime
   );
 
   if (loginRetryLockoutTime == null) {
+    // No active lockout — drop any stale persisted deadline and stop.
+    yield* sagaCall(clearLockoutDeadline);
     return;
   }
 
-  const currentTime = Date.now();
-  const isTimeoutExpired =
-    currentTime - loginRetryLockoutTime >= LOCK_VAULT_TIMEOUT;
+  let deadline: number;
 
-  //  if the timeout expired we reset the count and lockout time
-  if (isTimeoutExpired) {
-    yield put(loginRetryCountReseted());
-    yield put(loginRetryLockoutTimeReseted());
+  if (action.type === loginRetryLockoutTimeSet.type) {
+    // Arming: compute and persist the absolute deadline.
+    deadline = loginRetryLockoutTime + LOCK_VAULT_TIMEOUT;
+    yield* sagaCall(writeLockoutDeadline, deadline);
+  } else {
+    // Resume: read the persisted deadline, falling back to a computed one.
+    const stored = yield* sagaCall(readLockoutDeadline);
+    deadline =
+      (stored[LOGIN_RETRY_LOCKOUT_DEADLINE_KEY] as number | undefined) ??
+      loginRetryLockoutTime + LOCK_VAULT_TIMEOUT;
   }
 
-  //  if the timeout has not expired we set the timer with the time that is left
-  if (!isTimeoutExpired) {
-    const timeLeft = LOCK_VAULT_TIMEOUT - (currentTime - loginRetryLockoutTime);
-    const delay = (ms: number) =>
-      new Promise(resolve => setTimeout(resolve, ms));
+  const timeLeft = deadline - Date.now();
 
+  // Wait out only the residual; if it already elapsed we fall straight through
+  // to the reset below.
+  if (timeLeft > 0) {
     yield* sagaCall(delay, timeLeft);
-
-    yield put(loginRetryCountReseted());
-    yield put(loginRetryLockoutTimeReseted());
   }
+
+  yield put(loginRetryCountReseted());
+  yield put(loginRetryLockoutTimeReseted());
+  yield* sagaCall(clearLockoutDeadline);
 }
 
 /**
@@ -238,20 +288,33 @@ function* unlockVaultSaga(action: ReturnType<typeof unlockVault>) {
   }
 }
 
-/**
- * Saga to handle the timeout and locking mechanism of a vault based on its last activity time and a specified timeout duration setting.
- *
- * The generator function calculates the time elapsed since the last activity of the vault.
- * If the vault exists, it is not locked, and the last
- * activity time is available, it checks if the elapsed time surpasses the timeout duration.
- * If true, it triggers a vault lock action
- * immediately.
- * If false, it sets up a delay for the remaining time until the timeout duration is met before locking the vault.
- *
- */
-function* timeoutCounterSaga() {
-  const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+// Absolute auto-lock deadline persisted to `storage.local` so the inactivity
+// timer can be re-armed with the residual after a service-worker restart.
+const readAutoLockDeadline = () => storage.local.get(AUTO_LOCK_DEADLINE_KEY);
+const writeAutoLockDeadline = (deadline: number) =>
+  storage.local.set({ [AUTO_LOCK_DEADLINE_KEY]: deadline });
+const clearAutoLockDeadline = () =>
+  storage.local.remove(AUTO_LOCK_DEADLINE_KEY);
 
+/**
+ * Saga to handle the timeout and locking mechanism of a vault based on its last
+ * activity time and a specified timeout duration setting.
+ *
+ * On arming (`lastActivityTimeRefreshed` / `activeTimeoutDurationSettingChanged`)
+ * it computes an absolute `lastActivity + timeout` deadline and persists it to
+ * `storage.local`. On resume (`startBackground` after an MV3 service-worker
+ * restart) it reads that deadline back instead of recomputing. Either way it
+ * locks immediately if the deadline already elapsed, otherwise it waits only the
+ * residual (`deadline - now`) before locking. Persisting the absolute deadline is
+ * what lets the timer survive the service worker being killed.
+ */
+export function* timeoutCounterSaga(
+  action: ReturnType<
+    | typeof startBackground
+    | typeof lastActivityTimeRefreshed
+    | typeof activeTimeoutDurationSettingChanged
+  >
+) {
   try {
     const vaultDoesExist = yield* sagaSelect(selectVaultCipherDoesExist);
     const vaultIsLocked = yield* sagaSelect(selectVaultIsLocked);
@@ -265,21 +328,30 @@ function* timeoutCounterSaga() {
       MapTimeoutDurationSettingToValue[vaultTimeoutDurationSetting];
 
     if (vaultDoesExist && !vaultIsLocked && vaultLastActivityTime) {
-      const currentTime = Date.now();
-      const timeoutExpired =
-        currentTime - vaultLastActivityTime >= timeoutDurationValue;
+      let deadline: number;
 
-      if (timeoutExpired) {
-        yield put(lockVault());
+      if (action.type === startBackground.type) {
+        // Resume: read the persisted deadline, falling back to a computed one.
+        const stored = yield* sagaCall(readAutoLockDeadline);
+        deadline =
+          (stored[AUTO_LOCK_DEADLINE_KEY] as number | undefined) ??
+          vaultLastActivityTime + timeoutDurationValue;
       } else {
-        yield* sagaCall(delay, timeoutDurationValue);
-        yield put(lockVault());
+        // Arming: compute and persist the absolute deadline.
+        deadline = vaultLastActivityTime + timeoutDurationValue;
+        yield* sagaCall(writeAutoLockDeadline, deadline);
       }
+
+      const timeLeft = deadline - Date.now();
+
+      if (timeLeft > 0) {
+        yield* sagaCall(delay, timeLeft);
+      }
+
+      yield put(lockVault());
     }
   } catch (err) {
     console.error(err);
-  } finally {
-    //
   }
 }
 

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -17,6 +17,7 @@ import {
   loginRetryLockoutTimeSet
 } from '@background/redux/login-retry-lockout-time/actions';
 import { selectLoginRetryLockoutTime } from '@background/redux/login-retry-lockout-time/selectors';
+import { anchorServiceWorker } from '@background/sw-keep-alive-anchor';
 import { emitSdkEventToActiveTabs } from '@background/utils';
 
 import { sdkEvent } from '@content/sdk-event';
@@ -222,6 +223,10 @@ export function* setDelayForLockoutVaultSaga(
  * put new encryption key in session
  */
 function* unlockVaultSaga(action: ReturnType<typeof unlockVault>) {
+  // Keep the MV3 service worker alive for the whole unlock flow — Chrome may
+  // otherwise kill it mid-saga during the heavy crypto work.
+  const releaseAnchor = anchorServiceWorker('unlock');
+
   try {
     const {
       vault,
@@ -285,6 +290,8 @@ function* unlockVaultSaga(action: ReturnType<typeof unlockVault>) {
     }
   } catch (err) {
     console.error(err);
+  } finally {
+    releaseAnchor();
   }
 }
 
@@ -359,6 +366,10 @@ export function* timeoutCounterSaga(
  * update vault cipher on each vault update
  */
 function* updateVaultCipher() {
+  // Keep the MV3 service worker alive while the vault is re-encrypted —
+  // Chrome may otherwise kill it mid-saga during the heavy crypto work.
+  const releaseAnchor = anchorServiceWorker('encrypt');
+
   try {
     // get current encryption key
     const encryptionKeyHash = yield* sagaSelect(selectEncryptionKeyHash);
@@ -376,6 +387,8 @@ function* updateVaultCipher() {
     );
   } catch (err) {
     console.error(err);
+  } finally {
+    releaseAnchor();
   }
 }
 
@@ -383,6 +396,10 @@ function* updateVaultCipher() {
  *
  */
 function* createAccountSaga(action: ReturnType<typeof createAccount>) {
+  // Keep the MV3 service worker alive during key derivation — Chrome may
+  // otherwise kill it mid-saga during the heavy crypto work.
+  const releaseAnchor = anchorServiceWorker('create-account');
+
   try {
     const { name } = action.payload;
 
@@ -423,5 +440,7 @@ function* createAccountSaga(action: ReturnType<typeof createAccount>) {
     }
   } catch (err) {
     console.error(err);
+  } finally {
+    releaseAnchor();
   }
 }

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -127,12 +127,6 @@ export function* lockVaultSaga() {
     yield put(deploysReseted());
     yield put(accountInfoReset());
 
-    // The vault is locked, so the persisted auto-lock deadline is spent —
-    // remove it so a stale value can never fire against a future session.
-    // `timeoutCounterSaga` locks by dispatching this same `lockVault` action,
-    // so this single site covers both the timeout and manual-lock paths.
-    yield* sagaCall(clearAutoLockDeadline);
-
     emitSdkEventToActiveTabs(() => {
       return sdkEvent.lockedEvent({
         isLocked: true,
@@ -141,6 +135,14 @@ export function* lockVaultSaga() {
         activeKeySupports: undefined
       });
     });
+
+    // The vault is locked, so the persisted auto-lock deadline is spent —
+    // remove it so a stale value can never fire against a future session.
+    // `timeoutCounterSaga` locks by dispatching this same `lockVault` action,
+    // so this single site covers both the timeout and manual-lock paths.
+    // Sequenced AFTER the emit: this is the only fallible step in the saga,
+    // and a storage rejection must not prevent dapps from seeing the lock.
+    yield* sagaCall(clearAutoLockDeadline);
   } catch (err) {
     console.error(err);
   }
@@ -197,11 +199,15 @@ export function* setDelayForLockoutVaultSaga(
     deadline = loginRetryLockoutTime + LOCK_VAULT_TIMEOUT;
     yield* sagaCall(writeLockoutDeadline, deadline);
   } else {
-    // Resume: read the persisted deadline, falling back to a computed one.
+    // Resume: read the persisted deadline. Anything but a finite number
+    // (missing key, corrupted storage) falls back to recomputing from the
+    // lockout start time — never fail open into an immediate lockout reset.
     const stored = yield* sagaCall(readLockoutDeadline);
+    const raw = stored[LOGIN_RETRY_LOCKOUT_DEADLINE_KEY];
     deadline =
-      (stored[LOGIN_RETRY_LOCKOUT_DEADLINE_KEY] as number | undefined) ??
-      loginRetryLockoutTime + LOCK_VAULT_TIMEOUT;
+      typeof raw === 'number' && Number.isFinite(raw)
+        ? raw
+        : loginRetryLockoutTime + LOCK_VAULT_TIMEOUT;
   }
 
   const timeLeft = deadline - Date.now();
@@ -338,11 +344,15 @@ export function* timeoutCounterSaga(
       let deadline: number;
 
       if (action.type === startBackground.type) {
-        // Resume: read the persisted deadline, falling back to a computed one.
+        // Resume: read the persisted deadline. Anything but a finite number
+        // (missing key, corrupted storage) falls back to recomputing from the
+        // last activity time — same validation as the lockout saga.
         const stored = yield* sagaCall(readAutoLockDeadline);
+        const raw = stored[AUTO_LOCK_DEADLINE_KEY];
         deadline =
-          (stored[AUTO_LOCK_DEADLINE_KEY] as number | undefined) ??
-          vaultLastActivityTime + timeoutDurationValue;
+          typeof raw === 'number' && Number.isFinite(raw)
+            ? raw
+            : vaultLastActivityTime + timeoutDurationValue;
       } else {
         // Arming: compute and persist the absolute deadline.
         deadline = vaultLastActivityTime + timeoutDurationValue;
@@ -356,6 +366,12 @@ export function* timeoutCounterSaga(
       }
 
       yield put(lockVault());
+    } else {
+      // Locked (or no session) — e.g. a cold start where the session slice was
+      // lost. The `lockVault` path that normally clears the persisted deadline
+      // never ran in this worker, so drop any stale value here to keep it from
+      // ever firing against a future session.
+      yield* sagaCall(clearAutoLockDeadline);
     }
   } catch (err) {
     console.error(err);

--- a/src/background/sw-keep-alive-anchor.test.ts
+++ b/src/background/sw-keep-alive-anchor.test.ts
@@ -1,0 +1,160 @@
+// Toggled per test through the `@src/utils` getter mock below.
+let mockIsChromeBuild = true;
+
+const mockGetPlatformInfo = jest.fn();
+
+jest.mock('@src/utils', () => ({
+  get isChromeBuild() {
+    return mockIsChromeBuild;
+  }
+}));
+
+jest.mock('webextension-polyfill', () => ({
+  runtime: {
+    getPlatformInfo: (...args: unknown[]) => mockGetPlatformInfo(...args)
+  }
+}));
+
+type AnchorModule = typeof import('./sw-keep-alive-anchor');
+
+// The module keeps cold-start/refcount state at module level (re-evaluated on
+// every real SW start), so each test loads a fresh copy via resetModules.
+const loadAnchorModule = (): AnchorModule => {
+  let module: AnchorModule;
+  jest.isolateModules(() => {
+    module = jest.requireActual('./sw-keep-alive-anchor');
+  });
+  return module!;
+};
+
+describe('anchorServiceWorker', () => {
+  let debugSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockIsChromeBuild = true;
+    mockGetPlatformInfo.mockReset().mockResolvedValue({});
+    debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('is a no-op on non-Chrome builds: no breadcrumb, no heartbeat, safe disposer', () => {
+    mockIsChromeBuild = false;
+    const { anchorServiceWorker, ANCHOR_HEARTBEAT_INTERVAL } =
+      loadAnchorModule();
+
+    const release = anchorServiceWorker('unlock');
+    jest.advanceTimersByTime(ANCHOR_HEARTBEAT_INTERVAL * 3);
+
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(mockGetPlatformInfo).not.toHaveBeenCalled();
+    expect(() => release()).not.toThrow();
+  });
+
+  it('logs the cold-start breadcrumb only for the first anchored flow after SW start', () => {
+    const { anchorServiceWorker } = loadAnchorModule();
+
+    const releaseFirst = anchorServiceWorker('unlock');
+    releaseFirst();
+    const releaseSecond = anchorServiceWorker('encrypt');
+    releaseSecond();
+
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    expect(debugSpy).toHaveBeenCalledWith('[keepalive] SW resumed mid-unlock');
+  });
+
+  it('fires the extension-API heartbeat every interval while held and stops after release', () => {
+    const { anchorServiceWorker, ANCHOR_HEARTBEAT_INTERVAL } =
+      loadAnchorModule();
+
+    const release = anchorServiceWorker('encrypt');
+
+    jest.advanceTimersByTime(ANCHOR_HEARTBEAT_INTERVAL - 1);
+    expect(mockGetPlatformInfo).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(mockGetPlatformInfo).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(ANCHOR_HEARTBEAT_INTERVAL);
+    expect(mockGetPlatformInfo).toHaveBeenCalledTimes(2);
+
+    release();
+
+    jest.advanceTimersByTime(ANCHOR_HEARTBEAT_INTERVAL * 3);
+    expect(mockGetPlatformInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it('refcounts overlapping anchors: one shared interval, kept alive until the last release', () => {
+    const { anchorServiceWorker, ANCHOR_HEARTBEAT_INTERVAL } =
+      loadAnchorModule();
+
+    const releaseA = anchorServiceWorker('unlock');
+    const releaseB = anchorServiceWorker('encrypt');
+
+    // Shared interval: one heartbeat per tick, not one per anchor.
+    jest.advanceTimersByTime(ANCHOR_HEARTBEAT_INTERVAL);
+    expect(mockGetPlatformInfo).toHaveBeenCalledTimes(1);
+
+    releaseA();
+
+    // B still holds the anchor — heartbeat keeps firing.
+    jest.advanceTimersByTime(ANCHOR_HEARTBEAT_INTERVAL);
+    expect(mockGetPlatformInfo).toHaveBeenCalledTimes(2);
+
+    releaseB();
+
+    jest.advanceTimersByTime(ANCHOR_HEARTBEAT_INTERVAL * 3);
+    expect(mockGetPlatformInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it('disposers are idempotent: double-release must not steal another anchor holder', () => {
+    const { anchorServiceWorker, ANCHOR_HEARTBEAT_INTERVAL } =
+      loadAnchorModule();
+
+    const releaseA = anchorServiceWorker('unlock');
+    const releaseB = anchorServiceWorker('create-account');
+
+    releaseA();
+    releaseA(); // must not decrement B's hold
+
+    jest.advanceTimersByTime(ANCHOR_HEARTBEAT_INTERVAL);
+    expect(mockGetPlatformInfo).toHaveBeenCalledTimes(1);
+
+    releaseB();
+
+    jest.advanceTimersByTime(ANCHOR_HEARTBEAT_INTERVAL * 3);
+    expect(mockGetPlatformInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it('restarts the heartbeat when a new anchor is taken after full release', () => {
+    const { anchorServiceWorker, ANCHOR_HEARTBEAT_INTERVAL } =
+      loadAnchorModule();
+
+    anchorServiceWorker('unlock')();
+
+    const release = anchorServiceWorker('encrypt');
+    jest.advanceTimersByTime(ANCHOR_HEARTBEAT_INTERVAL);
+    expect(mockGetPlatformInfo).toHaveBeenCalledTimes(1);
+    release();
+  });
+
+  it('swallows heartbeat API rejections (the call itself is the keep-alive)', async () => {
+    mockGetPlatformInfo.mockRejectedValue(new Error('boom'));
+    const { anchorServiceWorker, ANCHOR_HEARTBEAT_INTERVAL } =
+      loadAnchorModule();
+
+    const release = anchorServiceWorker('unlock');
+    jest.advanceTimersByTime(ANCHOR_HEARTBEAT_INTERVAL);
+
+    // Flush the rejected promise; an unhandled rejection would fail the test.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockGetPlatformInfo).toHaveBeenCalledTimes(1);
+    release();
+  });
+});

--- a/src/background/sw-keep-alive-anchor.ts
+++ b/src/background/sw-keep-alive-anchor.ts
@@ -1,0 +1,75 @@
+import { runtime } from 'webextension-polyfill';
+
+import { isChromeBuild } from '@src/utils';
+
+/**
+ * Heartbeat period for the service-worker anchor. Must stay comfortably under
+ * Chrome's 30s service-worker idle deadline.
+ */
+export const ANCHOR_HEARTBEAT_INTERVAL = 20_000;
+
+// This module is re-evaluated on every MV3 service-worker start, so this flag
+// being `true` means no anchored crypto flow has run since the last (re)start.
+// The first anchored flow after a start therefore logs a cold-start breadcrumb
+// and clears the flag.
+let swStartIsFresh = true;
+
+// Refcount of currently anchored flows sharing the single heartbeat interval —
+// anchored sagas can overlap (e.g. an account change fires the vault
+// re-encrypt saga while another flow is still running).
+let anchorCount = 0;
+let heartbeatIntervalId: ReturnType<typeof setInterval> | undefined;
+
+/**
+ * Keeps the Chrome MV3 background service worker alive across a long crypto
+ * section (argon2 key derivation, vault encrypt/decrypt) by calling a cheap
+ * extension API every {@link ANCHOR_HEARTBEAT_INTERVAL} ms — each extension
+ * API call resets the SW's 30s idle timer (Chrome 110+). Merely holding a
+ * `runtime.connect` Port open does NOT reset the timer (Chrome 114+), so an
+ * API-call heartbeat is used instead of a Port anchor.
+ *
+ * No-op on Firefox/Safari: their MV2 background pages are persistent, and the
+ * `isChromeBuild` gate keeps Chrome-only machinery from running there.
+ *
+ * Call before the crypto body; invoke the returned disposer in `finally`.
+ * Overlapping anchors share one interval via refcounting, and the disposer is
+ * idempotent.
+ */
+export function anchorServiceWorker(flow: string): () => void {
+  if (!isChromeBuild) {
+    return () => undefined;
+  }
+
+  if (swStartIsFresh) {
+    swStartIsFresh = false;
+    // Breadcrumb: this crypto flow is the first since the SW (re)started —
+    // if it follows a mid-flow kill, this marks the resume point.
+    console.debug(`[keepalive] SW resumed mid-${flow}`);
+  }
+
+  anchorCount += 1;
+
+  if (heartbeatIntervalId === undefined) {
+    heartbeatIntervalId = setInterval(() => {
+      // The API call itself is the point — it resets the SW idle timer.
+      // The result is ignored and failures are irrelevant to the anchor.
+      runtime.getPlatformInfo().catch(() => undefined);
+    }, ANCHOR_HEARTBEAT_INTERVAL);
+  }
+
+  let released = false;
+
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+
+    anchorCount -= 1;
+
+    if (anchorCount === 0 && heartbeatIntervalId !== undefined) {
+      clearInterval(heartbeatIntervalId);
+      heartbeatIntervalId = undefined;
+    }
+  };
+}

--- a/src/manifest.v3.json
+++ b/src/manifest.v3.json
@@ -13,7 +13,7 @@
     "declarativeNetRequest",
     "alarms"
   ],
-  "minimum_chrome_version": "92",
+  "minimum_chrome_version": "120",
   "declarative_net_request": {
     "rule_resources": [
       {


### PR DESCRIPTION
## Summary

Part of the DEP-99 security & architecture backlog — **P0.3: MV3 service-worker lifetime hardening**.
Jira: https://make-software.atlassian.net/browse/WALLET-1343

Chrome kills the MV3 background service worker after ~30s of idle, which used to (a) silently kill the `setInterval`-based keep-alive, (b) drop the login-retry lockout and auto-lock countdowns, and (c) risk killing the SW mid crypto operation. Three fixes, one commit each (+ one review-driven hardening commit):

1. **Keep-alive on `chrome.alarms`** (`d3736480`, hardened in `e67c1dda`) — `setInterval` replaced with a `chrome.alarms` alarm (`casper-keep-alive`, 0.5 min, the MV3 minimum), which survives SW restarts. The `onAlarm` listener registers synchronously at module eval behind `isChromeBuild` — the gate is load-bearing: Firefox/Safari manifests don't declare the `alarms` permission, so the polyfill exposes no `alarms` namespace there. Start/stop are edge-triggered via a tri-state guard (`null` = fresh SW start), so per-dispatch store subscriptions no longer reset the alarm schedule, while the first call after a cold start always reaches the alarms API (a locked cold start must still clear a stale alarm surviving from the previous SW life).
2. **Lockout / auto-lock deadlines persisted as absolute timestamps** (`fb5f8343`) — on arming, `Date.now() + remaining` is written to `storage.local` under two new obfuscated keys (`get-main-store.ts`; key strings documented immutable). `startBackground` now also triggers the lockout saga, so after an SW restart the brute-force lockout timer resumes with the residual delay (or resets immediately if elapsed) instead of waiting for the next popup open. Deadlines are **derived, not authoritative**: if the deadline key is missing/cleared, the saga recomputes from the already-persisted lockout start time — clearing the new key cannot shorten a lockout. Keys are cleared on firing/reset (lockout) and on lock (auto-lock). Redux state shape unchanged.
3. **SW anchor during long crypto sagas** (`9ec18620`) — a refcounted `runtime.getPlatformInfo()` heartbeat (20s) held for the duration of `unlockVaultSaga` / `updateVaultCipher` / `createAccountSaga`, released in `finally` (verified against `takeLatest` cancellation — no wakelock leak). Includes a one-time `[keepalive] SW resumed mid-<flow>` cold-start breadcrumb (`console.debug`, flow name only — no secrets).

## Approved deviations from the plan

- **Port anchor → extension-API heartbeat (Task 3.3).** The plan's `runtime.connect`/Port anchor is a proven no-op on current Chrome: since Chrome 114 opening a port no longer resets the SW idle timer, and `runtime.onConnect` never fires in the caller's own context, so a self-connect from the SW immediately disconnects. Replaced (with approval) by the documented pattern: any extension-API call resets the idle timer (Chrome 110+), so a 20s `getPlatformInfo` heartbeat during long crypto work keeps the SW alive. Evidence and rationale are in the module doc comment of `sw-keep-alive-anchor.ts`.
- **Auto-lock deadline persistence is write-only today (Task 3.2).** The session slice (which holds `isLocked` and the decrypted vault) is not rehydrated after an SW restart, so the wallet always cold-starts locked and the auto-lock resume branch never runs in production. Kept per plan (decision: keep) — it is harmless (the key is cleared on every lock), and becomes functional automatically if session persistence ever lands.
- **`redux-saga-test-plan` added now** (devDependency; the plan formally introduces it in PR 8, but Task 3.2's saga tests need it). Adds 3 tiny transitive deps.

## Review round (Comp0te, 2026-07-08) — addressed in `f04cb620`

- **`minimum_chrome_version` 92 → 120** (`manifest.v3.json`): Chrome < 120 silently clamps `periodInMinutes: 0.5` to 1 minute, and a 60s pulse loses the MV3 SW at its ~30s idle deadline (silent session loss). ⚠️ Release management: this bump and the alarms keep-alive must ship in the **same store release** — do not cherry-pick one without the other. Permission/host delta: none in any manifest; Firefox `strict_min_version: 113.0` and the Safari manifest intentionally unchanged (persistent MV2 background pages, no `alarms` permission).
- Persisted lockout/auto-lock deadline reads now validated (`typeof` + `Number.isFinite`) — corrupt storage values fail closed into the full recompute instead of clearing the brute-force lockout.
- `clearAutoLockDeadline` moved after the `lockedEvent` emit in `lockVaultSaga` — a storage rejection can no longer swallow the dapp lock notification (order pinned by test).
- `timeoutCounterSaga` now clears a stale `AUTO_LOCK_DEADLINE_KEY` on a locked cold start (guard-fail branch), matching the lockout saga's hygiene.

## Known property (not a regression)

The 0.5 min alarm period equals Chrome's 30s idle deadline, so an occasional mid-idle SW death before the next pulse remains possible by design (0.5 min is the MV3 minimum). The failure mode degrades to pre-PR behavior: the SW restarts locked and the persisted deadlines now recover the security timers.

## Verification

- `npm run ci-check` — green (35 suites / 183 tests; tsc clean; lint 0 errors)
- `npm run build:chrome` / `build:firefox` / `build:safari` — all build (Safari: pre-existing CFBundleVersion warning only)
- `npm run e2e:chrome:headless:onboarding` — 6/6 passed
- `npm run e2e:chrome:headless:popup` — 46 passed, 1 skipped (pre-existing skip)
- New unit coverage: 9 keep-alive tests (incl. non-Chrome module-load regression test and edge-trigger guard), 9 vault-saga tests (redux-saga-test-plan; residual vs full delay, elapsed-deadline reset, storage effect args), 7 anchor tests (refcount, idempotent disposers, once-only breadcrumb)

### Manual QA checklist (reviewer/QA)

- [x] Unlock the wallet, trigger the login-retry lockout (5 wrong passwords), kill the SW via `chrome://serviceworker-internals` mid-countdown → the lockout timer resumes with the residual time (does not restart from full, cannot be bypassed) — _verified by owner 2026-07-08: unlock form reappears at the original T0+5:00 deadline after an SW kill mid-countdown_
- [x] With the wallet unlocked, confirm the SW stays alive (alarm pulses every 30s; no session loss during normal use) — _verified 2026-07-08: single edge-triggered `KeepAlive alarm started./stopped.` per transition, no per-dispatch log spam; the `Receiving end does not exist` ping error with no UI open is pre-existing behavior (same catch existed with setInterval)_
- [x] Unlock and watch the SW survive the unlock flow (breadcrumb `[keepalive] SW resumed mid-<flow>` appears in the SW console after an SW restart) — _verified 2026-07-08: `[keepalive] SW resumed mid-unlock` observed_
- [ ] Firefox and Safari builds load and background starts normally (no `alarms` usage there)
