### PR TITLE
feat: DEP-99 — saga error channel + tab-id fallback (WALLET-1343)

### DIFF
--- a/src/apps/connect-to-app/index.tsx
+++ b/src/apps/connect-to-app/index.tsx
@@ -28,6 +28,7 @@ import {
   darkTheme,
   lightTheme
 } from '@libs/ui';
+import { SagaErrorBanner } from '@libs/ui/components/saga-error-banner/saga-error-banner';
 
 const Tree = () => {
   const [state, setState] = useState<PopupState | null>(null);
@@ -67,6 +68,7 @@ const Tree = () => {
         <ThemeProvider theme={isDarkMode ? darkTheme : lightTheme}>
           <GlobalStyle />
           <ReduxProvider store={store}>
+            <SagaErrorBanner />
             <QueryClientProvider client={newQueryClient}>
               <ErrorBoundary>
                 <AppRouter />

--- a/src/apps/import-account-with-file/index.tsx
+++ b/src/apps/import-account-with-file/index.tsx
@@ -26,6 +26,7 @@ import {
   darkTheme,
   lightTheme
 } from '@libs/ui';
+import { SagaErrorBanner } from '@libs/ui/components/saga-error-banner/saga-error-banner';
 
 import { AppRouter } from './app-router';
 
@@ -65,6 +66,7 @@ const Tree = () => {
         <ThemeProvider theme={isDarkMode ? darkTheme : lightTheme}>
           <GlobalStyle />
           <ReduxProvider store={store}>
+            <SagaErrorBanner />
             <QueryClientProvider client={newQueryClient}>
               <ErrorBoundary>
                 <AppRouter />

--- a/src/apps/onboarding/index.tsx
+++ b/src/apps/onboarding/index.tsx
@@ -17,6 +17,7 @@ import '@libs/i18n/i18n';
 import { ErrorBoundary } from '@libs/layout';
 import { newQueryClient } from '@libs/services/query-client';
 import { CspStyleSheetManager, GlobalStyle, lightTheme } from '@libs/ui';
+import { SagaErrorBanner } from '@libs/ui/components/saga-error-banner/saga-error-banner';
 
 const Tree = () => {
   const [state, setState] = useState<PopupState | null>(null);
@@ -40,6 +41,7 @@ const Tree = () => {
         <ThemeProvider theme={lightTheme}>
           <GlobalStyle />
           <ReduxProvider store={store}>
+            <SagaErrorBanner />
             <QueryClientProvider client={newQueryClient}>
               <ErrorBoundary>
                 <AppRouter />

--- a/src/apps/popup/index.tsx
+++ b/src/apps/popup/index.tsx
@@ -27,6 +27,7 @@ import {
   darkTheme,
   lightTheme
 } from '@libs/ui';
+import { SagaErrorBanner } from '@libs/ui/components/saga-error-banner/saga-error-banner';
 
 import { AppRouter } from './app-router';
 
@@ -68,6 +69,7 @@ const Tree = () => {
         <ThemeProvider theme={isDarkMode ? darkTheme : lightTheme}>
           <GlobalStyle />
           <ReduxProvider store={store}>
+            <SagaErrorBanner />
             <QueryClientProvider client={newQueryClient}>
               <ErrorBoundary>
                 <AppRouter />

--- a/src/apps/signature-request/index.tsx
+++ b/src/apps/signature-request/index.tsx
@@ -28,6 +28,7 @@ import {
   darkTheme,
   lightTheme
 } from '@libs/ui';
+import { SagaErrorBanner } from '@libs/ui/components/saga-error-banner/saga-error-banner';
 
 import { AppRouter } from './app-router';
 
@@ -69,6 +70,7 @@ const Tree = () => {
         <ThemeProvider theme={isDarkMode ? darkTheme : lightTheme}>
           <GlobalStyle />
           <ReduxProvider store={store}>
+            <SagaErrorBanner />
             <QueryClientProvider client={newQueryClient}>
               <ErrorBoundary>
                 <AppRouter />

--- a/src/background/background-events.ts
+++ b/src/background/background-events.ts
@@ -5,7 +5,10 @@ import { PopupState } from './redux/types';
 // General purpose events emitted by background to all extension windows
 
 export const backgroundEvent = {
-  popupStateUpdated: createAction<PopupState>('popupStateUpdated')
+  popupStateUpdated: createAction<PopupState>('popupStateUpdated'),
+  // Payload-free by design (P0.1): tells UI replicas to re-fetch private
+  // state via fetchPrivateState() instead of carrying secret material.
+  privateStateUpdated: createAction('privateStateUpdated')
 };
 
 export type BackgroundEvent = ReturnType<

--- a/src/background/handlers/redux-actions.test.ts
+++ b/src/background/handlers/redux-actions.test.ts
@@ -1,0 +1,51 @@
+import { dismissSagaError } from '@background/redux/app-events/actions';
+import { MainStore } from '@background/redux/get-main-store';
+
+import { handleReduxAction } from './redux-actions';
+
+// `redux-actions.ts` transitively imports `open-onboarding-flow.ts`, which
+// touches `webextension-polyfill` at module load time. Stub it so the module
+// can load outside a browser extension context (same approach as
+// `sdk-response-to-tab.test.ts`).
+jest.mock('webextension-polyfill', () => ({
+  action: undefined,
+  browserAction: undefined,
+  storage: { local: { remove: jest.fn(), get: jest.fn(), set: jest.fn() } },
+  tabs: { get: jest.fn(), update: jest.fn(), create: jest.fn() },
+  windows: { update: jest.fn() }
+}));
+
+// Build a minimal fake store with a spied dispatch — modeled on
+// `sdk-response-to-tab.test.ts`'s `makeStore`.
+function makeStore() {
+  const dispatch = jest.fn();
+  const store = {
+    getState: () => ({}),
+    dispatch
+  } as unknown as MainStore;
+  return { store, dispatch };
+}
+
+describe('handleReduxAction (background router — UI-originated action forwarding)', () => {
+  it('dismissSagaError → forwarded to the store (dismiss button must work)', async () => {
+    const { store, dispatch } = makeStore();
+    const action = dismissSagaError(1);
+
+    const result = await handleReduxAction(action, store);
+
+    expect(result).toEqual({ handled: true, response: undefined });
+    expect(dispatch).toHaveBeenCalledWith(action);
+  });
+
+  it('unknown action type → { handled: false } (allowlist mechanism still gates unrecognized actions)', async () => {
+    const { store, dispatch } = makeStore();
+
+    const result = await handleReduxAction(
+      { type: 'totally/unknown/action' },
+      store
+    );
+
+    expect(result).toEqual({ handled: false });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/background/handlers/redux-actions.ts
+++ b/src/background/handlers/redux-actions.ts
@@ -8,6 +8,7 @@ import {
 } from '@background/redux/account-info/actions';
 import {
   dismissAppEvent,
+  dismissSagaError,
   resetAppEventsDismission
 } from '@background/redux/app-events/actions';
 import {
@@ -176,6 +177,7 @@ const FORWARDED_ACTION_TYPES: ReadonlySet<string> = new Set(
     addWatchingAccount,
     dismissAppEvent,
     resetAppEventsDismission,
+    dismissSagaError,
     addWasmToTrusted,
     removeWasmFromTrusted,
     removeAllWasmFromTrustedOrigin,

--- a/src/background/handlers/sdk-response-to-tab.test.ts
+++ b/src/background/handlers/sdk-response-to-tab.test.ts
@@ -6,6 +6,7 @@ import {
   SDK_RESPONSE_TO_TAB,
   SdkResponseToTabMessage
 } from '@background/send-sdk-response-to-specific-tab';
+import { emitSdkEventToActiveTabsWithOrigin } from '@background/utils';
 
 import { sdkMethod } from '@content/sdk-method';
 
@@ -21,9 +22,22 @@ jest.mock('webextension-polyfill', () => ({
   }
 }));
 
+// The same-origin fallback delegates to this util; stub it so we can assert it
+// is (or isn't) invoked without touching real `tabs.query`.
+jest.mock('@background/utils', () => ({
+  emitSdkEventToActiveTabsWithOrigin: jest.fn()
+}));
+
 const sendMessageMock = tabs.sendMessage as jest.MockedFunction<
   typeof tabs.sendMessage
 >;
+
+const emitToOriginMock =
+  emitSdkEventToActiveTabsWithOrigin as jest.MockedFunction<
+    typeof emitSdkEventToActiveTabsWithOrigin
+  >;
+
+const DAPP_ORIGIN = 'https://dapp.example';
 
 const REQUEST_ID = 'req-1';
 const TAB_ID = 7;
@@ -33,6 +47,14 @@ const TAB_ID = 7;
 const UI_SENDER = {
   id: 'ext-id',
   url: 'chrome-extension://ext-id/popup.html'
+} as Runtime.MessageSender;
+
+// Trusted UI sender whose page URL carries the dapp origin in its `?origin=`
+// query param — the mechanism the handler uses to recover the origin for the
+// same-origin fallback (no new state / message field is threaded).
+const UI_SENDER_WITH_ORIGIN = {
+  id: 'ext-id',
+  url: `chrome-extension://ext-id/signature-request.html?requestId=${REQUEST_ID}&origin=${DAPP_ORIGIN}&tabId=${TAB_ID}#/SignMessage`
 } as Runtime.MessageSender;
 
 // Build a fake store whose `requests` map carries the desired status for the
@@ -84,6 +106,8 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
   beforeEach(() => {
     sendMessageMock.mockReset();
     sendMessageMock.mockResolvedValue(undefined);
+    emitToOriginMock.mockReset();
+    emitToOriginMock.mockResolvedValue(undefined);
   });
 
   it('fresh request (no prior status) → delivers to the tab AND marks responded', async () => {
@@ -130,7 +154,7 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
     expect(result.handled).toBe(true);
   });
 
-  it('invalid tabId → no delivery, no throw', async () => {
+  it('invalid tabId, no origin → surfaces sagaError, no delivery, does not mark responded', async () => {
     const { store, dispatch } = makeStore(undefined);
 
     const result = await handleSdkResponseToTab(
@@ -139,8 +163,114 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
       store
     );
 
+    // No usable tab and no origin to fall back to: nothing is delivered and the
+    // request is NOT marked responded (a valid retry must still deliver).
     expect(sendMessageMock).not.toHaveBeenCalled();
-    expect(dispatch).not.toHaveBeenCalled();
+    expect(emitToOriginMock).not.toHaveBeenCalled();
+
+    // Exactly one dispatch: the non-fatal sagaError making the loss visible.
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const dispatched = dispatch.mock.calls[0][0];
+    expect(dispatched.payload.source).toBe('sdk-response-to-tab');
+    // No windowRequestResponded was dispatched.
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ payload: { requestId: REQUEST_ID } })
+    );
+
+    // SECURITY: the surfaced error must not leak signature material.
+    expect(JSON.stringify(dispatched)).not.toContain('deadbeef');
+    expect(dispatched.payload.message).not.toContain('deadbeef');
+
+    expect(result.handled).toBe(true);
+  });
+
+  it('invalid tabId, sender HAS origin → fallback broadcast, marks responded, surfaces sagaError', async () => {
+    const { store, dispatch } = makeStore(undefined);
+
+    const result = await handleSdkResponseToTab(
+      makeMessage(-1),
+      UI_SENDER_WITH_ORIGIN,
+      store
+    );
+
+    // No usable tab → no direct delivery, but the same-origin fallback fires.
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(emitToOriginMock).toHaveBeenCalledTimes(1);
+    expect(emitToOriginMock).toHaveBeenCalledWith(
+      DAPP_ORIGIN,
+      makeMessage(-1).action
+    );
+
+    // We ARE delivering via the fallback → mark responded so a later duplicate
+    // is deduped, plus surface the non-fatal sagaError.
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: { requestId: REQUEST_ID } })
+    );
+    const sagaErrorCall = dispatch.mock.calls.find(
+      ([a]) => a?.payload?.source === 'sdk-response-to-tab'
+    );
+    expect(sagaErrorCall).toBeDefined();
+    expect(JSON.stringify(sagaErrorCall?.[0])).not.toContain('deadbeef');
+
+    expect(result.handled).toBe(true);
+  });
+
+  it('valid tabId, delivery rejects, sender HAS origin → same-origin fallback + sagaError (already marked responded)', async () => {
+    const { store, dispatch } = makeStore(undefined);
+    sendMessageMock.mockRejectedValue(new Error('no listener / tab gone'));
+
+    const result = await handleSdkResponseToTab(
+      makeMessage(),
+      UI_SENDER_WITH_ORIGIN,
+      store
+    );
+
+    // Direct delivery was attempted (and rejected).
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageMock).toHaveBeenCalledWith(TAB_ID, makeMessage().action);
+
+    // Fallback broadcast to the same-origin active tab.
+    expect(emitToOriginMock).toHaveBeenCalledTimes(1);
+    expect(emitToOriginMock).toHaveBeenCalledWith(
+      DAPP_ORIGIN,
+      makeMessage().action
+    );
+
+    // Optimistic mark happened BEFORE the await (atomic dedupe contract).
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: { requestId: REQUEST_ID } })
+    );
+    const sagaErrorCall = dispatch.mock.calls.find(
+      ([a]) => a?.payload?.source === 'sdk-response-to-tab'
+    );
+    expect(sagaErrorCall).toBeDefined();
+
+    // SECURITY: no signature material in the surfaced error.
+    expect(JSON.stringify(sagaErrorCall?.[0])).not.toContain('deadbeef');
+    expect(sagaErrorCall?.[0].payload.message).not.toContain('deadbeef');
+
+    expect(result.handled).toBe(true);
+  });
+
+  it('valid tabId, delivery rejects, sender has NO origin → sagaError but no fallback', async () => {
+    const { store, dispatch } = makeStore(undefined);
+    sendMessageMock.mockRejectedValue(new Error('no listener / tab gone'));
+
+    const result = await handleSdkResponseToTab(
+      makeMessage(),
+      UI_SENDER,
+      store
+    );
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    // No origin recoverable → no fallback broadcast.
+    expect(emitToOriginMock).not.toHaveBeenCalled();
+
+    const sagaErrorCall = dispatch.mock.calls.find(
+      ([a]) => a?.payload?.source === 'sdk-response-to-tab'
+    );
+    expect(sagaErrorCall).toBeDefined();
+
     expect(result.handled).toBe(true);
   });
 

--- a/src/background/handlers/sdk-response-to-tab.test.ts
+++ b/src/background/handlers/sdk-response-to-tab.test.ts
@@ -23,7 +23,8 @@ jest.mock('webextension-polyfill', () => ({
 }));
 
 // The same-origin fallback delegates to this util; stub it so we can assert it
-// is (or isn't) invoked without touching real `tabs.query`.
+// is (or isn't) invoked without touching real `tabs.query`. It now resolves to
+// the COUNT of tabs it successfully delivered to.
 jest.mock('@background/utils', () => ({
   emitSdkEventToActiveTabsWithOrigin: jest.fn()
 }));
@@ -41,6 +42,12 @@ const DAPP_ORIGIN = 'https://dapp.example';
 
 const REQUEST_ID = 'req-1';
 const TAB_ID = 7;
+
+// Message-text fragments the handler surfaces via `sagaError`, keyed on whether
+// the same-origin fallback actually delivered.
+const DELIVERED_MSG = 'delivered via same-origin fallback';
+const NOT_DELIVERED_MSG =
+  'no same-origin fallback available — response not delivered';
 
 // Trusted extension-UI sender (id matches runtime.id, url under the extension
 // origin) — passes `isTrustedUiSender`.
@@ -102,12 +109,20 @@ function makeMessage(tabId: number = TAB_ID): SdkResponseToTabMessage {
   };
 }
 
+// Find the single `sagaError` dispatch (source === 'sdk-response-to-tab').
+function findSagaError(dispatch: jest.Mock) {
+  return dispatch.mock.calls.find(
+    ([a]) => a?.payload?.source === 'sdk-response-to-tab'
+  )?.[0];
+}
+
 describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
   beforeEach(() => {
     sendMessageMock.mockReset();
     sendMessageMock.mockResolvedValue(undefined);
     emitToOriginMock.mockReset();
-    emitToOriginMock.mockResolvedValue(undefined);
+    // Default: fallback delivers to one tab. Individual tests override with 0.
+    emitToOriginMock.mockResolvedValue(1);
   });
 
   it('fresh request (no prior status) → delivers to the tab AND marks responded', async () => {
@@ -154,7 +169,7 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
     expect(result.handled).toBe(true);
   });
 
-  it('invalid tabId, no origin → surfaces sagaError, no delivery, does not mark responded', async () => {
+  it('invalid tabId, no origin → surfaces "not delivered" sagaError, no delivery, does not mark responded', async () => {
     const { store, dispatch } = makeStore(undefined);
 
     const result = await handleSdkResponseToTab(
@@ -170,8 +185,11 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
 
     // Exactly one dispatch: the non-fatal sagaError making the loss visible.
     expect(dispatch).toHaveBeenCalledTimes(1);
-    const dispatched = dispatch.mock.calls[0][0];
+    const dispatched = findSagaError(dispatch);
+    expect(dispatched).toBeDefined();
     expect(dispatched.payload.source).toBe('sdk-response-to-tab');
+    // The message must state the response was NOT delivered.
+    expect(dispatched.payload.message).toContain(NOT_DELIVERED_MSG);
     // No windowRequestResponded was dispatched.
     expect(dispatch).not.toHaveBeenCalledWith(
       expect.objectContaining({ payload: { requestId: REQUEST_ID } })
@@ -184,8 +202,9 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
     expect(result.handled).toBe(true);
   });
 
-  it('invalid tabId, sender HAS origin → fallback broadcast, marks responded, surfaces sagaError', async () => {
+  it('invalid tabId, origin present, fallback delivers (1) → marks responded, "delivered" sagaError', async () => {
     const { store, dispatch } = makeStore(undefined);
+    emitToOriginMock.mockResolvedValue(1);
 
     const result = await handleSdkResponseToTab(
       makeMessage(-1),
@@ -201,23 +220,48 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
       makeMessage(-1).action
     );
 
-    // We ARE delivering via the fallback → mark responded so a later duplicate
-    // is deduped, plus surface the non-fatal sagaError.
+    // We DID deliver via the fallback → mark responded so a later duplicate is
+    // deduped, plus surface the "delivered" sagaError.
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ payload: { requestId: REQUEST_ID } })
     );
-    const sagaErrorCall = dispatch.mock.calls.find(
-      ([a]) => a?.payload?.source === 'sdk-response-to-tab'
-    );
-    expect(sagaErrorCall).toBeDefined();
-    expect(JSON.stringify(sagaErrorCall?.[0])).not.toContain('deadbeef');
+    const sagaError = findSagaError(dispatch);
+    expect(sagaError).toBeDefined();
+    expect(sagaError.payload.message).toContain(DELIVERED_MSG);
+    expect(JSON.stringify(sagaError)).not.toContain('deadbeef');
 
     expect(result.handled).toBe(true);
   });
 
-  it('valid tabId, delivery rejects, sender HAS origin → same-origin fallback + sagaError (already marked responded)', async () => {
+  it('invalid tabId, origin present, fallback delivers ZERO → does NOT mark responded, "not delivered" sagaError', async () => {
+    const { store, dispatch } = makeStore(undefined);
+    emitToOriginMock.mockResolvedValue(0);
+
+    const result = await handleSdkResponseToTab(
+      makeMessage(-1),
+      UI_SENDER_WITH_ORIGIN,
+      store
+    );
+
+    // Fallback was attempted but matched zero tabs → nothing delivered.
+    expect(emitToOriginMock).toHaveBeenCalledTimes(1);
+
+    // A legitimate retry must still deliver → do NOT mark responded.
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ payload: { requestId: REQUEST_ID } })
+    );
+    const sagaError = findSagaError(dispatch);
+    expect(sagaError).toBeDefined();
+    expect(sagaError.payload.message).toContain(NOT_DELIVERED_MSG);
+    expect(JSON.stringify(sagaError)).not.toContain('deadbeef');
+
+    expect(result.handled).toBe(true);
+  });
+
+  it('valid tabId, delivery rejects, origin present, fallback delivers (1) → optimistic responded + "delivered" sagaError', async () => {
     const { store, dispatch } = makeStore(undefined);
     sendMessageMock.mockRejectedValue(new Error('no listener / tab gone'));
+    emitToOriginMock.mockResolvedValue(1);
 
     const result = await handleSdkResponseToTab(
       makeMessage(),
@@ -240,19 +284,44 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ payload: { requestId: REQUEST_ID } })
     );
-    const sagaErrorCall = dispatch.mock.calls.find(
-      ([a]) => a?.payload?.source === 'sdk-response-to-tab'
-    );
-    expect(sagaErrorCall).toBeDefined();
+    const sagaError = findSagaError(dispatch);
+    expect(sagaError).toBeDefined();
+    expect(sagaError.payload.message).toContain(DELIVERED_MSG);
 
     // SECURITY: no signature material in the surfaced error.
-    expect(JSON.stringify(sagaErrorCall?.[0])).not.toContain('deadbeef');
-    expect(sagaErrorCall?.[0].payload.message).not.toContain('deadbeef');
+    expect(JSON.stringify(sagaError)).not.toContain('deadbeef');
+    expect(sagaError.payload.message).not.toContain('deadbeef');
 
     expect(result.handled).toBe(true);
   });
 
-  it('valid tabId, delivery rejects, sender has NO origin → sagaError but no fallback', async () => {
+  it('valid tabId, delivery rejects, origin present, fallback delivers ZERO → optimistic responded + "not delivered" sagaError', async () => {
+    const { store, dispatch } = makeStore(undefined);
+    sendMessageMock.mockRejectedValue(new Error('no listener / tab gone'));
+    emitToOriginMock.mockResolvedValue(0);
+
+    const result = await handleSdkResponseToTab(
+      makeMessage(),
+      UI_SENDER_WITH_ORIGIN,
+      store
+    );
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(emitToOriginMock).toHaveBeenCalledTimes(1);
+
+    // The optimistic mark is load-bearing: still dispatched before the await.
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: { requestId: REQUEST_ID } })
+    );
+    const sagaError = findSagaError(dispatch);
+    expect(sagaError).toBeDefined();
+    expect(sagaError.payload.message).toContain(NOT_DELIVERED_MSG);
+    expect(JSON.stringify(sagaError)).not.toContain('deadbeef');
+
+    expect(result.handled).toBe(true);
+  });
+
+  it('valid tabId, delivery rejects, sender has NO origin → "not delivered" sagaError but no fallback', async () => {
     const { store, dispatch } = makeStore(undefined);
     sendMessageMock.mockRejectedValue(new Error('no listener / tab gone'));
 
@@ -266,12 +335,54 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
     // No origin recoverable → no fallback broadcast.
     expect(emitToOriginMock).not.toHaveBeenCalled();
 
-    const sagaErrorCall = dispatch.mock.calls.find(
-      ([a]) => a?.payload?.source === 'sdk-response-to-tab'
-    );
-    expect(sagaErrorCall).toBeDefined();
+    const sagaError = findSagaError(dispatch);
+    expect(sagaError).toBeDefined();
+    expect(sagaError.payload.message).toContain(NOT_DELIVERED_MSG);
 
     expect(result.handled).toBe(true);
+  });
+
+  it('fallback emit THROWS (valid tab path) → handler still resolves, "not delivered" sagaError, does not reject', async () => {
+    const { store, dispatch } = makeStore(undefined);
+    sendMessageMock.mockRejectedValue(new Error('no listener / tab gone'));
+    emitToOriginMock.mockRejectedValue(new Error('tabs.query blew up'));
+
+    const result = await handleSdkResponseToTab(
+      makeMessage(),
+      UI_SENDER_WITH_ORIGIN,
+      store
+    );
+
+    // The emit rejection is swallowed → the error-surface dispatch still runs.
+    expect(emitToOriginMock).toHaveBeenCalledTimes(1);
+    const sagaError = findSagaError(dispatch);
+    expect(sagaError).toBeDefined();
+    expect(sagaError.payload.message).toContain(NOT_DELIVERED_MSG);
+    expect(JSON.stringify(sagaError)).not.toContain('deadbeef');
+
+    expect(result).toEqual({ handled: true, response: undefined });
+  });
+
+  it('fallback emit THROWS (invalid tab path) → handler still resolves, no responded, "not delivered" sagaError', async () => {
+    const { store, dispatch } = makeStore(undefined);
+    emitToOriginMock.mockRejectedValue(new Error('tabs.query blew up'));
+
+    const result = await handleSdkResponseToTab(
+      makeMessage(-1),
+      UI_SENDER_WITH_ORIGIN,
+      store
+    );
+
+    expect(emitToOriginMock).toHaveBeenCalledTimes(1);
+    // Nothing delivered → NOT marked responded.
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ payload: { requestId: REQUEST_ID } })
+    );
+    const sagaError = findSagaError(dispatch);
+    expect(sagaError).toBeDefined();
+    expect(sagaError.payload.message).toContain(NOT_DELIVERED_MSG);
+
+    expect(result).toEqual({ handled: true, response: undefined });
   });
 
   it('atomic dedupe: a second response arriving while the first send is still in-flight is dropped', async () => {

--- a/src/background/handlers/sdk-response-to-tab.ts
+++ b/src/background/handlers/sdk-response-to-tab.ts
@@ -30,14 +30,38 @@ function recoverDappOrigin(url: string | undefined): string | null {
   }
 }
 
+// Same-origin delivery fallback. Returns the number of tabs the response was
+// SUCCESSFULLY delivered to (0 when there is no recoverable origin, or when the
+// broadcast matched no active same-origin tab). Wrapping the emit isolates a
+// `tabs.query`-level rejection so the caller's error-surface dispatch still runs
+// and the handler never rejects back to the signature page.
+async function deliverViaOrigin(
+  origin: string | null,
+  action: SdkResponseToTabMessage['action']
+): Promise<number> {
+  if (!origin) {
+    return 0;
+  }
+  try {
+    return await emitSdkEventToActiveTabsWithOrigin(origin, action);
+  } catch {
+    // tabs.query / query-level failure → nothing delivered.
+    return 0;
+  }
+}
+
 // SECURITY: the dapp `action` is the SDK response and may carry secret material
 // (a `signatureHex` / `encryptedMessage` / signed payload). This surfaced error
 // must reference ONLY the tabId + a static reason — never the action or any
-// part of its payload.
-function deliveryFailedError(tabId: unknown) {
+// part of its payload. The message is parameterized on whether the same-origin
+// fallback actually delivered, so a support reader is not told the response was
+// recovered when it was in fact lost.
+function deliveryFailedError(tabId: unknown, fallbackDelivered: boolean) {
   return sagaError({
     source: 'sdk-response-to-tab',
-    message: `SDK response delivery to tab ${tabId} failed; used same-origin fallback`
+    message: fallbackDelivered
+      ? `SDK response delivery to tab ${tabId} failed; delivered via same-origin fallback`
+      : `SDK response delivery to tab ${tabId} failed; no same-origin fallback available — response not delivered`
   });
 }
 
@@ -96,18 +120,17 @@ export async function handleSdkResponseToTab(
   const validTab = Number.isInteger(tabId) && tabId >= 0;
 
   if (!validTab) {
-    // No usable tab. If we can recover the dapp origin, deliver via the
-    // same-origin fallback (broadcast to any active tab of that origin) and
-    // mark responded — we ARE delivering, so a later duplicate must dedupe.
-    // With no origin, nothing is delivered: do NOT mark responded (a valid
-    // retry must still deliver). Either way surface the non-fatal error.
-    if (origin) {
-      if (requestId != null) {
-        store.dispatch(windowRequestResponded({ requestId }));
-      }
-      await emitSdkEventToActiveTabsWithOrigin(origin, action);
+    // No usable tab. Attempt the same-origin fallback (broadcast to any active
+    // tab of the recovered dapp origin). Only mark responded when the fallback
+    // ACTUALLY delivered to at least one tab — we ARE delivering, so a later
+    // duplicate must dedupe. When nothing was delivered (no origin, or the
+    // broadcast matched zero tabs), do NOT mark responded: a valid retry must
+    // still be able to deliver. Either way surface the non-fatal error.
+    const delivered = await deliverViaOrigin(origin, action);
+    if (delivered > 0 && requestId != null) {
+      store.dispatch(windowRequestResponded({ requestId }));
     }
-    store.dispatch(deliveryFailedError(tabId));
+    store.dispatch(deliveryFailedError(tabId, delivered > 0));
     return { handled: true, response: undefined };
   }
 
@@ -129,12 +152,11 @@ export async function handleSdkResponseToTab(
     await tabs.sendMessage(tabId, action);
   } catch {
     // Tab gone / no listener → try the same-origin fallback (if we can recover
-    // the origin) and surface the non-fatal error. The optimistic mark above
-    // already deduped any retry.
-    if (origin) {
-      await emitSdkEventToActiveTabsWithOrigin(origin, action);
-    }
-    store.dispatch(deliveryFailedError(tabId));
+    // the origin) and surface the non-fatal error, choosing the message based
+    // on whether the fallback actually delivered. The optimistic mark above
+    // already deduped any retry (delivery failure is terminal by design).
+    const delivered = await deliverViaOrigin(origin, action);
+    store.dispatch(deliveryFailedError(tabId, delivered > 0));
   }
 
   return { handled: true, response: undefined };

--- a/src/background/handlers/sdk-response-to-tab.ts
+++ b/src/background/handlers/sdk-response-to-tab.ts
@@ -1,5 +1,6 @@
 import { Runtime, tabs } from 'webextension-polyfill';
 
+import { sagaError } from '@background/redux/app-events/actions';
 import { MainStore } from '@background/redux/get-main-store';
 import { windowRequestResponded } from '@background/redux/windowManagement/actions';
 import { selectRequestStatus } from '@background/redux/windowManagement/selectors';
@@ -7,9 +8,38 @@ import {
   SDK_RESPONSE_TO_TAB,
   SdkResponseToTabMessage
 } from '@background/send-sdk-response-to-specific-tab';
+import { emitSdkEventToActiveTabsWithOrigin } from '@background/utils';
 
 import { isTrustedUiSender } from './private-state';
 import { HandlerResult } from './types';
+
+// Recover the originating dapp origin from the sender page URL. The response
+// windows are opened with `?origin=<dappOrigin>` in their query string (e.g.
+// `signature-request.html?requestId=..&origin=<dappOrigin>&tabId=..#/..`), and
+// `sender.url` IS that page URL. `isTrustedUiSender` has already guaranteed
+// `sender.url` is a defined extension URL by the time we parse it. Returns null
+// if the param is absent or the URL is unparseable.
+function recoverDappOrigin(url: string | undefined): string | null {
+  if (!url) {
+    return null;
+  }
+  try {
+    return new URL(url).searchParams.get('origin');
+  } catch {
+    return null;
+  }
+}
+
+// SECURITY: the dapp `action` is the SDK response and may carry secret material
+// (a `signatureHex` / `encryptedMessage` / signed payload). This surfaced error
+// must reference ONLY the tabId + a static reason — never the action or any
+// part of its payload.
+function deliveryFailedError(tabId: unknown) {
+  return sagaError({
+    source: 'sdk-response-to-tab',
+    message: `SDK response delivery to tab ${tabId} failed; used same-origin fallback`
+  });
+}
 
 // Server-side dedupe of SDK responses (P0.5 root cause). The signature UI pages
 // used to `tabs.sendMessage` the response to the dapp tab directly and guard
@@ -62,9 +92,22 @@ export async function handleSdkResponseToTab(
     return { handled: true, response: undefined };
   }
 
-  if (!Number.isInteger(tabId) || tabId < 0) {
-    // Nothing was sent — do NOT mark responded (a valid retry must still deliver).
-    console.error('handleSdkResponseToTab: invalid tabId', tabId);
+  const origin = recoverDappOrigin(sender.url);
+  const validTab = Number.isInteger(tabId) && tabId >= 0;
+
+  if (!validTab) {
+    // No usable tab. If we can recover the dapp origin, deliver via the
+    // same-origin fallback (broadcast to any active tab of that origin) and
+    // mark responded — we ARE delivering, so a later duplicate must dedupe.
+    // With no origin, nothing is delivered: do NOT mark responded (a valid
+    // retry must still deliver). Either way surface the non-fatal error.
+    if (origin) {
+      if (requestId != null) {
+        store.dispatch(windowRequestResponded({ requestId }));
+      }
+      await emitSdkEventToActiveTabsWithOrigin(origin, action);
+    }
+    store.dispatch(deliveryFailedError(tabId));
     return { handled: true, response: undefined };
   }
 
@@ -84,8 +127,14 @@ export async function handleSdkResponseToTab(
 
   try {
     await tabs.sendMessage(tabId, action);
-  } catch (err) {
-    console.warn('handleSdkResponseToTab: delivery failed', err);
+  } catch {
+    // Tab gone / no listener → try the same-origin fallback (if we can recover
+    // the origin) and surface the non-fatal error. The optimistic mark above
+    // already deduped any retry.
+    if (origin) {
+      await emitSdkEventToActiveTabsWithOrigin(origin, action);
+    }
+    store.dispatch(deliveryFailedError(tabId));
   }
 
   return { handled: true, response: undefined };

--- a/src/background/private-state-broadcast.test.ts
+++ b/src/background/private-state-broadcast.test.ts
@@ -1,0 +1,82 @@
+import { backgroundEvent } from '@background/background-events';
+import { PrivateState } from '@background/handlers/private-state';
+
+import { privateStateChanged } from './private-state-broadcast';
+
+const basePrivateState: PrivateState = {
+  passwordHash: 'password-hash',
+  passwordSaltHash: 'password-salt-hash',
+  keyDerivationSaltHash: 'key-derivation-salt-hash',
+  vaultCipher: 'vault-cipher'
+};
+
+describe('privateStateChanged', () => {
+  it('returns false for two identical selections', () => {
+    expect(privateStateChanged(basePrivateState, { ...basePrivateState })).toBe(
+      false
+    );
+  });
+
+  it('returns true when passwordHash differs', () => {
+    expect(
+      privateStateChanged(basePrivateState, {
+        ...basePrivateState,
+        passwordHash: 'new-password-hash'
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when passwordSaltHash differs', () => {
+    expect(
+      privateStateChanged(basePrivateState, {
+        ...basePrivateState,
+        passwordSaltHash: 'new-password-salt-hash'
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when keyDerivationSaltHash differs', () => {
+    expect(
+      privateStateChanged(basePrivateState, {
+        ...basePrivateState,
+        keyDerivationSaltHash: 'new-key-derivation-salt-hash'
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when vaultCipher differs', () => {
+    expect(
+      privateStateChanged(basePrivateState, {
+        ...basePrivateState,
+        vaultCipher: 'new-vault-cipher'
+      })
+    ).toBe(true);
+  });
+
+  it('returns true on a null-to-value transition', () => {
+    const nullState: PrivateState = {
+      passwordHash: null,
+      passwordSaltHash: null,
+      keyDerivationSaltHash: null,
+      vaultCipher: null
+    };
+
+    expect(privateStateChanged(nullState, basePrivateState)).toBe(true);
+  });
+});
+
+describe('backgroundEvent.privateStateUpdated', () => {
+  it('is payload-free — carries no private material', () => {
+    const action = backgroundEvent.privateStateUpdated();
+
+    // toEqual treats an undefined-valued key as equal to a missing key, so
+    // this also covers the `{ type: 'privateStateUpdated' }` shape.
+    expect(action).toEqual({ type: 'privateStateUpdated' });
+    // RTK's createAction() with no payload type still attaches a `payload`
+    // key valued `undefined` at runtime (verified against this RTK version)
+    // rather than omitting the key outright. The security property that
+    // actually matters — no private material travels in the message — is
+    // that the payload carries no value, which this asserts directly.
+    expect(action.payload).toBeUndefined();
+  });
+});

--- a/src/background/private-state-broadcast.ts
+++ b/src/background/private-state-broadcast.ts
@@ -1,0 +1,14 @@
+import { PrivateState } from '@background/handlers/private-state';
+
+/** True if any private-material field differs between two selections. */
+export function privateStateChanged(
+  prev: PrivateState,
+  next: PrivateState
+): boolean {
+  return (
+    prev.passwordHash !== next.passwordHash ||
+    prev.passwordSaltHash !== next.passwordSaltHash ||
+    prev.keyDerivationSaltHash !== next.keyDerivationSaltHash ||
+    prev.vaultCipher !== next.vaultCipher
+  );
+}

--- a/src/background/redux/app-events/actions.ts
+++ b/src/background/redux/app-events/actions.ts
@@ -1,1 +1,6 @@
-export { dismissAppEvent, resetAppEventsDismission } from './reducer';
+export {
+  dismissAppEvent,
+  dismissSagaError,
+  resetAppEventsDismission,
+  sagaError
+} from './reducer';

--- a/src/background/redux/app-events/reducer.test.ts
+++ b/src/background/redux/app-events/reducer.test.ts
@@ -11,60 +11,72 @@ describe('app-events reducer', () => {
   it('has empty initial state', () => {
     expect(reducer(undefined, { type: '@@INIT' } as any)).toEqual({
       dismissedEventIds: [],
-      errors: []
+      errors: [],
+      nextErrorId: 0
     });
   });
   it('adds dismissed ids without duplicates', () => {
     const s1 = reducer(
-      { dismissedEventIds: [1], errors: [] },
+      { dismissedEventIds: [1], errors: [], nextErrorId: 0 },
       dismissAppEvent(2)
     );
-    expect(s1).toEqual({ dismissedEventIds: [1, 2], errors: [] });
+    expect(s1).toEqual({
+      dismissedEventIds: [1, 2],
+      errors: [],
+      nextErrorId: 0
+    });
     expect(reducer(s1, dismissAppEvent(2))).toEqual({
       dismissedEventIds: [1, 2],
-      errors: []
+      errors: [],
+      nextErrorId: 0
     });
   });
   it('resets', () => {
     expect(
       reducer(
-        { dismissedEventIds: [1, 2], errors: [] },
+        { dismissedEventIds: [1, 2], errors: [], nextErrorId: 5 },
         resetAppEventsDismission()
       )
-    ).toEqual({ dismissedEventIds: [], errors: [] });
+    ).toEqual({ dismissedEventIds: [], errors: [], nextErrorId: 0 });
   });
 
   describe('sagaError', () => {
-    it('appends an entry with an incrementing id', () => {
+    it('assigns ids from the monotonic counter and increments it', () => {
       const s1 = reducer(
-        { dismissedEventIds: [], errors: [] },
+        { dismissedEventIds: [], errors: [], nextErrorId: 0 },
         sagaError({ source: 'sagaA', message: 'boom' })
       );
       expect(s1.errors).toEqual([{ id: 0, source: 'sagaA', message: 'boom' }]);
+      expect(s1.nextErrorId).toBe(1);
 
       const s2 = reducer(s1, sagaError({ source: 'sagaB', message: 'bang' }));
       expect(s2.errors).toEqual([
         { id: 0, source: 'sagaA', message: 'boom' },
         { id: 1, source: 'sagaB', message: 'bang' }
       ]);
+      expect(s2.nextErrorId).toBe(2);
     });
 
     it('keeps the code field when provided, and omits it when absent', () => {
       const s1 = reducer(
-        { dismissedEventIds: [], errors: [] },
+        { dismissedEventIds: [], errors: [], nextErrorId: 0 },
         sagaError({ source: 'sagaA', message: 'boom', code: 'ERR_CODE' })
       );
       expect(s1.errors[0].code).toBe('ERR_CODE');
 
       const s2 = reducer(
-        { dismissedEventIds: [], errors: [] },
+        { dismissedEventIds: [], errors: [], nextErrorId: 0 },
         sagaError({ source: 'sagaA', message: 'boom' })
       );
       expect(s2.errors[0].code).toBeUndefined();
     });
 
-    it('caps the list at the last 10 entries, dropping the oldest', () => {
-      let state: AppEventsState = { dismissedEventIds: [], errors: [] };
+    it('caps the list at the last 10 entries, dropping the oldest, while the counter keeps climbing', () => {
+      let state: AppEventsState = {
+        dismissedEventIds: [],
+        errors: [],
+        nextErrorId: 0
+      };
       for (let i = 0; i < 11; i++) {
         state = reducer(
           state,
@@ -83,6 +95,29 @@ describe('app-events reducer', () => {
         message: 'error-10'
       });
       expect(state.errors.find(e => e.id === 0)).toBeUndefined();
+      expect(state.nextErrorId).toBe(11);
+    });
+
+    it('never reuses a dismissed id, even when it was the highest one (anti-reuse race)', () => {
+      let state: AppEventsState = {
+        dismissedEventIds: [],
+        errors: [],
+        nextErrorId: 0
+      };
+      // add 2 errors -> ids 0, 1
+      state = reducer(state, sagaError({ source: 'sagaA', message: 'a' }));
+      state = reducer(state, sagaError({ source: 'sagaB', message: 'b' }));
+      expect(state.errors.map(e => e.id)).toEqual([0, 1]);
+
+      // dismiss the highest id (1) — an in-flight dismiss for a
+      // subsequently-created error must never target this id again
+      state = reducer(state, dismissSagaError(1));
+      expect(state.errors.map(e => e.id)).toEqual([0]);
+
+      // a new error must get id 2, NOT the freed-up id 1
+      state = reducer(state, sagaError({ source: 'sagaC', message: 'c' }));
+      expect(state.errors.map(e => e.id)).toEqual([0, 2]);
+      expect(state.nextErrorId).toBe(3);
     });
   });
 
@@ -94,7 +129,8 @@ describe('app-events reducer', () => {
           { id: 0, source: 'sagaA', message: 'a' },
           { id: 1, source: 'sagaB', message: 'b' },
           { id: 2, source: 'sagaC', message: 'c' }
-        ]
+        ],
+        nextErrorId: 3
       };
       const result = reducer(seeded, dismissSagaError(1));
       expect(result.errors).toEqual([

--- a/src/background/redux/app-events/reducer.test.ts
+++ b/src/background/redux/app-events/reducer.test.ts
@@ -1,22 +1,106 @@
-import { dismissAppEvent, resetAppEventsDismission } from './actions';
+import {
+  dismissAppEvent,
+  dismissSagaError,
+  resetAppEventsDismission,
+  sagaError
+} from './actions';
 import { reducer } from './reducer';
+import { AppEventsState } from './types';
 
 describe('app-events reducer', () => {
   it('has empty initial state', () => {
     expect(reducer(undefined, { type: '@@INIT' } as any)).toEqual({
-      dismissedEventIds: []
+      dismissedEventIds: [],
+      errors: []
     });
   });
   it('adds dismissed ids without duplicates', () => {
-    const s1 = reducer({ dismissedEventIds: [1] }, dismissAppEvent(2));
-    expect(s1).toEqual({ dismissedEventIds: [1, 2] });
+    const s1 = reducer(
+      { dismissedEventIds: [1], errors: [] },
+      dismissAppEvent(2)
+    );
+    expect(s1).toEqual({ dismissedEventIds: [1, 2], errors: [] });
     expect(reducer(s1, dismissAppEvent(2))).toEqual({
-      dismissedEventIds: [1, 2]
+      dismissedEventIds: [1, 2],
+      errors: []
     });
   });
   it('resets', () => {
     expect(
-      reducer({ dismissedEventIds: [1, 2] }, resetAppEventsDismission())
-    ).toEqual({ dismissedEventIds: [] });
+      reducer(
+        { dismissedEventIds: [1, 2], errors: [] },
+        resetAppEventsDismission()
+      )
+    ).toEqual({ dismissedEventIds: [], errors: [] });
+  });
+
+  describe('sagaError', () => {
+    it('appends an entry with an incrementing id', () => {
+      const s1 = reducer(
+        { dismissedEventIds: [], errors: [] },
+        sagaError({ source: 'sagaA', message: 'boom' })
+      );
+      expect(s1.errors).toEqual([{ id: 0, source: 'sagaA', message: 'boom' }]);
+
+      const s2 = reducer(s1, sagaError({ source: 'sagaB', message: 'bang' }));
+      expect(s2.errors).toEqual([
+        { id: 0, source: 'sagaA', message: 'boom' },
+        { id: 1, source: 'sagaB', message: 'bang' }
+      ]);
+    });
+
+    it('keeps the code field when provided, and omits it when absent', () => {
+      const s1 = reducer(
+        { dismissedEventIds: [], errors: [] },
+        sagaError({ source: 'sagaA', message: 'boom', code: 'ERR_CODE' })
+      );
+      expect(s1.errors[0].code).toBe('ERR_CODE');
+
+      const s2 = reducer(
+        { dismissedEventIds: [], errors: [] },
+        sagaError({ source: 'sagaA', message: 'boom' })
+      );
+      expect(s2.errors[0].code).toBeUndefined();
+    });
+
+    it('caps the list at the last 10 entries, dropping the oldest', () => {
+      let state: AppEventsState = { dismissedEventIds: [], errors: [] };
+      for (let i = 0; i < 11; i++) {
+        state = reducer(
+          state,
+          sagaError({ source: 'saga', message: `error-${i}` })
+        );
+      }
+      expect(state.errors).toHaveLength(10);
+      expect(state.errors[0]).toEqual({
+        id: 1,
+        source: 'saga',
+        message: 'error-1'
+      });
+      expect(state.errors[9]).toEqual({
+        id: 10,
+        source: 'saga',
+        message: 'error-10'
+      });
+      expect(state.errors.find(e => e.id === 0)).toBeUndefined();
+    });
+  });
+
+  describe('dismissSagaError', () => {
+    it('removes the entry with the given id and leaves the rest', () => {
+      const seeded = {
+        dismissedEventIds: [],
+        errors: [
+          { id: 0, source: 'sagaA', message: 'a' },
+          { id: 1, source: 'sagaB', message: 'b' },
+          { id: 2, source: 'sagaC', message: 'c' }
+        ]
+      };
+      const result = reducer(seeded, dismissSagaError(1));
+      expect(result.errors).toEqual([
+        { id: 0, source: 'sagaA', message: 'a' },
+        { id: 2, source: 'sagaC', message: 'c' }
+      ]);
+    });
   });
 });

--- a/src/background/redux/app-events/reducer.ts
+++ b/src/background/redux/app-events/reducer.ts
@@ -4,7 +4,8 @@ import { AppEventsState, SagaError } from './types';
 
 const initialState: AppEventsState = {
   dismissedEventIds: [],
-  errors: []
+  errors: [],
+  nextErrorId: 0
 };
 
 const slice = createSlice({
@@ -26,11 +27,8 @@ const slice = createSlice({
         code?: string;
       }>
     ) => {
-      const nextId = state.errors.length
-        ? Math.max(...state.errors.map(error => error.id)) + 1
-        : 0;
       const entry: SagaError = {
-        id: nextId,
+        id: state.nextErrorId,
         source: action.payload.source,
         message: action.payload.message,
         ...(action.payload.code !== undefined
@@ -39,7 +37,8 @@ const slice = createSlice({
       };
       return {
         ...state,
-        errors: [...state.errors, entry].slice(-10)
+        errors: [...state.errors, entry].slice(-10),
+        nextErrorId: state.nextErrorId + 1
       };
     },
     dismissSagaError: (state, action: PayloadAction<number>) => ({

--- a/src/background/redux/app-events/reducer.ts
+++ b/src/background/redux/app-events/reducer.ts
@@ -1,9 +1,10 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import { AppEventsState } from './types';
+import { AppEventsState, SagaError } from './types';
 
 const initialState: AppEventsState = {
-  dismissedEventIds: []
+  dismissedEventIds: [],
+  errors: []
 };
 
 const slice = createSlice({
@@ -16,9 +17,42 @@ const slice = createSlice({
         ...new Set([...state.dismissedEventIds, action.payload])
       ]
     }),
-    resetAppEventsDismission: () => initialState
+    resetAppEventsDismission: () => initialState,
+    sagaError: (
+      state,
+      action: PayloadAction<{
+        source: string;
+        message: string;
+        code?: string;
+      }>
+    ) => {
+      const nextId = state.errors.length
+        ? Math.max(...state.errors.map(error => error.id)) + 1
+        : 0;
+      const entry: SagaError = {
+        id: nextId,
+        source: action.payload.source,
+        message: action.payload.message,
+        ...(action.payload.code !== undefined
+          ? { code: action.payload.code }
+          : {})
+      };
+      return {
+        ...state,
+        errors: [...state.errors, entry].slice(-10)
+      };
+    },
+    dismissSagaError: (state, action: PayloadAction<number>) => ({
+      ...state,
+      errors: state.errors.filter(error => error.id !== action.payload)
+    })
   }
 });
 
-export const { dismissAppEvent, resetAppEventsDismission } = slice.actions;
+export const {
+  dismissAppEvent,
+  resetAppEventsDismission,
+  sagaError,
+  dismissSagaError
+} = slice.actions;
 export const reducer = slice.reducer;

--- a/src/background/redux/app-events/selectors.ts
+++ b/src/background/redux/app-events/selectors.ts
@@ -2,3 +2,5 @@ import { RootState } from '@background/redux/store-types';
 
 export const selectDismissedAppEvents = (state: RootState) =>
   state.appEvents.dismissedEventIds;
+
+export const selectSagaErrors = (state: RootState) => state.appEvents.errors;

--- a/src/background/redux/app-events/types.ts
+++ b/src/background/redux/app-events/types.ts
@@ -8,4 +8,5 @@ export interface SagaError {
 export interface AppEventsState {
   dismissedEventIds: number[];
   errors: SagaError[];
+  nextErrorId: number;
 }

--- a/src/background/redux/app-events/types.ts
+++ b/src/background/redux/app-events/types.ts
@@ -1,3 +1,11 @@
+export interface SagaError {
+  id: number;
+  source: string;
+  message: string;
+  code?: string;
+}
+
 export interface AppEventsState {
   dismissedEventIds: number[];
+  errors: SagaError[];
 }

--- a/src/background/redux/get-main-store.ts
+++ b/src/background/redux/get-main-store.ts
@@ -1,6 +1,8 @@
 import { runtime, storage } from 'webextension-polyfill';
 
 import { backgroundEvent } from '@background/background-events';
+import { selectPrivateState } from '@background/handlers/private-state';
+import { privateStateChanged } from '@background/private-state-broadcast';
 import { AppEventsState } from '@background/redux/app-events/types';
 import { ContactsState } from '@background/redux/contacts/types';
 import { createStore } from '@background/redux/index';
@@ -140,6 +142,7 @@ export async function getExistingMainStoreSingletonOrInit() {
       }
       // send start action
       storeSingleton.dispatch(startBackground());
+      let previousPrivateState = selectPrivateState(storeSingleton.getState());
       // on updates propagate new state to replicas and also persist encrypted vault
       storeSingleton.subscribe(() => {
         const state = storeSingleton.getState();
@@ -151,6 +154,18 @@ export async function getExistingMainStoreSingletonOrInit() {
           .catch(() => {
             // no UI replica is open to receive the update — expected, ignore
           });
+
+        // P0.1: tell replicas to re-fetch private state on change, without
+        // ever including the private material itself in the broadcast.
+        const nextPrivateState = selectPrivateState(state);
+        if (privateStateChanged(previousPrivateState, nextPrivateState)) {
+          previousPrivateState = nextPrivateState;
+          runtime
+            .sendMessage(backgroundEvent.privateStateUpdated())
+            .catch(() => {
+              // no UI replica open to receive it — expected, ignore
+            });
+        }
 
         // persist selected state
         const {

--- a/src/background/redux/get-main-store.ts
+++ b/src/background/redux/get-main-store.ts
@@ -146,7 +146,8 @@ export async function getExistingMainStoreSingletonOrInit() {
           appEvents: appEvents
             ? {
                 dismissedEventIds: appEvents.dismissedEventIds ?? [],
-                errors: []
+                errors: [],
+                nextErrorId: 0
               }
             : undefined,
           trustedWasm

--- a/src/background/redux/get-main-store.ts
+++ b/src/background/redux/get-main-store.ts
@@ -129,7 +129,12 @@ export async function getExistingMainStoreSingletonOrInit() {
           recentRecipientPublicKeys,
           contacts,
           rateApp,
-          appEvents,
+          appEvents: appEvents
+            ? {
+                dismissedEventIds: appEvents.dismissedEventIds ?? [],
+                errors: []
+              }
+            : undefined,
           trustedWasm
         });
       }
@@ -172,7 +177,7 @@ export async function getExistingMainStoreSingletonOrInit() {
             [RECENT_RECIPIENT_PUBLIC_KEYS]: recentRecipientPublicKeys,
             [CONTACTS_KEY]: contacts,
             [RATE_APP]: rateApp,
-            [APP_EVENTS]: appEvents,
+            [APP_EVENTS]: { dismissedEventIds: appEvents.dismissedEventIds },
             [TRUSTED_WASM]: trustedWasm
           })
           .catch(e => {

--- a/src/background/redux/sagas/check-casper2-network-saga.ts
+++ b/src/background/redux/sagas/check-casper2-network-saga.ts
@@ -3,6 +3,7 @@ import { call, put, select, takeLatest } from 'redux-saga/effects';
 
 import { REFERRER_URL } from '@src/constants';
 
+import { sagaError } from '@background/redux/app-events/actions';
 import {
   activeNetworkSettingChanged,
   casperNetworkApiVersionChanged
@@ -36,5 +37,8 @@ function* checkCasper2NetworkSaga() {
     yield put(casperNetworkApiVersionChanged(status.apiVersion));
   } catch (err) {
     console.error(err);
+    yield put(
+      sagaError({ source: 'checkCasper2NetworkSaga', message: String(err) })
+    );
   }
 }

--- a/src/background/redux/sagas/check-casper2-network-saga.ts
+++ b/src/background/redux/sagas/check-casper2-network-saga.ts
@@ -11,6 +11,7 @@ import {
 import { selectApiConfigBasedOnActiveNetwork } from '@background/redux/settings/selectors';
 
 import { unlockVault } from './actions';
+import { errorToMessage } from './utils';
 
 export function* watchCasper2NetworkSaga() {
   yield takeLatest(
@@ -38,7 +39,10 @@ function* checkCasper2NetworkSaga() {
   } catch (err) {
     console.error(err);
     yield put(
-      sagaError({ source: 'checkCasper2NetworkSaga', message: String(err) })
+      sagaError({
+        source: 'checkCasper2NetworkSaga',
+        message: errorToMessage(err)
+      })
     );
   }
 }

--- a/src/background/redux/sagas/onboarding-sagas.ts
+++ b/src/background/redux/sagas/onboarding-sagas.ts
@@ -39,6 +39,7 @@ import {
   vaultReseted
 } from '../vault/actions';
 import { initKeys, initVault, recoverVault, resetVault } from './actions';
+import { errorToMessage } from './utils';
 
 export function* onboardingSagas() {
   yield takeLatest(resetVault.type, resetVaultSaga);
@@ -68,7 +69,9 @@ function* resetVaultSaga() {
     storage.local.clear();
   } catch (err) {
     console.error(err);
-    yield put(sagaError({ source: 'resetVaultSaga', message: String(err) }));
+    yield put(
+      sagaError({ source: 'resetVaultSaga', message: errorToMessage(err) })
+    );
   }
 }
 
@@ -101,7 +104,9 @@ function* initKeysSage(action: ReturnType<typeof initKeys>) {
     );
   } catch (err) {
     console.error(err);
-    yield put(sagaError({ source: 'initKeysSage', message: String(err) }));
+    yield put(
+      sagaError({ source: 'initKeysSage', message: errorToMessage(err) })
+    );
   }
 }
 
@@ -129,7 +134,9 @@ function* initVaultSaga(action: ReturnType<typeof initVault>) {
     disableOnboardingFlow();
   } catch (err) {
     console.error(err);
-    yield put(sagaError({ source: 'initVaultSaga', message: String(err) }));
+    yield put(
+      sagaError({ source: 'initVaultSaga', message: errorToMessage(err) })
+    );
   }
 }
 
@@ -147,6 +154,8 @@ function* recoverVaultSaga(action: ReturnType<typeof recoverVault>) {
     disableOnboardingFlow();
   } catch (err) {
     console.error(err);
-    yield put(sagaError({ source: 'recoverVaultSaga', message: String(err) }));
+    yield put(
+      sagaError({ source: 'recoverVaultSaga', message: errorToMessage(err) })
+    );
   }
 }

--- a/src/background/redux/sagas/onboarding-sagas.ts
+++ b/src/background/redux/sagas/onboarding-sagas.ts
@@ -4,7 +4,10 @@ import { storage } from 'webextension-polyfill';
 import { ErrorMessages } from '@src/constants';
 
 import { disableOnboardingFlow } from '@background/open-onboarding-flow';
-import { resetAppEventsDismission } from '@background/redux/app-events/actions';
+import {
+  resetAppEventsDismission,
+  sagaError
+} from '@background/redux/app-events/actions';
 import { contactsReseted } from '@background/redux/contacts/actions';
 import { resetRateApp } from '@background/redux/rate-app/actions';
 import { recipientPublicKeyReseted } from '@background/redux/recent-recipient-public-keys/actions';
@@ -65,6 +68,7 @@ function* resetVaultSaga() {
     storage.local.clear();
   } catch (err) {
     console.error(err);
+    yield put(sagaError({ source: 'resetVaultSaga', message: String(err) }));
   }
 }
 
@@ -97,6 +101,7 @@ function* initKeysSage(action: ReturnType<typeof initKeys>) {
     );
   } catch (err) {
     console.error(err);
+    yield put(sagaError({ source: 'initKeysSage', message: String(err) }));
   }
 }
 
@@ -124,6 +129,7 @@ function* initVaultSaga(action: ReturnType<typeof initVault>) {
     disableOnboardingFlow();
   } catch (err) {
     console.error(err);
+    yield put(sagaError({ source: 'initVaultSaga', message: String(err) }));
   }
 }
 
@@ -141,5 +147,6 @@ function* recoverVaultSaga(action: ReturnType<typeof recoverVault>) {
     disableOnboardingFlow();
   } catch (err) {
     console.error(err);
+    yield put(sagaError({ source: 'recoverVaultSaga', message: String(err) }));
   }
 }

--- a/src/background/redux/sagas/utils.test.ts
+++ b/src/background/redux/sagas/utils.test.ts
@@ -1,0 +1,19 @@
+import { errorToMessage } from './utils';
+
+describe('errorToMessage', () => {
+  it('returns the message of an Error instance', () => {
+    expect(errorToMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('stringifies a plain object', () => {
+    expect(errorToMessage({})).toBe('[object Object]');
+  });
+
+  it('stringifies a string as-is', () => {
+    expect(errorToMessage('x')).toBe('x');
+  });
+
+  it('stringifies null', () => {
+    expect(errorToMessage(null)).toBe('null');
+  });
+});

--- a/src/background/redux/sagas/utils.ts
+++ b/src/background/redux/sagas/utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Converts an unknown caught value into a user-facing error message.
+ *
+ * `String(err)` on a non-`Error` throw (e.g. a plain object) renders the
+ * unhelpful `"[object Object]"`; this keeps the `Error#message` when available
+ * and only falls back to `String` otherwise.
+ */
+export const errorToMessage = (err: unknown): string =>
+  err instanceof Error ? err.message : String(err);

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -79,6 +79,7 @@ import {
   startBackground,
   unlockVault
 } from './actions';
+import { errorToMessage } from './utils';
 
 export function* vaultSagas() {
   yield takeLatest(lockVault.type, lockVaultSaga);
@@ -146,7 +147,9 @@ export function* lockVaultSaga() {
     yield* sagaCall(clearAutoLockDeadline);
   } catch (err) {
     console.error(err);
-    yield put(sagaError({ source: 'lockVaultSaga', message: String(err) }));
+    yield put(
+      sagaError({ source: 'lockVaultSaga', message: errorToMessage(err) })
+    );
   }
 }
 
@@ -298,7 +301,9 @@ function* unlockVaultSaga(action: ReturnType<typeof unlockVault>) {
     }
   } catch (err) {
     console.error(err);
-    yield put(sagaError({ source: 'unlockVaultSaga', message: String(err) }));
+    yield put(
+      sagaError({ source: 'unlockVaultSaga', message: errorToMessage(err) })
+    );
   } finally {
     releaseAnchor();
   }
@@ -379,7 +384,7 @@ export function* timeoutCounterSaga(
   } catch (err) {
     console.error(err);
     yield put(
-      sagaError({ source: 'timeoutCounterSaga', message: String(err) })
+      sagaError({ source: 'timeoutCounterSaga', message: errorToMessage(err) })
     );
   }
 }
@@ -409,7 +414,9 @@ function* updateVaultCipher() {
     );
   } catch (err) {
     console.error(err);
-    yield put(sagaError({ source: 'updateVaultCipher', message: String(err) }));
+    yield put(
+      sagaError({ source: 'updateVaultCipher', message: errorToMessage(err) })
+    );
   } finally {
     releaseAnchor();
   }
@@ -463,7 +470,9 @@ function* createAccountSaga(action: ReturnType<typeof createAccount>) {
     }
   } catch (err) {
     console.error(err);
-    yield put(sagaError({ source: 'createAccountSaga', message: String(err) }));
+    yield put(
+      sagaError({ source: 'createAccountSaga', message: errorToMessage(err) })
+    );
   } finally {
     releaseAnchor();
   }

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -7,6 +7,7 @@ import {
   MapTimeoutDurationSettingToValue
 } from '@popup/constants';
 
+import { sagaError } from '@background/redux/app-events/actions';
 import {
   loginRetryLockoutTimeReseted,
   loginRetryLockoutTimeSet
@@ -131,6 +132,7 @@ function* lockVaultSaga() {
     });
   } catch (err) {
     console.error(err);
+    yield put(sagaError({ source: 'lockVaultSaga', message: String(err) }));
   }
 }
 
@@ -235,6 +237,7 @@ function* unlockVaultSaga(action: ReturnType<typeof unlockVault>) {
     }
   } catch (err) {
     console.error(err);
+    yield put(sagaError({ source: 'unlockVaultSaga', message: String(err) }));
   }
 }
 
@@ -278,6 +281,9 @@ function* timeoutCounterSaga() {
     }
   } catch (err) {
     console.error(err);
+    yield put(
+      sagaError({ source: 'timeoutCounterSaga', message: String(err) })
+    );
   } finally {
     //
   }
@@ -304,6 +310,7 @@ function* updateVaultCipher() {
     );
   } catch (err) {
     console.error(err);
+    yield put(sagaError({ source: 'updateVaultCipher', message: String(err) }));
   }
 }
 
@@ -351,5 +358,6 @@ function* createAccountSaga(action: ReturnType<typeof createAccount>) {
     }
   } catch (err) {
     console.error(err);
+    yield put(sagaError({ source: 'createAccountSaga', message: String(err) }));
   }
 }

--- a/src/background/utils.test.ts
+++ b/src/background/utils.test.ts
@@ -140,17 +140,23 @@ describe('emitSdkEventToActiveTabsWithOrigin', () => {
     queryMock.mockResolvedValue([matchingTab, otherOriginTab]);
     sendMessageMock.mockResolvedValue(undefined);
 
-    await emitSdkEventToActiveTabsWithOrigin('https://foo.com', testAction);
+    const delivered = await emitSdkEventToActiveTabsWithOrigin(
+      'https://foo.com',
+      testAction
+    );
 
     expect(sendMessageMock).toHaveBeenCalledTimes(1);
     expect(sendMessageMock).toHaveBeenCalledWith(1, testAction);
+    // Delivered to exactly the one matching tab.
+    expect(delivered).toBe(1);
   });
 
   it('does not query or send when origin is empty', async () => {
-    await emitSdkEventToActiveTabsWithOrigin('', testAction);
+    const delivered = await emitSdkEventToActiveTabsWithOrigin('', testAction);
 
     expect(queryMock).not.toHaveBeenCalled();
     expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(delivered).toBe(0);
   });
 
   it('isolates a failing tab: second matching tab still receives its send and the function resolves', async () => {
@@ -164,9 +170,10 @@ describe('emitSdkEventToActiveTabsWithOrigin', () => {
       return undefined;
     });
 
+    // Only the second tab's send succeeded → count is 1, not 2.
     await expect(
       emitSdkEventToActiveTabsWithOrigin('https://foo.com', testAction)
-    ).resolves.toBeUndefined();
+    ).resolves.toBe(1);
 
     expect(sendMessageMock).toHaveBeenCalledWith(1, testAction);
     expect(sendMessageMock).toHaveBeenCalledWith(2, testAction);
@@ -181,7 +188,7 @@ describe('emitSdkEventToActiveTabsWithOrigin', () => {
 
     await expect(
       emitSdkEventToActiveTabsWithOrigin('https://foo.com', testAction)
-    ).resolves.toBeUndefined();
+    ).resolves.toBe(1);
 
     expect(sendMessageMock).toHaveBeenCalledTimes(1);
     expect(sendMessageMock).toHaveBeenCalledWith(2, testAction);

--- a/src/background/utils.ts
+++ b/src/background/utils.ts
@@ -34,19 +34,25 @@ export async function emitSdkEventToActiveTabs(
   );
 }
 
+// Returns the number of tabs the action was SUCCESSFULLY delivered to. The
+// same-origin delivery fallback (`handleSdkResponseToTab`) uses this count to
+// decide whether the response actually reached the dapp; the SDK-event callers
+// ignore the return value (backward-compatible).
 export async function emitSdkEventToActiveTabsWithOrigin(
   origin: string,
   // A method **response** may also be broadcast through here as a same-origin
   // delivery fallback (see `handleSdkResponseToTab`), hence `SdkEvent | SdkMethod`.
   action: SdkEvent | SdkMethod
-) {
+): Promise<number> {
   if (!origin) {
-    return;
+    return 0;
   }
 
   const tabsList = await tabs.query({
     active: true
   });
+
+  let delivered = 0;
 
   await Promise.all(
     tabsList.map(async tab => {
@@ -59,6 +65,7 @@ export async function emitSdkEventToActiveTabsWithOrigin(
         ) {
           try {
             await tabs.sendMessage(tab.id, action);
+            delivered += 1;
           } catch (error) {
             console.warn('Failed to send SDK event to tab: ' + tab.id, error);
           }
@@ -68,4 +75,6 @@ export async function emitSdkEventToActiveTabsWithOrigin(
       }
     })
   );
+
+  return delivered;
 }

--- a/src/background/utils.ts
+++ b/src/background/utils.ts
@@ -3,6 +3,7 @@ import { Tabs, tabs } from 'webextension-polyfill';
 import { getUrlOrigin, hasHttpPrefix } from '@src/utils';
 
 import { SdkEvent } from '@content/sdk-event';
+import { SdkMethod } from '@content/sdk-method';
 
 export async function emitSdkEventToActiveTabs(
   callback: (tab: Tabs.Tab) => SdkEvent | undefined
@@ -35,7 +36,9 @@ export async function emitSdkEventToActiveTabs(
 
 export async function emitSdkEventToActiveTabsWithOrigin(
   origin: string,
-  action: SdkEvent
+  // A method **response** may also be broadcast through here as a same-origin
+  // delivery fallback (see `handleSdkResponseToTab`), hence `SdkEvent | SdkMethod`.
+  action: SdkEvent | SdkMethod
 ) {
   if (!origin) {
     return;

--- a/src/fixtures/initial-state-for-popup-tests.ts
+++ b/src/fixtures/initial-state-for-popup-tests.ts
@@ -111,6 +111,7 @@ export const initialStateForPopupTests: RootState = {
     askForReviewAfter: null
   },
   appEvents: {
-    dismissedEventIds: []
+    dismissedEventIds: [],
+    errors: []
   }
 };

--- a/src/fixtures/initial-state-for-popup-tests.ts
+++ b/src/fixtures/initial-state-for-popup-tests.ts
@@ -112,6 +112,7 @@ export const initialStateForPopupTests: RootState = {
   },
   appEvents: {
     dismissedEventIds: [],
-    errors: []
+    errors: [],
+    nextErrorId: 0
   }
 };

--- a/src/hooks/use-private-state.test.ts
+++ b/src/hooks/use-private-state.test.ts
@@ -9,6 +9,18 @@ jest.mock('@background/handlers/private-state', () => ({
   fetchPrivateState: jest.fn()
 }));
 
+// `use-private-state` imports `webextension-polyfill` directly (to listen for
+// the payload-free `privateStateUpdated` push signal), which throws outside a
+// browser extension. Stub it so the module can load under this node-env suite.
+jest.mock('webextension-polyfill', () => ({
+  runtime: {
+    onMessage: {
+      addListener: jest.fn(),
+      removeListener: jest.fn()
+    }
+  }
+}));
+
 const fetchMock = fetchPrivateState as jest.MockedFunction<
   typeof fetchPrivateState
 >;

--- a/src/hooks/use-private-state.ts
+++ b/src/hooks/use-private-state.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
+import { runtime } from 'webextension-polyfill';
 
+import { backgroundEvent } from '@background/background-events';
 import {
   PrivateState,
   fetchPrivateState
@@ -85,6 +87,21 @@ export function usePrivateState(): UsePrivateStateResult {
       mounted = false;
     };
   }, [fetchAttemptId]);
+
+  useEffect(() => {
+    function listener(message: unknown) {
+      if (backgroundEvent.privateStateUpdated.match(message)) {
+        setFetchAttemptId(id => id + 1);
+      }
+      return undefined;
+    }
+
+    runtime.onMessage.addListener(listener);
+
+    return () => {
+      runtime.onMessage.removeListener(listener);
+    };
+  }, []);
 
   const retry = useCallback(() => setFetchAttemptId(id => id + 1), []);
 

--- a/src/libs/ui/components/saga-error-banner/saga-error-banner.tsx
+++ b/src/libs/ui/components/saga-error-banner/saga-error-banner.tsx
@@ -16,7 +16,6 @@ const BannerContainer = styled(FlexColumn)`
   top: 0;
   left: 0;
   right: 0;
-  width: 360px;
   z-index: ${({ theme }) => theme.zIndex.tooltip};
 
   max-height: 100vh;
@@ -90,8 +89,8 @@ export const SagaErrorBanner = () => {
           </ErrorTextContainer>
           <DismissButton
             type="button"
-            aria-label={'dismiss'}
-            title={'dismiss'}
+            aria-label={t('Dismiss')}
+            title={t('Dismiss')}
             onClick={() => handleDismiss(error.id)}
           >
             <SvgIcon src="assets/icons/close.svg" size={16} />

--- a/src/libs/ui/components/saga-error-banner/saga-error-banner.tsx
+++ b/src/libs/ui/components/saga-error-banner/saga-error-banner.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
+import styled from 'styled-components';
+
+import { dismissSagaError } from '@background/redux/app-events/actions';
+import { selectSagaErrors } from '@background/redux/app-events/selectors';
+import { SagaError } from '@background/redux/app-events/types';
+import { dispatchToMainStore } from '@background/redux/utils';
+
+import { AlignedFlexRow, FlexColumn, SpacingSize } from '@libs/layout';
+import { SvgIcon, Typography } from '@libs/ui/components';
+
+const BannerContainer = styled(FlexColumn)`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 360px;
+  z-index: ${({ theme }) => theme.zIndex.tooltip};
+
+  max-height: 100vh;
+  overflow-y: auto;
+
+  background: ${({ theme }) => theme.color.backgroundPrimary};
+  border-bottom: 1px solid ${({ theme }) => theme.color.borderPrimary};
+  box-shadow: ${({ theme }) => theme.shadow.contextMenu};
+`;
+
+const ErrorRow = styled(AlignedFlexRow)`
+  align-items: flex-start;
+  padding: 12px 16px;
+
+  border-bottom: 1px solid ${({ theme }) => theme.color.borderPrimary};
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const ErrorTextContainer = styled(FlexColumn)`
+  flex: 1;
+  min-width: 0;
+  word-break: break-word;
+`;
+
+const DismissButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 0;
+  margin-left: auto;
+
+  border: none;
+  background: none;
+
+  cursor: pointer;
+`;
+
+export const SagaErrorBanner = () => {
+  const { t } = useTranslation();
+
+  const errors = useSelector(selectSagaErrors);
+
+  if (errors.length === 0) {
+    return null;
+  }
+
+  const handleDismiss = (id: SagaError['id']) => {
+    dispatchToMainStore(dismissSagaError(id));
+  };
+
+  return (
+    <BannerContainer role="alert">
+      {errors.map(error => (
+        <ErrorRow key={error.id} gap={SpacingSize.Small}>
+          <SvgIcon
+            src="assets/icons/error.svg"
+            size={20}
+            color="contentActionCritical"
+          />
+          <ErrorTextContainer gap={SpacingSize.Tiny}>
+            <Typography type="bodySemiBold">
+              <Trans t={t}>Something went wrong</Trans>
+            </Typography>
+            <Typography type="captionRegular" color="contentSecondary">
+              {error.source}: {error.message}
+            </Typography>
+          </ErrorTextContainer>
+          <DismissButton
+            type="button"
+            aria-label={'dismiss'}
+            title={'dismiss'}
+            onClick={() => handleDismiss(error.id)}
+          >
+            <SvgIcon src="assets/icons/close.svg" size={16} />
+          </DismissButton>
+        </ErrorRow>
+      ))}
+    </BannerContainer>
+  );
+};


### PR DESCRIPTION
## DEP-99 PR4 — saga error channel (P1.2 + P1.4)

Part of the DEP-99 security & architecture backlog ([WALLET-1343](https://make-software.atlassian.net/browse/WALLET-1343)). Fourth of the thematic PRs; targets `release/2.6.0`.

Before this change, background sagas that failed only `console.error`'d — the failure was invisible to the user and to any dapp waiting on a response. This PR adds a non-fatal error surface and closes two silent-failure gaps.

### What's in it

**P1.2 — saga error channel + non-fatal banner**

- New `sagaError` / `dismissSagaError` actions and `selectSagaErrors` selector on the `appEvents` slice. `errors` is capped to the last 10, uses a monotonic id counter, and is **runtime-only** — it is deliberately excluded from `storage.local` persistence (only `dismissedEventIds` round-trips), so a stale error never reappears after a service-worker restart.
- All 10 background saga catch blocks (`vault-sagas`, `onboarding-sagas`, `check-casper2-network-saga`) now `yield put(sagaError(...))` alongside the existing `console.error`.
- A dismissable `SagaErrorBanner` renders `selectSagaErrors` from the read-only replica; dismiss dispatches `dismissSagaError(id)` back to the background store. It is mounted in every UI app (popup, onboarding, connect-to-app, signature-request, import-account-with-file), so an error raised while any window is open surfaces there.

**P1.4 — stale/dead tab-id delivery fallback**

- When the background delivers an SDK **response** to the originating dapp tab and that tab is gone (closed / no listener) or the captured `tabId` is invalid, it now recovers the dapp origin from the request window's URL and re-delivers to any active same-origin tab via `emitSdkEventToActiveTabsWithOrigin`, surfacing a non-fatal `sagaError`. The existing atomic response-dedup (mark-responded-before-`await`) and the `isTrustedUiSender` gate are preserved.

**Private-state resubscribe (PR #1394 review #2)**

- The UI used to snapshot private state once on mount and never refresh, so a password change in one window left another window validating the old hash. The background now emits a **payload-free** `privateStateUpdated` signal when private material changes, and `usePrivateState` re-fetches on receipt (reusing the existing timeout + bounded-retry path). No secret material is ever placed in the broadcast (P0.1 preserved).

### Scope / deviations from the appendix

- **Sentry is a deliberate NON-GOAL.** P1.2 in the appendix reads "…+ Sentry", but there is no Sentry SDK in the repo and adding telemetry to a self-custody wallet is a product decision — so P1.2 here is scoped to the in-app error channel + banner only. This is an intentional omission, not an oversight.
- **P1.4 `tabs.get` pre-check deviation.** The appendix suggests pre-checking `tabs.get(tabId)`; instead the handler catches the `tabs.sendMessage` rejection and falls back. This is atomic (no TOCTOU gap between the check and the send) and saves a round-trip, while detecting the same dead/stale-tab condition.

### Security notes

- No private material (`passwordHash` / salts / `vaultCipher`) appears in any broadcast to UI replicas; the `privateStateUpdated` signal carries nothing but its type string.
- The `sagaError` surfaced on a failed SDK delivery references only the `tabId` and a static reason — never the response action or its payload (which may contain a signature / encrypted message).
- **Intentional trade-off:** the same-origin delivery fallback broadcasts the response to _all_ active tabs of the requesting dapp's origin, not only the original tab. This is bounded by an exact origin match, and only the tab with the matching pending `requestId` resolves it — a best-effort recovery, not a cross-origin leak.

### Review response (Comp0te)

All findings from the first review are addressed:

- **Critical — banner un-dismissable** (`dismissSagaError` missing from `FORWARDED_ACTION_TYPES`): fixed + routing-level test added.
- **Medium — misleading fallback message**: message now reflects whether the fallback actually delivered.
- **Medium — mark-responded on zero delivery / unguarded emit**: `emitSdkEventToActiveTabsWithOrigin` returns a delivered count (mark responded only when `> 0`); the fallback emit is wrapped so a `tabs.query` rejection can't reject the handler.
- **Medium — banner popup-only**: now mounted in all UI apps (onboarding-saga errors surface).
- **Low — id-reuse race**: replaced derived id with a monotonic counter + regression test.
- **Minors**: safe `errorToMessage` for non-`Error` throws (all 10 catch blocks); translated dismiss `aria-label`/`title`; banner now full-width (removed the contradictory fixed `360px`).

### Verification

- `npm run ci-check` green (256 tests, tsc clean, 0 lint errors).
- Chrome + Firefox production builds succeed.
- Whole-branch review: ready to merge (no Critical/Important findings); first external review fixes applied.

### Owner-gated (not done here)

- Safari build (requires macOS + Xcode).
- Manual QA: (a) force a saga error → banner shows + **dismisses** (validates the Critical fix); (b) force an onboarding-saga error → banner renders in the onboarding window; (c) close the dapp tab before approving a request → response reaches a same-origin tab; (d) change password in one window with `password-protection-page` mounted in another → the mounted page accepts the NEW password.
- Full Playwright e2e (onboarding + popup) via CI.

### Notes

- New user-facing strings ride the English fallback (`locale:extract_pot` intentionally not run — the stale catalog would add unrelated diff).

[WALLET-1343]: https://make-software.atlassian.net/browse/WALLET-1343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
