### PR TITLE
fix: WALLET-1344 — cancel pending dapp SDK requests when the approval window is closed via "X"

### DIFF
--- a/src/apps/connect-to-app/pages/switch-account/index.tsx
+++ b/src/apps/connect-to-app/pages/switch-account/index.tsx
@@ -31,7 +31,7 @@ export function SwitchAccountPage() {
 
   const handleCancel = async () => {
     await sendSdkResponseToSpecificTab(
-      sdkMethod.connectResponse(false, { requestId }),
+      sdkMethod.switchAccountResponse(false, { requestId }),
       requestTabId
     );
     closeCurrentWindow();

--- a/src/apps/signature-request/pages/decrypt-message/index.tsx
+++ b/src/apps/signature-request/pages/decrypt-message/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { shallowEqual, useSelector } from 'react-redux';
 
@@ -121,12 +121,6 @@ export function DecryptMessagePage() {
     );
     closeCurrentWindow();
   }, [requestId, requestTabId]);
-
-  useEffect(() => {
-    window.addEventListener('beforeunload', handleCancel);
-
-    return () => window.removeEventListener('beforeunload', handleCancel);
-  }, [handleCancel]);
 
   const handleDecrypt = useCallback(async () => {
     try {

--- a/src/apps/signature-request/pages/sign-eip712/index.tsx
+++ b/src/apps/signature-request/pages/sign-eip712/index.tsx
@@ -3,7 +3,7 @@ import {
   IEIP712SignTypedDataOptions,
   IEIP712TypedData
 } from 'casper-wallet-core';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { shallowEqual, useSelector } from 'react-redux';
 
@@ -248,12 +248,6 @@ export function SignEip712Page() {
     requestId,
     requestTabId
   ]);
-
-  useEffect(() => {
-    window.addEventListener('beforeunload', handleCancel);
-
-    return () => window.removeEventListener('beforeunload', handleCancel);
-  }, [handleCancel]);
 
   const renderFooter = () => {
     if (shouldTryToConnectAccount) {

--- a/src/apps/signature-request/pages/sign-message/index.tsx
+++ b/src/apps/signature-request/pages/sign-message/index.tsx
@@ -253,7 +253,7 @@ export function SignMessagePage() {
 
   const handleCancel = useCallback(() => {
     sendSdkResponseToSpecificTab(
-      sdkMethod.signResponse({ cancelled: true }, { requestId }),
+      sdkMethod.signMessageResponse({ cancelled: true }, { requestId }),
       requestTabId
     );
     closeCurrentWindow();

--- a/src/apps/signature-request/pages/sign-message/index.tsx
+++ b/src/apps/signature-request/pages/sign-message/index.tsx
@@ -259,12 +259,6 @@ export function SignMessagePage() {
     closeCurrentWindow();
   }, [requestId, requestTabId]);
 
-  useEffect(() => {
-    window.addEventListener('beforeunload', handleCancel);
-
-    return () => window.removeEventListener('beforeunload', handleCancel);
-  }, [handleCancel]);
-
   return (
     <LayoutWindow
       renderHeader={() => (

--- a/src/apps/signature-request/pages/sign-transaction/index.tsx
+++ b/src/apps/signature-request/pages/sign-transaction/index.tsx
@@ -279,12 +279,6 @@ export function SignTransactionPage() {
     closeCurrentWindow();
   }, [requestId, requestTabId]);
 
-  useEffect(() => {
-    window.addEventListener('beforeunload', handleCancel);
-
-    return () => window.removeEventListener('beforeunload', handleCancel);
-  }, [handleCancel]);
-
   const {
     ledgerEventStatusToRender,
     makeSubmitLedgerAction,

--- a/src/background/handlers/cancel-open-requests-on-close.test.ts
+++ b/src/background/handlers/cancel-open-requests-on-close.test.ts
@@ -1,0 +1,213 @@
+import { tabs } from 'webextension-polyfill';
+
+import { emitSdkEventToActiveTabsWithOrigin } from '@background/utils';
+
+import { sdkMethod } from '@content/sdk-method';
+
+import {
+  CANCEL_GRACE_MS,
+  buildCancelResponse,
+  cancelOpenRequestsForClosedWindow
+} from './cancel-open-requests-on-close';
+
+jest.mock('webextension-polyfill', () => ({
+  tabs: { sendMessage: jest.fn() }
+}));
+jest.mock('@background/utils', () => ({
+  emitSdkEventToActiveTabsWithOrigin: jest.fn()
+}));
+
+const state = (
+  windowId: number | null,
+  requests: any,
+  pendingRequests: any
+) => ({
+  windowManagement: { windowId, requests, pendingRequests }
+});
+const closed = () =>
+  expect.objectContaining({ type: expect.stringContaining('windowIdCleared') });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+});
+afterEach(() => jest.useRealTimers());
+
+describe('buildCancelResponse', () => {
+  const c = (m: any) => buildCancelResponse(m, 'r');
+  it('connect', () =>
+    expect(c('connect')).toEqual(
+      sdkMethod.connectResponse(false, { requestId: 'r' })
+    ));
+  it('switchAccount', () =>
+    expect(c('switchAccount')).toEqual(
+      sdkMethod.switchAccountResponse(false, { requestId: 'r' })
+    ));
+  it('sign', () =>
+    expect(c('sign')).toEqual(
+      sdkMethod.signResponse({ cancelled: true }, { requestId: 'r' })
+    ));
+  it('signMessage', () =>
+    expect(c('signMessage')).toEqual(
+      sdkMethod.signMessageResponse({ cancelled: true }, { requestId: 'r' })
+    ));
+  it('signTypedData', () =>
+    expect(c('signTypedData')).toEqual(
+      sdkMethod.signTypedDataResponse(
+        {
+          cancelled: true,
+          signature: null,
+          digest: null,
+          publicKey: null,
+          error: null
+        },
+        { requestId: 'r' }
+      )
+    ));
+  it('decryptMessage', () =>
+    expect(c('decryptMessage')).toEqual(
+      sdkMethod.decryptMessageResponse({ cancelled: true }, { requestId: 'r' })
+    ));
+});
+
+describe('cancelOpenRequestsForClosedWindow', () => {
+  const run = async (getState: jest.Mock) => {
+    const dispatch = jest.fn();
+    const p = cancelOpenRequestsForClosedWindow(
+      { dispatch, getState } as any,
+      7
+    );
+    await jest.advanceTimersByTimeAsync(CANCEL_GRACE_MS);
+    await p;
+    return dispatch;
+  };
+
+  it('still open after grace → sends cancel, marks responded, clears windowId', async () => {
+    (tabs.sendMessage as jest.Mock).mockResolvedValue(undefined);
+    const s = state(
+      7,
+      { r1: 'open' },
+      { r1: { tabId: 3, origin: 'https://d', method: 'sign' } }
+    );
+    const dispatch = await run(jest.fn().mockReturnValue(s));
+    expect(tabs.sendMessage).toHaveBeenCalledWith(
+      3,
+      sdkMethod.signResponse({ cancelled: true }, { requestId: 'r1' })
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: expect.stringContaining('windowRequestResponded')
+      })
+    );
+    expect(dispatch).toHaveBeenCalledWith(closed());
+  });
+
+  it('genuine response arrives during grace → not cancelled', async () => {
+    const getState = jest
+      .fn()
+      .mockReturnValueOnce(
+        state(
+          7,
+          { r1: 'open' },
+          { r1: { tabId: 3, origin: 'o', method: 'sign' } }
+        )
+      )
+      .mockReturnValue(
+        state(
+          7,
+          { r1: 'responded' },
+          { r1: { tabId: 3, origin: 'o', method: 'sign' } }
+        )
+      );
+    const dispatch = await run(getState);
+    expect(tabs.sendMessage).not.toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith(closed());
+  });
+
+  it('new request opened during grace → not cancelled, windowId not cleared', async () => {
+    (tabs.sendMessage as jest.Mock).mockResolvedValue(undefined);
+    const getState = jest
+      .fn()
+      .mockReturnValueOnce(
+        state(
+          7,
+          { r1: 'open' },
+          { r1: { tabId: 3, origin: 'o', method: 'sign' } }
+        )
+      )
+      .mockReturnValue(
+        state(
+          99,
+          { r1: 'open', r2: 'open' },
+          {
+            r1: { tabId: 3, origin: 'o', method: 'sign' },
+            r2: { tabId: 4, origin: 'o', method: 'connect' }
+          }
+        )
+      );
+    const dispatch = await run(getState);
+    expect(tabs.sendMessage).toHaveBeenCalledTimes(1);
+    expect(tabs.sendMessage).toHaveBeenCalledWith(
+      3,
+      sdkMethod.signResponse({ cancelled: true }, { requestId: 'r1' })
+    );
+    expect(dispatch).not.toHaveBeenCalledWith(closed()); // windowId already moved to 99
+  });
+
+  it('nothing open → no send, clears windowId', async () => {
+    const dispatch = jest.fn();
+    const getState = jest
+      .fn()
+      .mockReturnValue(state(7, { r1: 'responded' }, {}));
+    await cancelOpenRequestsForClosedWindow({ dispatch, getState } as any, 7);
+    expect(tabs.sendMessage).not.toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith(closed());
+  });
+
+  it('send fails, fallback delivers nothing → sagaError "not delivered"', async () => {
+    (tabs.sendMessage as jest.Mock).mockRejectedValue(new Error('gone'));
+    (emitSdkEventToActiveTabsWithOrigin as jest.Mock).mockResolvedValue(0);
+    const dispatch = await run(
+      jest
+        .fn()
+        .mockReturnValue(
+          state(
+            7,
+            { r1: 'open' },
+            { r1: { tabId: 3, origin: 'https://d', method: 'connect' } }
+          )
+        )
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          source: 'cancel-on-close',
+          message: expect.stringContaining('not delivered')
+        })
+      })
+    );
+  });
+
+  it('send fails, fallback delivers → sagaError "same-origin fallback"', async () => {
+    (tabs.sendMessage as jest.Mock).mockRejectedValue(new Error('gone'));
+    (emitSdkEventToActiveTabsWithOrigin as jest.Mock).mockResolvedValue(1);
+    const dispatch = await run(
+      jest
+        .fn()
+        .mockReturnValue(
+          state(
+            7,
+            { r1: 'open' },
+            { r1: { tabId: 3, origin: 'https://d', method: 'connect' } }
+          )
+        )
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          message: expect.stringContaining('same-origin fallback')
+        })
+      })
+    );
+  });
+});

