### PR TITLE
fix: WALLET-1345 — Safari key export writes the file, and the final screen stops claiming it did

### DIFF
--- a/src/apps/popup/pages/download-account-keys/failure.tsx
+++ b/src/apps/popup/pages/download-account-keys/failure.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+
+import {
+  ContentContainer,
+  IllustrationContainer,
+  ParagraphContainer,
+  SpacingSize
+} from '@libs/layout';
+import { SvgIcon, Typography } from '@libs/ui/components';
+
+export const Failure = () => {
+  const { t } = useTranslation();
+
+  return (
+    <ContentContainer>
+      <IllustrationContainer>
+        <SvgIcon
+          src="assets/illustrations/error.svg"
+          width={190}
+          height={120}
+        />
+      </IllustrationContainer>
+
+      <ParagraphContainer top={SpacingSize.XL}>
+        <Typography type="header">
+          <Trans t={t}>Couldn’t download your keys</Trans>
+        </Typography>
+      </ParagraphContainer>
+
+      <ParagraphContainer top={SpacingSize.Medium}>
+        <Typography type="body" color="contentSecondary">
+          <Trans t={t}>
+            No file was saved. Nothing left your wallet and your accounts are
+            unchanged, so it is safe to try again.
+          </Trans>
+        </Typography>
+      </ParagraphContainer>
+    </ContentContainer>
+  );
+};