--- a/src/background/handlers/cancel-open-requests-on-close.ts
+++ b/src/background/handlers/cancel-open-requests-on-close.ts
@@ -1,0 +1,111 @@
+import { tabs } from 'webextension-polyfill';
+
+import { sagaError } from '@background/redux/app-events/actions';
+import { MainStore } from '@background/redux/get-main-store';
+import {
+  windowIdCleared,
+  windowRequestResponded
+} from '@background/redux/windowManagement/actions';
+import {
+  selectOpenRequests,
+  selectWindowId
+} from '@background/redux/windowManagement/selectors';
+import { CancellableMethod } from '@background/redux/windowManagement/types';
+
+import { SdkMethod, sdkMethod } from '@content/sdk-method';
+
+import { deliverViaOrigin } from './deliver-via-origin';
+
+// Grace before assuming a closed window means "cancelled": lets an in-flight genuine
+// response (a button response, or a Ledger success cleanup that closes this window) land
+// and mark itself 'responded' first. ~250 ms >> one in-process runtime.sendMessage hop.
+export const CANCEL_GRACE_MS = 250;
+const delay = (ms: number) =>
+  new Promise<void>(resolve => setTimeout(resolve, ms));
+
+export function buildCancelResponse(
+  method: CancellableMethod,
+  requestId: string
+): SdkMethod {
+  const meta = { requestId };
+  switch (method) {
+    case 'connect':
+      return sdkMethod.connectResponse(false, meta);
+    case 'switchAccount':
+      return sdkMethod.switchAccountResponse(false, meta);
+    case 'sign':
+      return sdkMethod.signResponse({ cancelled: true }, meta);
+    case 'signMessage':
+      return sdkMethod.signMessageResponse({ cancelled: true }, meta);
+    case 'signTypedData':
+      return sdkMethod.signTypedDataResponse(
+        {
+          cancelled: true,
+          signature: null,
+          digest: null,
+          publicKey: null,
+          error: null
+        },
+        meta
+      );
+    case 'decryptMessage':
+      return sdkMethod.decryptMessageResponse({ cancelled: true }, meta);
+  }
+}
+
+export async function cancelOpenRequestsForClosedWindow(
+  store: MainStore,
+  removedWindowId: number
+): Promise<void> {
+  const initiallyOpen = selectOpenRequests(store.getState());
+
+  // Null windowId only if the removed window is still the tracked one (no new window took
+  // over during the grace). windowIdCleared touches ONLY windowId — never the requests map —
+  // so it cannot clobber a concurrently-registered request.
+  const clearIfStillTracked = () => {
+    if (selectWindowId(store.getState()) === removedWindowId) {
+      store.dispatch(windowIdCleared());
+    }
+  };
+
+  if (initiallyOpen.length === 0) {
+    clearIfStillTracked();
+    return;
+  }
+
+  await delay(CANCEL_GRACE_MS);
+
+  const stillOpenIds = new Set(
+    selectOpenRequests(store.getState()).map(r => r.requestId)
+  );
+  // Requests open at close AND still open now — excludes answered-during-grace and any new
+  // request opened during the grace.
+  const toCancel = initiallyOpen.filter(r => stillOpenIds.has(r.requestId));
+
+  // Mark synchronously from this snapshot, before the async sends.
+  for (const { requestId } of toCancel) {
+    store.dispatch(windowRequestResponded({ requestId }));
+  }
+  clearIfStillTracked();
+
+  await Promise.all(
+    toCancel.map(async ({ requestId, tabId, origin, method }) => {
+      const action = buildCancelResponse(method, requestId);
+      try {
+        await tabs.sendMessage(tabId, action);
+      } catch {
+        const delivered = await deliverViaOrigin(origin, action);
+        store.dispatch(
+          sagaError({
+            source: 'cancel-on-close',
+            message:
+              `Cancel-on-close delivery to tab ${tabId} failed` +
+              (delivered > 0
+                ? '; delivered via same-origin fallback'
+                : '; not delivered')
+          })
+        );
+      }
+    })
+  );
+}