--- a/src/apps/popup/pages/download-account-keys/index.tsx
+++ b/src/apps/popup/pages/download-account-keys/index.tsx
@@ -47,25 +47,35 @@ export const DownloadAccountKeysPage = () => {
   }
 
   const downloadKeys = async () => {
-    const zip = new JSZip();
+    try {
+      const zip = new JSZip();
 
-    for (const account of selectedAccounts) {
-      const asymmetricKey = createAsymmetricKeys(
-        account.publicKey,
-        account.secretKey
-      );
+      for (const account of selectedAccounts) {
+        const asymmetricKey = createAsymmetricKeys(
+          account.publicKey,
+          account.secretKey
+        );
 
-      if (asymmetricKey.secretKey) {
-        const file = asymmetricKey.secretKey.toPem();
-        zip.file(`${account.name}_secret_key.pem`, file);
+        if (asymmetricKey.secretKey) {
+          const file = asymmetricKey.secretKey.toPem();
+          zip.file(`${account.name}_secret_key.pem`, file);
+        }
       }
-    }
 
-    await zip.generateAsync({ type: 'blob' }).then(function (content) {
+      const content = await zip.generateAsync({ type: 'blob' });
       downloadFile(new Blob([content]), 'casper-wallet-secret_keys.zip');
-    });
 
-    setDownloadAccountKeysStep(DownloadAccountKeysSteps.Success);
+      setDownloadAccountKeysStep(DownloadAccountKeysSteps.Success);
+    } catch (error) {
+      // Stay on this step: advancing to Success here is exactly the false
+      // "your keys were saved" this ticket exists to remove. Only the error
+      // name is logged — the thrown value is built from key material and must
+      // not reach the console.
+      console.error(
+        'downloadKeys: failed to build or download the keys archive',
+        error instanceof Error ? error.name : 'unknown error'
+      );
+    }
   };
 
   const content = {

--- a/src/apps/popup/pages/download-account-keys/index.tsx
+++ b/src/apps/popup/pages/download-account-keys/index.tsx
@@ -3,7 +3,8 @@ import React, { useCallback, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { PasswordProtectionPage } from '@popup/pages/password-protection-page';
-import { RouterPath, useTypedNavigate } from '@popup/router';
+
+import { closeExportKeysSurface } from '@background/open-export-keys-surface';
 
 import { createAsymmetricKeys } from '@libs/crypto/create-asymmetric-key';
 import {
@@ -31,7 +32,6 @@ export const DownloadAccountKeysPage = () => {
   );
 
   const { t } = useTranslation();
-  const navigate = useTypedNavigate();
 
   const setPasswordConfirmed = useCallback(() => {
     setIsPasswordConfirmed(true);
@@ -39,7 +39,10 @@ export const DownloadAccountKeysPage = () => {
 
   if (!isPasswordConfirmed) {
     return (
-      <PasswordProtectionPage setPasswordConfirmed={setPasswordConfirmed} />
+      <PasswordProtectionPage
+        setPasswordConfirmed={setPasswordConfirmed}
+        onCloseWindow={() => closeExportKeysSurface()}
+      />
     );
   }
 
@@ -77,8 +80,14 @@ export const DownloadAccountKeysPage = () => {
   };
 
   const headerButton = {
+    // "Back" is only used where it genuinely steps back inside the flow. The
+    // entry step has nowhere to go back to in a dedicated window, so it closes
+    // instead — labelling that "Back" would be a lie (WALLET-1345).
     [DownloadAccountKeysSteps.Instruction]: (
-      <HeaderSubmenuBarNavLink linkType="back" />
+      <HeaderSubmenuBarNavLink
+        linkType="close"
+        onClick={() => closeExportKeysSurface()}
+      />
     ),
     [DownloadAccountKeysSteps.Download]: (
       <HeaderSubmenuBarNavLink
@@ -89,7 +98,10 @@ export const DownloadAccountKeysPage = () => {
       />
     ),
     [DownloadAccountKeysSteps.Success]: (
-      <HeaderSubmenuBarNavLink linkType="close" />
+      <HeaderSubmenuBarNavLink
+        linkType="close"
+        onClick={() => closeExportKeysSurface()}
+      />
     )
   };
 
@@ -109,19 +121,25 @@ export const DownloadAccountKeysPage = () => {
       </Button>
     ),
     [DownloadAccountKeysSteps.Success]: (
-      <Button onClick={() => navigate(RouterPath.Home)}>
-        <Trans t={t}>Done</Trans>
-      </Button>
+      <>
+        <Button onClick={() => closeExportKeysSurface()}>
+          <Trans t={t}>Done</Trans>
+        </Button>
+        <Button color="secondaryBlue" onClick={downloadKeys}>
+          <Trans t={t}>Download again</Trans>
+        </Button>
+      </>
     )
   };
 
   return (
     <PopupLayout
       renderHeader={() => (
+        // Deliberately bare: this window exists to export secret keys and
+        // nothing else. The wallet menu / network switcher / connection status
+        // would let the user navigate the full wallet inside a 376px export
+        // window and strand themselves there (WALLET-1345).
         <HeaderPopup
-          withNetworkSwitcher
-          withMenu
-          withConnectionStatus
           renderSubmenuBarItems={() => headerButton[downloadAccountKeysStep]}
         />
       )}

--- a/src/apps/popup/pages/download-account-keys/index.tsx
+++ b/src/apps/popup/pages/download-account-keys/index.tsx
@@ -17,6 +17,7 @@ import { AccountListRows } from '@libs/types/account';
 import { Button } from '@libs/ui/components';
 
 import { Download } from './download';
+import { Failure } from './failure';
 import { Instruction } from './instruction';
 import { Success } from './success';
 import { DownloadAccountKeysSteps, downloadFile } from './utils';
@@ -67,14 +68,15 @@ export const DownloadAccountKeysPage = () => {
 
       setDownloadAccountKeysStep(DownloadAccountKeysSteps.Success);
     } catch (error) {
-      // Stay on this step: advancing to Success here is exactly the false
-      // "your keys were saved" this ticket exists to remove. Only the error
-      // name is logged — the thrown value is built from key material and must
-      // not reach the console.
+      // Only the error name is logged — the thrown value is built from key
+      // material and must not reach the console. Nothing collects these logs
+      // (the project has no Sentry or equivalent), so the Failure step below is
+      // the only way this reaches anyone.
       console.error(
         'downloadKeys: failed to build or download the keys archive',
         error instanceof Error ? error.name : 'unknown error'
       );
+      setDownloadAccountKeysStep(DownloadAccountKeysSteps.Failure);
     }
   };
 
@@ -86,7 +88,8 @@ export const DownloadAccountKeysPage = () => {
         setSelectedAccounts={setSelectedAccounts}
       />
     ),
-    [DownloadAccountKeysSteps.Success]: <Success />
+    [DownloadAccountKeysSteps.Success]: <Success />,
+    [DownloadAccountKeysSteps.Failure]: <Failure />
   };
 
   const headerButton = {
@@ -108,6 +111,12 @@ export const DownloadAccountKeysPage = () => {
       />
     ),
     [DownloadAccountKeysSteps.Success]: (
+      <HeaderSubmenuBarNavLink
+        linkType="close"
+        onClick={() => closeExportKeysSurface()}
+      />
+    ),
+    [DownloadAccountKeysSteps.Failure]: (
       <HeaderSubmenuBarNavLink
         linkType="close"
         onClick={() => closeExportKeysSurface()}
@@ -139,6 +148,17 @@ export const DownloadAccountKeysPage = () => {
           <Trans t={t}>Download again</Trans>
         </Button>
       </>
+    ),
+    // Back to account selection rather than retrying blind: the selection is
+    // still in state, so the user can confirm or change it before trying again.
+    [DownloadAccountKeysSteps.Failure]: (
+      <Button
+        onClick={() =>
+          setDownloadAccountKeysStep(DownloadAccountKeysSteps.Download)
+        }
+      >
+        <Trans t={t}>Try again</Trans>
+      </Button>
     )
   };
 

--- a/src/apps/popup/pages/download-account-keys/success.tsx
+++ b/src/apps/popup/pages/download-account-keys/success.tsx
@@ -24,7 +24,16 @@ export const Success = () => {
 
       <ParagraphContainer top={SpacingSize.XL}>
         <Typography type="header">
-          <Trans t={t}>You downloaded account private key(s)</Trans>
+          <Trans t={t}>Check your Downloads folder</Trans>
+        </Typography>
+      </ParagraphContainer>
+
+      <ParagraphContainer top={SpacingSize.Medium}>
+        <Typography type="body" color="contentSecondary">
+          <Trans t={t}>
+            Look for casper-wallet-secret_keys.zip in your Downloads folder. If
+            it isn’t there, the download didn’t complete — try again.
+          </Trans>
         </Typography>
       </ParagraphContainer>
 

--- a/src/apps/popup/pages/download-account-keys/utils.ts
+++ b/src/apps/popup/pages/download-account-keys/utils.ts
@@ -1,7 +1,11 @@
 export enum DownloadAccountKeysSteps {
   Instruction = 'instruction',
   Download = 'download',
-  Success = 'success'
+  Success = 'success',
+  // Reached only when the export throws. Deliberately a step of its own rather
+  // than a banner on Success: the user must never see "your keys were saved"
+  // alongside a failure (WALLET-1345).
+  Failure = 'failure'
 }
 
 export const downloadFile = (content: Blob, filename: string): void => {

--- a/src/apps/popup/pages/navigation-menu/index.tsx
+++ b/src/apps/popup/pages/navigation-menu/index.tsx
@@ -10,12 +10,13 @@ import {
   TERMS_URLS,
   USER_GUIDES_URL
 } from '@src/constants';
-import { isLedgerAvailable, isSafariBuild } from '@src/utils';
+import { isLedgerAvailable } from '@src/utils';
 
 import { TimeoutDurationSetting } from '@popup/constants';
 import { RouterPath, useNavigationMenu, useTypedNavigate } from '@popup/router';
 
 import { WindowApp } from '@background/create-open-window';
+import { openExportKeysSurface } from '@background/open-export-keys-surface';
 import { selectCountOfContacts } from '@background/redux/contacts/selectors';
 import { lockVault } from '@background/redux/sagas/actions';
 import {
@@ -310,11 +311,9 @@ export function NavigationMenuPageContent() {
             title: t('Download account keys'),
             iconPath: 'assets/icons/download.svg',
             disabled: false,
-            // https://github.com/make-software/casper-wallet/issues/611
-            hide: isSafariBuild,
             handleOnClick: () => {
               closeNavigationMenu();
-              navigate(RouterPath.DownloadAccountKeys);
+              openExportKeysSurface();
             }
           },
           {

--- a/src/apps/popup/pages/navigation-menu/index.tsx
+++ b/src/apps/popup/pages/navigation-menu/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
@@ -38,9 +38,11 @@ import {
   ContentContainer,
   FlexColumn,
   SpaceBetweenFlexRow,
-  SpacingSize
+  SpacingSize,
+  VerticalSpaceContainer
 } from '@libs/layout';
 import {
+  Error as ErrorMessage,
   Link,
   List,
   Modal,
@@ -106,6 +108,8 @@ export function NavigationMenuPageContent() {
   const navigate = useTypedNavigate();
   const { t } = useTranslation();
   const isDarkMode = useIsDarkMode();
+
+  const [exportKeysWindowFailed, setExportKeysWindowFailed] = useState(false);
 
   const timeoutDurationSetting = useSelector(selectTimeoutDurationSetting);
   const countOfConnectedSites = useSelector(selectCountOfConnectedSites);
@@ -311,9 +315,21 @@ export function NavigationMenuPageContent() {
             title: t('Download account keys'),
             iconPath: 'assets/icons/download.svg',
             disabled: false,
-            handleOnClick: () => {
-              closeNavigationMenu();
-              openExportKeysSurface();
+            handleOnClick: async () => {
+              setExportKeysWindowFailed(false);
+
+              try {
+                await openExportKeysSurface();
+                // Only dismiss the menu once the window actually exists —
+                // otherwise the error below would have nowhere to render.
+                closeNavigationMenu();
+              } catch (error) {
+                console.error(
+                  'navigation-menu: failed to open the key export window',
+                  error
+                );
+                setExportKeysWindowFailed(true);
+              }
             }
           },
           {
@@ -430,6 +446,16 @@ export function NavigationMenuPageContent() {
 
   return (
     <ContentContainer>
+      {exportKeysWindowFailed && (
+        <VerticalSpaceContainer top={SpacingSize.Medium}>
+          <ErrorMessage
+            header={t('Couldn’t open the export window')}
+            description={t(
+              'Your keys were not exported. Close any other wallet windows and try again.'
+            )}
+          />
+        </VerticalSpaceContainer>
+      )}
       {menuGroups.map(
         ({ headerLabel: groupLabel, items: groupItems }, index) => (
           <List

--- a/src/apps/popup/pages/password-protection-page/index.tsx
+++ b/src/apps/popup/pages/password-protection-page/index.tsx
@@ -34,6 +34,12 @@ interface BackupSecretPhrasePasswordPageType {
   setPasswordConfirmed?: () => void;
   onClick?: (password: string) => Promise<void>;
   isLoading?: boolean;
+  // Set when this page is rendered inside a dedicated window rather than the
+  // extension popup (WALLET-1345). Such a window has a single history entry, so
+  // the default "back" link is a no-op and would trap the user; it also has no
+  // business showing the wallet menu / network switcher. Passing this swaps the
+  // header for a bare one whose only action closes the window.
+  onCloseWindow?: () => void;
 }
 
 interface VerifyPasswordMessageEvent extends MessageEvent {
@@ -45,7 +51,8 @@ interface VerifyPasswordMessageEvent extends MessageEvent {
 export const PasswordProtectionPage = ({
   setPasswordConfirmed,
   onClick,
-  isLoading = false
+  isLoading = false,
+  onCloseWindow
 }: BackupSecretPhrasePasswordPageType) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -146,16 +153,27 @@ export const PasswordProtectionPage = ({
     <PopupLayout
       variant="form"
       onSubmit={handleSubmit(onSubmit)}
-      renderHeader={() => (
-        <HeaderPopup
-          withNetworkSwitcher
-          withMenu
-          withConnectionStatus
-          renderSubmenuBarItems={() => (
-            <HeaderSubmenuBarNavLink linkType="back" />
-          )}
-        />
-      )}
+      renderHeader={() =>
+        onCloseWindow ? (
+          <HeaderPopup
+            renderSubmenuBarItems={() => (
+              <HeaderSubmenuBarNavLink
+                linkType="close"
+                onClick={onCloseWindow}
+              />
+            )}
+          />
+        ) : (
+          <HeaderPopup
+            withNetworkSwitcher
+            withMenu
+            withConnectionStatus
+            renderSubmenuBarItems={() => (
+              <HeaderSubmenuBarNavLink linkType="back" />
+            )}
+          />
+        )
+      }
       renderContent={() => (
         <UnlockProtectedPageContent errors={errors} register={register} />
       )}

--- a/src/apps/popup/pages/password-protection-page/index.tsx
+++ b/src/apps/popup/pages/password-protection-page/index.tsx
@@ -175,7 +175,11 @@ export const PasswordProtectionPage = ({
         )
       }
       renderContent={() => (
-        <UnlockProtectedPageContent errors={errors} register={register} />
+        <UnlockProtectedPageContent
+          errors={errors}
+          register={register}
+          disabled={isSubmitting || isLoading}
+        />
       )}
       renderFooter={() => (
         <FooterButtonsContainer>

--- a/src/background/open-export-keys-surface.ts
+++ b/src/background/open-export-keys-surface.ts
@@ -14,26 +14,44 @@ const EXPORT_KEYS_URL = `popup.html#${RouterPath.DownloadAccountKeys}`;
 const SURFACE_WIDTH = 376;
 const SURFACE_HEIGHT = 700;
 
+// Both helpers are called fire-and-forget from onClick handlers, so they settle
+// their own failures rather than leaving an unhandled rejection. Same reasoning
+// as open-window.ts: a silent no-op with no trace is the worst outcome.
+
 export async function openExportKeysSurface(): Promise<void> {
-  const currentWindow = await windows.getCurrent();
+  try {
+    const currentWindow = await windows.getCurrent();
 
-  // Firefox ignores width/height when the parent window is fullscreen and would
-  // open a tiny popup instead; omitting them lets it size the window itself.
-  // Chrome and Safari do this by default. Mirrors create-open-window.ts.
-  const isFullscreen = currentWindow.state === 'fullscreen';
+    // Firefox ignores width/height when the parent window is fullscreen and
+    // would open a tiny popup instead; omitting them lets it size the window
+    // itself. Chrome and Safari do this by default. Mirrors
+    // create-open-window.ts.
+    const isFullscreen = currentWindow.state === 'fullscreen';
 
-  await windows.create({
-    url: EXPORT_KEYS_URL,
-    type: 'popup',
-    focused: true,
-    ...(isFullscreen ? {} : { width: SURFACE_WIDTH, height: SURFACE_HEIGHT })
-  });
+    await windows.create({
+      url: EXPORT_KEYS_URL,
+      type: 'popup',
+      focused: true,
+      ...(isFullscreen ? {} : { width: SURFACE_WIDTH, height: SURFACE_HEIGHT })
+    });
+  } catch (error) {
+    console.error('openExportKeysSurface: failed to open export window', error);
+  }
 }
 
 export async function closeExportKeysSurface(): Promise<void> {
-  const currentWindow = await windows.getCurrent();
+  try {
+    const currentWindow = await windows.getCurrent();
 
-  if (currentWindow.id != null) {
-    await windows.remove(currentWindow.id);
+    if (currentWindow.id != null) {
+      await windows.remove(currentWindow.id);
+    }
+  } catch (error) {
+    // The window stays open and the user can still close it from the title bar,
+    // so this is recoverable — but it must not vanish without a trace.
+    console.error(
+      'closeExportKeysSurface: failed to close export window',
+      error
+    );
   }
 }

--- a/src/background/open-export-keys-surface.ts
+++ b/src/background/open-export-keys-surface.ts
@@ -1,0 +1,39 @@
+import { windows } from 'webextension-polyfill';
+
+import { RouterPath } from '@popup/router/paths';
+
+// WALLET-1345: key export must not run in the extension popup. On Safari the
+// popup closes the moment a download steals focus; its document is torn down,
+// the browser revokes the blob: URL mid-read, and the file never lands. The
+// anchor+blob mechanism itself is fine — it only needs a context that outlives
+// the click, which is why nothing in download-account-keys/utils.ts changed.
+const EXPORT_KEYS_URL = `popup.html#${RouterPath.DownloadAccountKeys}`;
+
+// Matches the sizing in create-open-window.ts (360 + 16 cross-platform width
+// offset) so the 360px-wide popup UI is not clipped.
+const SURFACE_WIDTH = 376;
+const SURFACE_HEIGHT = 700;
+
+export async function openExportKeysSurface(): Promise<void> {
+  const currentWindow = await windows.getCurrent();
+
+  // Firefox ignores width/height when the parent window is fullscreen and would
+  // open a tiny popup instead; omitting them lets it size the window itself.
+  // Chrome and Safari do this by default. Mirrors create-open-window.ts.
+  const isFullscreen = currentWindow.state === 'fullscreen';
+
+  await windows.create({
+    url: EXPORT_KEYS_URL,
+    type: 'popup',
+    focused: true,
+    ...(isFullscreen ? {} : { width: SURFACE_WIDTH, height: SURFACE_HEIGHT })
+  });
+}
+
+export async function closeExportKeysSurface(): Promise<void> {
+  const currentWindow = await windows.getCurrent();
+
+  if (currentWindow.id != null) {
+    await windows.remove(currentWindow.id);
+  }
+}

--- a/src/background/open-export-keys-surface.ts
+++ b/src/background/open-export-keys-surface.ts
@@ -14,29 +14,24 @@ const EXPORT_KEYS_URL = `popup.html#${RouterPath.DownloadAccountKeys}`;
 const SURFACE_WIDTH = 376;
 const SURFACE_HEIGHT = 700;
 
-// Both helpers are called fire-and-forget from onClick handlers, so they settle
-// their own failures rather than leaving an unhandled rejection. Same reasoning
-// as open-window.ts: a silent no-op with no trace is the worst outcome.
-
+// Rejects on failure — the caller is expected to tell the user. If this window
+// never opens there is no other surface on which the export could report back,
+// so swallowing here would leave the menu item looking simply dead.
 export async function openExportKeysSurface(): Promise<void> {
-  try {
-    const currentWindow = await windows.getCurrent();
+  const currentWindow = await windows.getCurrent();
 
-    // Firefox ignores width/height when the parent window is fullscreen and
-    // would open a tiny popup instead; omitting them lets it size the window
-    // itself. Chrome and Safari do this by default. Mirrors
-    // create-open-window.ts.
-    const isFullscreen = currentWindow.state === 'fullscreen';
+  // Firefox ignores width/height when the parent window is fullscreen and
+  // would open a tiny popup instead; omitting them lets it size the window
+  // itself. Chrome and Safari do this by default. Mirrors
+  // create-open-window.ts.
+  const isFullscreen = currentWindow.state === 'fullscreen';
 
-    await windows.create({
-      url: EXPORT_KEYS_URL,
-      type: 'popup',
-      focused: true,
-      ...(isFullscreen ? {} : { width: SURFACE_WIDTH, height: SURFACE_HEIGHT })
-    });
-  } catch (error) {
-    console.error('openExportKeysSurface: failed to open export window', error);
-  }
+  await windows.create({
+    url: EXPORT_KEYS_URL,
+    type: 'popup',
+    focused: true,
+    ...(isFullscreen ? {} : { width: SURFACE_WIDTH, height: SURFACE_HEIGHT })
+  });
 }
 
 export async function closeExportKeysSurface(): Promise<void> {

--- a/src/libs/layout/unlock-protected-page-content/index.tsx
+++ b/src/libs/layout/unlock-protected-page-content/index.tsx
@@ -30,11 +30,16 @@ interface PasswordPageContentType {
   register: UseFormRegister<PasswordFormValues>;
   errors: FieldErrors<PasswordFormValues>;
   title?: string;
+  // Mirrors the submit button's disabled state. Without it the field stays
+  // editable while the password is being verified, so a user who hits Enter can
+  // keep typing into a form that is already on its way out.
+  disabled?: boolean;
 }
 export const UnlockProtectedPageContent = ({
   register,
   errors,
-  title
+  title,
+  disabled
 }: PasswordPageContentType) => {
   const [passwordInputType, setPasswordInputType] =
     useState<PasswordInputType>('password');
@@ -79,6 +84,7 @@ export const UnlockProtectedPageContent = ({
           error={!!errors.password}
           validationText={errors.password?.message}
           autoFocus
+          disabled={disabled}
           suffixIcon={
             <PasswordVisibilityIcon
               passwordInputType={passwordInputType}


### PR DESCRIPTION
Fixes the long-standing Safari bug where "Download account keys" showed a success screen but never wrote the file.

- Jira: [WALLET-1345](https://make-software.atlassian.net/browse/WALLET-1345)
- GitHub issue: #609 (open since 2023-04)

## Root cause

The export screen ran in the **ephemeral extension popup**. Triggering a download steals focus, Safari closes the popup, its document is torn down, and the browser revokes every `blob:` URL that document owned — aborting the in-flight read. The file never landed.

This was established by probing on a real Safari build, not inferred. In a persistent tab, four variants all downloaded correctly with correct filenames: a detached anchor with an immediate `revokeObjectURL` (a literal reproduction of the shipped code), an attached anchor with immediate revoke, an attached anchor with deferred revoke, and a `data:` URL. The same probe inside the popup produced no file and the popup closed. An earlier single-statement popup probe *did* produce a file, but named `Unknown` — a partially-won race.

So the anchor+blob mechanism, the detached anchor, the revoke timing, the `download` attribute and the MIME type are all exonerated. **`downloadFile` in `utils.ts` is deliberately unchanged** — changing it would have been a fix with no evidence behind it. Only the context was at fault.

The 2023 mitigation merely hid the menu entry on Safari (`hide: isSafariBuild`) while leaving the route registered, so the feature was never disabled — only made unreachable. That gate is now removed.

## What changed

**The flow opens in a dedicated window** (`windows.create({ type: 'popup' })`), verified on Safari to survive the download. Applied to **all three browsers** rather than gating Safari, to avoid a second behavioural branch — this is the main regression surface for review, since Chrome and Firefox worked before and their flow now moves off the popup.

**The final screen no longer claims a completed write.** Nothing can verify one: `downloadFile` is a fire-and-forget anchor click, and `browser.downloads` — the only API that reports success — [does not exist in Safari Web Extensions](https://developer.apple.com/forums/thread/660046). Rather than fake a signal, the screen states what to look for and offers a working **Download again**. That retry is only possible because the surface now outlives the click; in the popup the context was already gone by the time a user noticed the file was missing.

**Navigation corrected for a window.** `Back` is kept only where it genuinely steps back inside the flow. The two screens with nowhere to go back to now close the window instead of running a dead `navigate(-1)`, which in a single-history-entry window was a no-op that trapped the user. The header drops the wallet menu, network switcher and connection status — they otherwise let a user navigate the entire wallet inside a 376px export window.

**Failures are now visible to the user.** Previously every failure path in this flow was silent. See below — this turned out to be the larger half of the change.

### Failure handling

The project has **no Sentry or equivalent** — no error-tracking dependency of any kind. A `console.error` is therefore visible only to someone who opens devtools on the extension, which in practice means nobody. Production failures in this flow were invisible to users and to us simultaneously, so a failed key export was indistinguishable from a dead button. Every failure path now has a visible outcome.

**A failed export lands on a dedicated `Failure` step, not a banner.** This is deliberate: a banner on the Success screen would put "your keys were saved" next to a failure, which is the exact defect this ticket exists to remove. The step states that no file was written and that *nothing left the wallet and the accounts are unchanged* — the fear a secret-key export error actually raises — and offers **Try again**, which returns to account selection rather than retrying blind, so the user can confirm or change the selection first. `Download again` on the Success screen routes into the same step if it fails.

**`openExportKeysSurface` no longer swallows its rejection.** If the window cannot be created there is no export surface on which anything could be reported, so the menu reports it instead, and dismisses itself only once the window actually exists — otherwise the message would have nowhere to render.

**`closeExportKeysSurface` still only logs.** Deliberate: if closing fails, the window visibly stays on screen, so the failure is self-evident and the user's remaining action — closing it from the title bar — is the same one a message would suggest.

**Only the error name is logged, never the thrown value.** On this path the thrown value is built from key material, and it must not reach the console.

**The `Error` component is imported aliased** (`Error as ErrorMessage`). Imported unaliased it shadows the global `Error` constructor, which silently breaks any `new Error(...)` later in the same file — this bit during development.

### The shared password screen — note for reviewers

`PasswordProtectionPage` gates five flows: this one plus contact-details, backup-secret-phrase, wallet-qr-code and change-password. It is touched in two ways, and only one of them is scoped to key export.

**Scoped to this flow.** A new optional `onCloseWindow` prop swaps the header for a bare one whose only action closes the window. The four other callers do not pass it and therefore take the unchanged branch, byte-for-byte identical to before. This exists because a dedicated window has a single history entry, so the default `back` link was a dead `navigate(-1)` that trapped the user on the first screen of the export window.

**Affects all five flows.** The password field is now disabled while the password is being verified, matching the submit button, which was already disabled on the same condition. Previously, pressing Enter left the field editable and a user could keep typing into a form already on its way out. This is a pre-existing bug found while testing the export window; the fix is deliberately applied to the shared component rather than worked around locally, so it changes behaviour in the other four flows too. Worth a look during review even though it is outside the ticket's scope.

Neither change touches `onSubmit`, the verify-password worker call, or `setPasswordConfirmed` — the password gate itself is untouched.

## Testing

`npm run ci-check` passes (51 suites, 341 tests). e2e passes. Manually verified.

No unit tests were added: UI is outside `collectCoverageFrom` in `jest.config.js` and the repo has no component-testing layer. An e2e test would not have covered Safari — the only platform with the bug — nor could it assert that a file was written.

## Known and deliberately not addressed

**One-time window widening on Safari.** The first export shows Safari's native download-permission dialog, which is wider than the window, so Safari widens the window to fit it. Subsequent exports have no dialog and no resize, and the next window is created at the normal width. This is platform UI we do not control; forcing the size back would race the still-open dialog.

**Stale i18n catalogs.** `lang/` has not been regenerated since 2022 — roughly 400 source strings already fall back to English in every locale. The three new strings are no worse off. Regenerating rebuilds the entire catalog (~1750 changes) and belongs in its own ticket.

**`revokeObjectURL` race in `utils.ts`.** The synchronous revoke immediately after `click()` is latent fragility, explicitly refuted as the cause here. Worth a separate cleanup ticket.


[WALLET-1345]: https://make-software.atlassian.net/browse/WALLET-1345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