--- a/src/background/handlers/deliver-via-origin.ts
+++ b/src/background/handlers/deliver-via-origin.ts
@@ -1,0 +1,20 @@
+import { emitSdkEventToActiveTabsWithOrigin } from '@background/utils';
+
+import { SdkMethod } from '@content/sdk-method';
+
+// Same-origin delivery fallback. Returns the number of tabs the response was
+// SUCCESSFULLY delivered to (0 when there is no recoverable origin, or when the
+// broadcast matched no active same-origin tab). Wrapping the emit isolates a
+// `tabs.query`-level rejection so the caller's error-surface dispatch still runs
+// and the handler never rejects back to the signature page.
+export async function deliverViaOrigin(
+  origin: string | null,
+  action: SdkMethod
+): Promise<number> {
+  if (!origin) return 0;
+  try {
+    return await emitSdkEventToActiveTabsWithOrigin(origin, action);
+  } catch {
+    return 0;
+  }
+}

--- a/src/background/handlers/redux-actions.parity.test.ts
+++ b/src/background/handlers/redux-actions.parity.test.ts
@@ -110,8 +110,8 @@ const EXCLUSIONS: ReadonlySet<string> = new Set(
     // Background-only: dispatched by the sdk-methods handler for an EIP-712
     // signature request. Never dispatched from the UI.
     vaultActions.eip712PayloadReceived,
-    // Background-only: dispatched in background/index.ts when the tracked
-    // approval window closes. Never dispatched from the UI.
+    // Background-only: retained for the reducer/parity guard but no longer
+    // dispatched (the close path now uses windowIdCleared). Never from the UI.
     windowManagementActions.windowClosed,
     // Background-only: dispatched by sdk-methods when opening an approval
     // window (tracks the in-flight request). Never dispatched from the UI.

--- a/src/background/handlers/sdk-methods.test.ts
+++ b/src/background/handlers/sdk-methods.test.ts
@@ -172,7 +172,14 @@ describe('connectRequest', () => {
     );
 
     expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({ payload: { requestId: 'req-1' } })
+      expect.objectContaining({
+        payload: {
+          requestId: 'req-1',
+          tabId: 9,
+          origin: ORIGIN,
+          method: 'connect'
+        }
+      })
     );
     expect(openWindowMock).toHaveBeenCalledWith(
       store,
@@ -211,6 +218,16 @@ describe('switchAccountRequest', () => {
       store
     );
     expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: {
+          requestId: 'req-1',
+          tabId: 9,
+          origin: ORIGIN,
+          method: 'switchAccount'
+        }
+      })
+    );
     expect(openWindowMock).toHaveBeenCalledWith(
       store,
       expect.objectContaining({ windowApp: WindowApp.SwitchAccount })
@@ -276,6 +293,16 @@ describe('signRequest', () => {
     );
 
     expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: {
+          requestId: 'req-1',
+          tabId: 9,
+          origin: ORIGIN,
+          method: 'sign'
+        }
+      })
+    );
     expect(openWindowMock).toHaveBeenCalledWith(
       store,
       expect.objectContaining({
@@ -299,6 +326,16 @@ describe('signMessageRequest', () => {
       store
     );
     expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: {
+          requestId: 'req-1',
+          tabId: 9,
+          origin: ORIGIN,
+          method: 'signMessage'
+        }
+      })
+    );
     expect(openWindowMock).toHaveBeenCalledWith(
       store,
       expect.objectContaining({ windowApp: WindowApp.SignatureRequestMessage })
@@ -323,6 +360,16 @@ describe('signTypedDataRequest', () => {
       store
     );
     expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: {
+          requestId: 'req-1',
+          tabId: 9,
+          origin: ORIGIN,
+          method: 'signTypedData'
+        }
+      })
+    );
     expect(openWindowMock).toHaveBeenCalledWith(
       store,
       expect.objectContaining({ windowApp: WindowApp.SignatureRequestEip712 })
@@ -343,6 +390,16 @@ describe('decryptMessageRequest', () => {
       store
     );
     expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: {
+          requestId: 'req-1',
+          tabId: 9,
+          origin: ORIGIN,
+          method: 'decryptMessage'
+        }
+      })
+    );
     expect(openWindowMock).toHaveBeenCalledWith(
       store,
       expect.objectContaining({ windowApp: WindowApp.DecryptMessageRequest })

--- a/src/background/handlers/sdk-methods.ts
+++ b/src/background/handlers/sdk-methods.ts
@@ -75,7 +75,14 @@ export async function handleSdkMethod(
         response: sdkMethod.connectResponse(true, action.meta)
       };
     } else {
-      store.dispatch(windowRequestOpened({ requestId: action.meta.requestId }));
+      store.dispatch(
+        windowRequestOpened({
+          requestId: action.meta.requestId,
+          tabId: senderTabId,
+          origin,
+          method: 'connect'
+        })
+      );
       openWindow(store, {
         windowApp: WindowApp.ConnectToApp,
         searchParams: query
@@ -104,7 +111,14 @@ export async function handleSdkMethod(
       query.title = action.payload.title;
     }
 
-    store.dispatch(windowRequestOpened({ requestId: action.meta.requestId }));
+    store.dispatch(
+      windowRequestOpened({
+        requestId: action.meta.requestId,
+        tabId: senderTabId,
+        origin,
+        method: 'switchAccount'
+      })
+    );
     openWindow(store, {
       windowApp: WindowApp.SwitchAccount,
       searchParams: query
@@ -158,7 +172,14 @@ export async function handleSdkMethod(
       })
     );
 
-    store.dispatch(windowRequestOpened({ requestId: action.meta.requestId }));
+    store.dispatch(
+      windowRequestOpened({
+        requestId: action.meta.requestId,
+        tabId: senderTabId,
+        origin,
+        method: 'sign'
+      })
+    );
     openWindow(store, {
       windowApp: WindowApp.SignatureRequestDeploy,
       searchParams: {
@@ -184,7 +205,14 @@ export async function handleSdkMethod(
 
     const { signingPublicKeyHex, message } = action.payload;
 
-    store.dispatch(windowRequestOpened({ requestId: action.meta.requestId }));
+    store.dispatch(
+      windowRequestOpened({
+        requestId: action.meta.requestId,
+        tabId: senderTabId,
+        origin,
+        method: 'signMessage'
+      })
+    );
     openWindow(store, {
       windowApp: WindowApp.SignatureRequestMessage,
       searchParams: {
@@ -218,7 +246,14 @@ export async function handleSdkMethod(
       })
     );
 
-    store.dispatch(windowRequestOpened({ requestId: action.meta.requestId }));
+    store.dispatch(
+      windowRequestOpened({
+        requestId: action.meta.requestId,
+        tabId: senderTabId,
+        origin,
+        method: 'signTypedData'
+      })
+    );
     openWindow(store, {
       windowApp: WindowApp.SignatureRequestEip712,
       searchParams: {
@@ -245,7 +280,14 @@ export async function handleSdkMethod(
 
     const { signingPublicKeyHex, message } = action.payload;
 
-    store.dispatch(windowRequestOpened({ requestId: action.meta.requestId }));
+    store.dispatch(
+      windowRequestOpened({
+        requestId: action.meta.requestId,
+        tabId: senderTabId,
+        origin,
+        method: 'decryptMessage'
+      })
+    );
     openWindow(store, {
       windowApp: WindowApp.DecryptMessageRequest,
       searchParams: {

--- a/src/background/handlers/sdk-response-to-tab.ts
+++ b/src/background/handlers/sdk-response-to-tab.ts
@@ -52,14 +52,14 @@ function deliveryFailedError(tabId: unknown, fallbackDelivered: boolean) {
 // FIRST response for a request wins, later ones are dropped — atomically,
 // because the background store is the single writer.
 //
-// CRITICAL: drop ONLY when the request is already 'responded', NEVER on 'closed'.
-// `handleCancel` fires on `beforeunload` and sends its response just before the
-// window unloads; the `windows.onRemoved` listener then dispatches
-// `windowClosed()` (marking still-open requests 'closed'). These race. Dropping
-// on 'closed' would suppress a legitimate beforeunload-cancel for a window that
-// closed WITHOUT a prior response (dapp left hanging). Dropping only on
-// 'responded' kills the real duplicate (a cancel after a successful sign, where
+// CRITICAL: drop ONLY when the request is already 'responded'. When the tracked
+// approval window closes, the `windows.onRemoved` listener runs
+// `cancelOpenRequestsForClosedWindow`, which — after a short grace — marks each
+// request it cancels 'responded' (via `windowRequestResponded`). Dropping only on
+// 'responded' kills the real duplicate (a cancel racing a successful sign, where
 // the sign already set 'responded') without ever suppressing a first response.
+// ('closed' is now dispatch-dead: the close path uses `windowIdCleared`, not
+// `windowClosed`; the never-drop-on-'closed' stance is kept defensively.)
 export async function handleSdkResponseToTab(
   message: unknown,
   sender: Runtime.MessageSender,
@@ -116,10 +116,10 @@ export async function handleSdkResponseToTab(
 
   // Mark responded OPTIMISTICALLY, BEFORE the await. `runtime.onMessage`
   // handlers interleave at every `await`, so two near-simultaneous responses
-  // for the same requestId (the P0.5 repro: handleSign sends, then
-  // closeCurrentWindow → beforeunload → handleCancel sends) would BOTH read
-  // status `undefined` if we marked after the send — and both would reach the
-  // dapp. Dispatching synchronously here (before yielding the event loop) means
+  // for the same requestId (e.g. a genuine sign response racing the close-cancel
+  // emitted by `cancelOpenRequestsForClosedWindow`) would BOTH read status
+  // `undefined` if we marked after the send — and both would reach the dapp.
+  // Dispatching synchronously here (before yielding the event loop) means
   // a second message processed during the first's in-flight send reads
   // 'responded' and drops. Trade-off: on a genuine delivery failure the request
   // stays 'responded' and any retry is dropped — acceptable, since delivery

--- a/src/background/handlers/sdk-response-to-tab.ts
+++ b/src/background/handlers/sdk-response-to-tab.ts
@@ -8,8 +8,8 @@ import {
   SDK_RESPONSE_TO_TAB,
   SdkResponseToTabMessage
 } from '@background/send-sdk-response-to-specific-tab';
-import { emitSdkEventToActiveTabsWithOrigin } from '@background/utils';
 
+import { deliverViaOrigin } from './deliver-via-origin';
 import { isTrustedUiSender } from './private-state';
 import { HandlerResult } from './types';
 
@@ -27,26 +27,6 @@ function recoverDappOrigin(url: string | undefined): string | null {
     return new URL(url).searchParams.get('origin');
   } catch {
     return null;
-  }
-}
-
-// Same-origin delivery fallback. Returns the number of tabs the response was
-// SUCCESSFULLY delivered to (0 when there is no recoverable origin, or when the
-// broadcast matched no active same-origin tab). Wrapping the emit isolates a
-// `tabs.query`-level rejection so the caller's error-surface dispatch still runs
-// and the handler never rejects back to the signature page.
-async function deliverViaOrigin(
-  origin: string | null,
-  action: SdkResponseToTabMessage['action']
-): Promise<number> {
-  if (!origin) {
-    return 0;
-  }
-  try {
-    return await emitSdkEventToActiveTabsWithOrigin(origin, action);
-  } catch {
-    // tabs.query / query-level failure → nothing delivered.
-    return 0;
   }
 }
 

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -18,6 +18,7 @@ import {
 } from '@src/utils';
 
 import { handleBringWeb3 } from '@background/handlers/bringweb3';
+import { cancelOpenRequestsForClosedWindow } from '@background/handlers/cancel-open-requests-on-close';
 import { handleLegacyImport } from '@background/handlers/legacy-import';
 import {
   isPrivateStateRequest,
@@ -38,7 +39,6 @@ import {
   selectIsAccountConnected,
   selectVaultActiveAccount
 } from '@background/redux/vault/selectors';
-import { windowClosed } from '@background/redux/windowManagement/actions';
 import { selectWindowId } from '@background/redux/windowManagement/selectors';
 
 import { sdkEvent } from '@content/sdk-event';
@@ -174,12 +174,13 @@ tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 // per-creation `windows.onRemoved` listeners that used to be added inside
 // `createOpenWindow` (one leaked per opened window). `windows.onRemoved` fires
 // for ANY window, so the id-match guard ensures we only react when the removed
-// window is the tracked approval window. `windowClosed()` nulls the slice
-// `windowId` AND marks any still-open requests as 'closed'.
+// window is the tracked approval window. `cancelOpenRequestsForClosedWindow`
+// waits a grace period, then cancels any requests still open for that window
+// and dispatches `windowIdCleared` to null the slice `windowId`.
 windows.onRemoved.addListener(async (removedWindowId: number) => {
   const store = await getExistingMainStoreSingletonOrInit();
   if (removedWindowId === selectWindowId(store.getState())) {
-    store.dispatch(windowClosed());
+    await cancelOpenRequestsForClosedWindow(store, removedWindowId);
   }
 });
 

--- a/src/background/redux/get-main-store.ts
+++ b/src/background/redux/get-main-store.ts
@@ -77,7 +77,16 @@ const selectPopupState = (state: RootState): PopupState => {
     session: { ...state.session, encryptionKeyHash: null },
     loginRetryCount: state.loginRetryCount,
     vault: state.vault,
-    windowManagement: state.windowManagement,
+    // Narrowed on purpose: `pendingRequests` maps each in-flight requestId to
+    // its dapp origin + tabId. The approval window is a single reused slot, so
+    // requests from two different origins can be open at once — broadcasting
+    // the whole slice would put dapp A's origin into dapp B's UI replica. No
+    // UI reads it (only `selectWindowId` is consumed, in use-window-manager);
+    // the cancel-on-close path reads it in the background, off the real store.
+    windowManagement: {
+      windowId: state.windowManagement.windowId,
+      requests: state.windowManagement.requests
+    },
     loginRetryLockoutTime: state.loginRetryLockoutTime,
     lastActivityTime: state.lastActivityTime,
     activeOrigin: state.activeOrigin,
@@ -230,5 +239,11 @@ export type MainStore = Awaited<
 >;
 
 export function createMainStoreReplica<T extends PopupState>(state: T) {
-  return createStore(state);
+  // `selectPopupState` strips `pendingRequests` (dapp origins + tabIds stay in
+  // the background). Restore the shape the slice reducer expects with an empty
+  // map — truthful, since a replica genuinely holds no request descriptors.
+  return createStore({
+    ...state,
+    windowManagement: { ...state.windowManagement, pendingRequests: {} }
+  });
 }

--- a/src/background/redux/types.d.ts
+++ b/src/background/redux/types.d.ts
@@ -21,7 +21,10 @@ export type PopupState = {
   session: SessionState;
   loginRetryCount: LoginRetryCountState;
   vault: VaultState;
-  windowManagement: WindowManagementState;
+  // `pendingRequests` is deliberately NOT broadcast: it holds each in-flight
+  // request's dapp origin and tabId, and only background code needs it. See
+  // the narrowing in `selectPopupState`.
+  windowManagement: Omit<WindowManagementState, 'pendingRequests'>;
   loginRetryLockoutTime: LoginRetryLockoutTimeState;
   lastActivityTime: LastActivityTimeState;
   settings: SettingsState;

--- a/src/background/redux/windowManagement/reducer.test.ts
+++ b/src/background/redux/windowManagement/reducer.test.ts
@@ -12,23 +12,30 @@ import {
 } from './actions';
 import { reducer } from './reducer';
 
+const empty = { windowId: null, requests: {}, pendingRequests: {} } as const;
+
 describe('windowManagement reducer', () => {
   it('has null windowId and no requests initially', () => {
     expect(reducer(undefined, { type: '@@INIT' } as any)).toEqual({
       windowId: null,
-      requests: {}
+      requests: {},
+      pendingRequests: {}
     });
   });
   it('sets and clears windowId', () => {
-    const s = reducer({ windowId: null, requests: {} }, windowIdChanged(7));
-    expect(s).toEqual({ windowId: 7, requests: {} });
+    const s = reducer(
+      { windowId: null, requests: {}, pendingRequests: {} },
+      windowIdChanged(7)
+    );
+    expect(s).toEqual({ windowId: 7, requests: {}, pendingRequests: {} });
     expect(reducer(s, windowIdCleared())).toEqual({
       windowId: null,
-      requests: {}
+      requests: {},
+      pendingRequests: {}
     });
   });
   it('window-init actions do not change state', () => {
-    const state = { windowId: 7, requests: {} };
+    const state = { windowId: 7, requests: {}, pendingRequests: {} };
     expect(reducer(state, onboardingAppInit())).toEqual(state);
     expect(reducer(state, popupWindowInit())).toEqual(state);
     expect(reducer(state, connectWindowInit())).toEqual(state);
@@ -38,16 +45,26 @@ describe('windowManagement reducer', () => {
 
   it('opens a request', () => {
     const s = reducer(
-      { windowId: null, requests: {} },
-      windowRequestOpened({ requestId: 'r1' })
+      { windowId: null, requests: {}, pendingRequests: {} },
+      windowRequestOpened({
+        requestId: 'r1',
+        tabId: 9,
+        origin: 'https://dapp.example',
+        method: 'sign'
+      })
     );
     expect(s.requests.r1).toBe('open');
   });
 
   it('marks a request as responded, and is idempotent on a second respond', () => {
     let s = reducer(
-      { windowId: null, requests: {} },
-      windowRequestOpened({ requestId: 'r1' })
+      { windowId: null, requests: {}, pendingRequests: {} },
+      windowRequestOpened({
+        requestId: 'r1',
+        tabId: 9,
+        origin: 'https://dapp.example',
+        method: 'sign'
+      })
     );
     s = reducer(s, windowRequestResponded({ requestId: 'r1' }));
     expect(s.requests.r1).toBe('responded');
@@ -58,8 +75,13 @@ describe('windowManagement reducer', () => {
 
   it('closes open requests and clears windowId on windowClosed', () => {
     let s = reducer(
-      { windowId: 7, requests: {} },
-      windowRequestOpened({ requestId: 'r2' })
+      { windowId: 7, requests: {}, pendingRequests: {} },
+      windowRequestOpened({
+        requestId: 'r2',
+        tabId: 9,
+        origin: 'https://dapp.example',
+        method: 'sign'
+      })
     );
     s = reducer(s, windowClosed());
     expect(s.requests.r2).toBe('closed');
@@ -68,12 +90,59 @@ describe('windowManagement reducer', () => {
 
   it('leaves a responded request as responded on windowClosed', () => {
     let s = reducer(
-      { windowId: 7, requests: {} },
-      windowRequestOpened({ requestId: 'r3' })
+      { windowId: 7, requests: {}, pendingRequests: {} },
+      windowRequestOpened({
+        requestId: 'r3',
+        tabId: 9,
+        origin: 'https://dapp.example',
+        method: 'sign'
+      })
     );
     s = reducer(s, windowRequestResponded({ requestId: 'r3' }));
     s = reducer(s, windowClosed());
     expect(s.requests.r3).toBe('responded');
     expect(s.windowId).toBeNull();
+  });
+
+  it('windowRequestOpened sets status open AND stores the descriptor', () => {
+    const next = reducer(
+      empty,
+      windowRequestOpened({
+        requestId: 'r1',
+        tabId: 9,
+        origin: 'https://dapp.example',
+        method: 'sign'
+      })
+    );
+    expect(next.requests.r1).toBe('open');
+    expect(next.pendingRequests.r1).toEqual({
+      tabId: 9,
+      origin: 'https://dapp.example',
+      method: 'sign'
+    });
+  });
+
+  it('windowRequestResponded flips only the status map', () => {
+    const opened = reducer(
+      empty,
+      windowRequestOpened({
+        requestId: 'r1',
+        tabId: 9,
+        origin: 'o',
+        method: 'connect'
+      })
+    );
+    const next = reducer(opened, windowRequestResponded({ requestId: 'r1' }));
+    expect(next.requests.r1).toBe('responded');
+    expect(next.pendingRequests.r1).toEqual({
+      tabId: 9,
+      origin: 'o',
+      method: 'connect'
+    });
+  });
+
+  it('windowIdCleared nulls only windowId', () => {
+    const next = reducer({ ...empty, windowId: 5 }, windowIdCleared());
+    expect(next.windowId).toBeNull();
   });
 });

--- a/src/background/redux/windowManagement/reducer.ts
+++ b/src/background/redux/windowManagement/reducer.ts
@@ -1,8 +1,16 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import { RequestStatus, WindowManagementState } from './types';
+import {
+  CancellableMethod,
+  RequestStatus,
+  WindowManagementState
+} from './types';
 
-const initialState: WindowManagementState = { windowId: null, requests: {} };
+const initialState: WindowManagementState = {
+  windowId: null,
+  requests: {},
+  pendingRequests: {}
+};
 
 const slice = createSlice({
   name: 'windowManagement',
@@ -20,12 +28,25 @@ const slice = createSlice({
     signWindowInit: state => state,
     windowRequestOpened: (
       state,
-      action: PayloadAction<{ requestId: string }>
+      action: PayloadAction<{
+        requestId: string;
+        tabId: number;
+        origin: string;
+        method: CancellableMethod;
+      }>
     ) => ({
       ...state,
       requests: {
         ...state.requests,
         [action.payload.requestId]: 'open'
+      },
+      pendingRequests: {
+        ...state.pendingRequests,
+        [action.payload.requestId]: {
+          tabId: action.payload.tabId,
+          origin: action.payload.origin,
+          method: action.payload.method
+        }
       }
     }),
     windowRequestResponded: (

--- a/src/background/redux/windowManagement/selectors.test.ts
+++ b/src/background/redux/windowManagement/selectors.test.ts
@@ -1,0 +1,24 @@
+import { selectOpenRequests, selectRequestStatus } from './selectors';
+
+const state = {
+  windowManagement: {
+    windowId: null,
+    requests: { a: 'open', b: 'responded', c: 'closed' },
+    pendingRequests: {
+      a: { tabId: 1, origin: 'o', method: 'sign' },
+      b: { tabId: 2, origin: 'o', method: 'connect' },
+      c: { tabId: 3, origin: 'o', method: 'decryptMessage' }
+    }
+  }
+} as any;
+
+it('selectRequestStatus returns the status or undefined', () => {
+  expect(selectRequestStatus(state, 'a')).toBe('open');
+  expect(selectRequestStatus(state, 'z')).toBeUndefined();
+});
+
+it('selectOpenRequests joins open status with its descriptor', () => {
+  expect(selectOpenRequests(state)).toEqual([
+    { requestId: 'a', tabId: 1, origin: 'o', method: 'sign' }
+  ]);
+});

--- a/src/background/redux/windowManagement/selectors.ts
+++ b/src/background/redux/windowManagement/selectors.ts
@@ -9,3 +9,11 @@ export const selectRequestStatus = (
   state: RootState,
   requestId: string
 ): RequestStatus | undefined => state.windowManagement.requests[requestId];
+
+export const selectOpenRequests = (state: RootState) =>
+  Object.entries(state.windowManagement.requests)
+    .filter(([, status]) => status === 'open')
+    .map(([requestId]) => ({
+      requestId,
+      ...state.windowManagement.pendingRequests[requestId]
+    }));

--- a/src/background/redux/windowManagement/selectors.ts
+++ b/src/background/redux/windowManagement/selectors.ts
@@ -1,3 +1,5 @@
+import { createSelector } from 'reselect';
+
 import { RootState } from '@background/redux/store-types';
 
 import { RequestStatus } from './types';
@@ -10,10 +12,20 @@ export const selectRequestStatus = (
   requestId: string
 ): RequestStatus | undefined => state.windowManagement.requests[requestId];
 
-export const selectOpenRequests = (state: RootState) =>
-  Object.entries(state.windowManagement.requests)
-    .filter(([, status]) => status === 'open')
-    .map(([requestId]) => ({
-      requestId,
-      ...state.windowManagement.pendingRequests[requestId]
-    }));
+const selectRequests = (state: RootState) => state.windowManagement.requests;
+
+const selectPendingRequests = (state: RootState) =>
+  state.windowManagement.pendingRequests;
+
+// Joins the status map with the descriptor map, yielding the descriptor of
+// every request still awaiting a response. Memoized (reselect) so repeated
+// reads — `cancelOpenRequestsForClosedWindow` reads it once before the grace
+// and once after — do not rebuild the array while the slice is unchanged.
+export const selectOpenRequests = createSelector(
+  selectRequests,
+  selectPendingRequests,
+  (requests, pendingRequests) =>
+    Object.entries(requests)
+      .filter(([, status]) => status === 'open')
+      .map(([requestId]) => ({ requestId, ...pendingRequests[requestId] }))
+);

--- a/src/background/redux/windowManagement/types.ts
+++ b/src/background/redux/windowManagement/types.ts
@@ -1,6 +1,21 @@
 export type RequestStatus = 'open' | 'responded' | 'closed';
 
+export type CancellableMethod =
+  | 'connect'
+  | 'switchAccount'
+  | 'sign'
+  | 'signMessage'
+  | 'signTypedData'
+  | 'decryptMessage';
+
+export interface PendingRequestDescriptor {
+  tabId: number;
+  origin: string;
+  method: CancellableMethod;
+}
+
 export interface WindowManagementState {
   windowId: number | null;
   requests: Record<string, RequestStatus>;
+  pendingRequests: Record<string, PendingRequestDescriptor>;
 }

--- a/src/background/redux/windowManagement/types.ts
+++ b/src/background/redux/windowManagement/types.ts
@@ -8,7 +8,7 @@ export type CancellableMethod =
   | 'signTypedData'
   | 'decryptMessage';
 
-export interface PendingRequestDescriptor {
+interface PendingRequestDescriptor {
   tabId: number;
   origin: string;
   method: CancellableMethod;

--- a/src/fixtures/initial-state-for-popup-tests.ts
+++ b/src/fixtures/initial-state-for-popup-tests.ts
@@ -75,7 +75,8 @@ export const initialStateForPopupTests: RootState = {
   },
   windowManagement: {
     windowId: null,
-    requests: {}
+    requests: {},
+    pendingRequests: {}
   },
   ledger: {
     windowId: null,


### PR DESCRIPTION
## Summary

Dapp SDK promises (`requestConnection`, `requestSwitchAccount`, `sign`, `signMessage`, `signMessageEIP712`, `decryptMessage`) previously **hung forever** when the user dismissed the wallet approval popup with the OS **"X"** button instead of Confirm/Cancel. This PR makes the background `windows.onRemoved` listener the authoritative close-canceller, so closing via "X" now resolves the dapp promise with the method-correct Cancel shape.

- Fixes make-software/casper-wallet#560 (connect / switch account)
- Fixes make-software/casper-wallet#730 (sign)
- Jira: https://make-software.atlassian.net/browse/WALLET-1344

## Root cause (re-verified after the DEP-99 refactor)

DEP-99 (WALLET-1343) built the request registry and server-side response dedup, but it never sent a cancellation on window close — `windowClosed` was a pure reducer. Actual cancellation still depended on the per-page `beforeunload → handleCancel` handlers, which Chrome frequently does **not** fire when an extension popup is torn down via "X" (#730), while the connect-to-app pages had **no** close handler at all (#560).

## What changed

1. **Registry carries a descriptor.** A new parallel `pendingRequests: Record<requestId, { tabId, origin, method }>` map on the `windowManagement` slice. The existing `requests` status map and `selectRequestStatus` are kept byte-unchanged, so the server-side dedup path and its tests are untouched. Populated at the 6 SDK-method dispatch sites.
2. **Background cancel-on-close handler** (`cancelOpenRequestsForClosedWindow`). On the tracked window's removal it waits a bounded grace (`CANCEL_GRACE_MS` = 250 ms), then cancels only the requests still open (`initiallyOpen ∩ stillOpen`), sending each its method-correct Cancel to the dapp tab via `tabs.sendMessage` (with same-origin delivery fallback). It dispatches `windowIdCleared` (not `windowClosed`) so it can never clobber a request opened during the grace.
3. **The grace protects genuine in-flight responses.** A Confirm/Cancel button response — or a **Ledger success cleanup that programmatically closes the approval window** — lands and marks the request `'responded'` within the grace, so the post-grace re-read skips it and a real signature is never replaced by a close-cancel. This is why no `use-ledger.ts` change was needed.
4. **Removed the unreliable `beforeunload` cancel handlers** from the 4 signature-request pages (`onRemoved` + grace is now the single close-cancel path for all approval pages).
5. **Side-fixes.** Two `handleCancel`s emitted a payload-correct but wrong-event-type response (`connectResponse` on a switch-account request; `signResponse` on a sign-message request) — corrected to the method's own builder. Harmless today (the SDK correlates by `requestId`), fixed for contract consistency.

6. **`pendingRequests` is kept out of the broadcast popup state.** `selectPopupState` pushed the whole `windowManagement` slice to every UI replica, which would have put each in-flight request's dapp origin and tabId into every open extension window (and the approval window is a single reused slot, so two origins can be open at once). The broadcast is narrowed to `{ windowId, requests }`; `createMainStoreReplica` restores the reducer's expected shape with an empty map. Found by the pre-merge security review.

## Testing

- `npm run ci-check` green — 358 tests. Coverage: `windowManagement/reducer.ts` 100%; `handlers/` directory 95.78 / 85.99 / 100 / 95.75 (floor 85 / 100 / 95 / 95); new `cancel-open-requests-on-close.ts` and `deliver-via-origin.ts` at 100%.
- `npm run build:chrome` and `npm run build:firefox` both pass.
- Unit tests exercise the grace re-check, the _answered-during-grace_ and _new-request-during-grace_ cases, and both delivery-fallback branches, using fake timers.

## Manual verification (cannot be covered by CI)

- [x] **Ledger on-device regression** — verified on hardware: a real Ledger `sign` / `signMessage` whose completion programmatically closes the approval window still returns the signature, not a cancel. The 250 ms grace holds in practice.
- [x] **Interactive e2e on Chrome**, against the playground dapp. Instrumented the background to log every SDK request and every cancel-on-close, and confirmed against the logs:
  - one `sign` → "X" → exactly one request cancelled, one Cancel delivered;
  - `sign` → Confirm/Cancel button → the request is already `'responded'` when `onRemoved` fires, so the close path correctly cancels nothing (no double-response);
  - two overlapping requests → "X" → both are open and both are cancelled — two requests, two promises, two resolutions. Before this PR the first of the two hung forever.
- [x] **Firefox (MV2)** — verified, close-via-"X" cancels correctly there too.

## Pre-merge review

Two independent reviews were run over the whole branch — a general engineering review and a security review. Both findings they raised are addressed or triaged:

- **Security (Medium): `pendingRequests` in the broadcast popup state** — fixed, see item 6 above.
- **General (Important): window reuse abandons an unanswered request** — real, but pre-existing and not a regression of this branch. See the discussion comment on this PR; needs a decision.

Verified clean by the security review: the cancel path cannot be induced to target an attacker-chosen tab (its `tabId`/`origin` come only from browser-supplied `sender` fields, and the path is triggered solely by the browser's own `windows.onRemoved`); `requestId` is 128-bit and SDK-internal, so cross-origin request confusion is not reachable; both dedupe paths mark `'responded'` synchronously before their own `await`, so one approval cannot yield two deliveries; cancel payloads carry no secret material for any of the 6 method shapes.

## Out of scope (documented follow-up)

- **MV3 durability.** The registry is in-memory (not persisted). A request pending while the vault is **locked** and the service worker is suspended mid-grace would find an empty registry on a cold `onRemoved` wake and cancel nothing. The warm/unlocked case (all signing, unlocked connect/switch) is covered by the existing keep-alive alarm. Persisting the registry is a separate ticket.
