### PR TITLE
fix: WALLET-1347 — render QR codes dark-on-light in both themes

### DIFF
--- a/src/apps/popup/pages/account-settings/content.tsx
+++ b/src/apps/popup/pages/account-settings/content.tsx
@@ -1,9 +1,8 @@
-import { QRCodeCanvas } from 'qrcode.react';
 import React, { useCallback } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
-import styled, { useTheme } from 'styled-components';
+import styled from 'styled-components';
 
 import { RouterPath, useTypedNavigate } from '@popup/router';
 
@@ -30,14 +29,23 @@ import { useFetchAccountsInfo } from '@libs/services/account-info';
 import {
   Hash,
   HashVariant,
+  QrCode,
   SvgIcon,
   Tile,
   Typography
 } from '@libs/ui/components';
 
+// At 120px the modules were 2.45px each — the smallest QR we render, on the
+// screen with the most room to spare (WALLET-1347). The tile gives us 296px;
+// 240 takes the modules to 5.33px and still reads as an inset thumbnail rather
+// than taking over the screen.
+const QrCodeContainer = styled(VerticalSpaceContainer)`
+  display: flex;
+  justify-content: center;
+`;
+
 export function AccountSettingsPageContent() {
   const { t } = useTranslation();
-  const theme = useTheme();
 
   const { accountName } = useParams();
   const account = useSelector((state: RootState) =>
@@ -60,16 +68,9 @@ export function AccountSettingsPageContent() {
         <Tile>
           <TileContainer paddingVertical={SpacingSize.XL}>
             <Typography type="header">{account.name}</Typography>
-            <VerticalSpaceContainer top={SpacingSize.XL}>
-              <QRCodeCanvas
-                id="qrCode"
-                value={account.publicKey}
-                size={120}
-                fgColor={theme.color.contentPrimary}
-                bgColor={theme.color.backgroundPrimary}
-                level={'H'}
-              />
-            </VerticalSpaceContainer>
+            <QrCodeContainer top={SpacingSize.XL}>
+              <QrCode value={account.publicKey} size={240} />
+            </QrCodeContainer>
             <VerticalSpaceContainer top={SpacingSize.XL}>
               <FlexColumn gap={SpacingSize.Small}>
                 <Typography type="bodySemiBold">

--- a/src/apps/popup/pages/receive/content.tsx
+++ b/src/apps/popup/pages/receive/content.tsx
@@ -1,8 +1,7 @@
-import { QRCodeCanvas } from 'qrcode.react';
 import React, { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-import styled, { useTheme } from 'styled-components';
+import styled from 'styled-components';
 
 import { formatCep18Tokens } from '@popup/pages/home/components/tokens-list/utils';
 import { useTypedLocation } from '@popup/router';
@@ -20,7 +19,12 @@ import {
 } from '@libs/layout';
 import { useFetchWalletBalance } from '@libs/services/balance-service';
 import { useFetchCep18Tokens } from '@libs/services/cep18-service';
-import { ActiveAccountPlate, Tile, Typography } from '@libs/ui/components';
+import {
+  ActiveAccountPlate,
+  QrCode,
+  Tile,
+  Typography
+} from '@libs/ui/components';
 import { motesToCSPR } from '@libs/ui/utils';
 
 const Container = styled.div`
@@ -42,7 +46,6 @@ interface ITokenData {
 
 export const ReceivePageContent = () => {
   const { t } = useTranslation();
-  const theme = useTheme();
 
   const activeAccount = useSelector(selectVaultActiveAccount);
 
@@ -91,14 +94,7 @@ export const ReceivePageContent = () => {
         <Tile>
           <Container>
             <FlexColumn gap={SpacingSize.Medium}>
-              <QRCodeCanvas
-                id="qrCode"
-                value={activeAccount?.publicKey || ''}
-                size={296}
-                fgColor={theme.color.contentPrimary}
-                bgColor={theme.color.backgroundPrimary}
-                level={'H'}
-              />
+              <QrCode value={activeAccount?.publicKey || ''} size={296} />
               {isClicked ? (
                 <Typography type="captionHash" color="contentPositive">
                   <Trans t={t}>Address copied!</Trans>

--- a/src/apps/popup/pages/wallet-qr-code/content.tsx
+++ b/src/apps/popup/pages/wallet-qr-code/content.tsx
@@ -1,7 +1,6 @@
-import { QRCodeCanvas } from 'qrcode.react';
 import React, { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import styled, { useTheme } from 'styled-components';
+import styled from 'styled-components';
 
 import {
   CenteredFlexRow,
@@ -9,11 +8,15 @@ import {
   ParagraphContainer,
   SpacingSize
 } from '@libs/layout';
-import { Typography } from '@libs/ui/components';
+import { QrCode, Typography } from '@libs/ui/components';
 
+// The symbol carries its own white quiet zone (see QrCode), so the card adds no
+// padding of its own — the full content width goes to the symbol instead, which
+// is what keeps the modules big enough to scan. The canvas covers the card
+// edge to edge, so the card needs no background of its own either; `overflow`
+// keeps the square canvas inside the rounded corners.
 const QRContainer = styled(CenteredFlexRow)`
-  padding: 20px 16px;
-  background-color: ${({ theme }) => theme.color.backgroundPrimary};
+  overflow: hidden;
   border-radius: ${({ theme }) => theme.borderRadius.base}px;
   margin-top: 24px;
 `;
@@ -25,7 +28,6 @@ interface WalletQrCodePageContentProps {
 export const WalletQrCodePageContent = ({
   qrStrings
 }: WalletQrCodePageContentProps) => {
-  const theme = useTheme();
   const [currentQrIndex, setCurrentQrIndex] = useState<number>(0);
 
   useEffect(() => {
@@ -59,14 +61,7 @@ export const WalletQrCodePageContent = ({
         </Typography>
       </ParagraphContainer>
       <QRContainer>
-        <QRCodeCanvas
-          id="qrCode"
-          value={qrStrings[currentQrIndex]}
-          size={296}
-          fgColor={theme.color.contentPrimary}
-          bgColor={theme.color.backgroundPrimary}
-          level={'H'}
-        />
+        <QrCode value={qrStrings[currentQrIndex]} size={328} />
       </QRContainer>
     </ContentContainer>
   );

--- a/src/libs/ui/components/index.ts
+++ b/src/libs/ui/components/index.ts
@@ -53,3 +53,4 @@ export * from './ledger-event-view/ledger-event-view';
 export * from './ledger-connection-view/ledger-connection-view';
 export * from './dynamic-accounts-list-with-select/dynamic-accounts-list-with-select';
 export * from './approve-connection-content/approve-connection-content';
+export * from './qr-code/qr-code';

--- a/src/libs/ui/components/qr-code/qr-code.tsx
+++ b/src/libs/ui/components/qr-code/qr-code.tsx
@@ -1,0 +1,50 @@
+import { QRCodeCanvas } from 'qrcode.react';
+import React from 'react';
+
+/**
+ * QR symbols are always rendered dark-on-light, in both themes.
+ *
+ * ISO/IEC 18004 defines a symbol as dark modules on a light background.
+ * Reading an inverted (light-on-dark) symbol is an optional extra that many
+ * decoders never attempt — ZXing, which backs most Android scanners, gives up
+ * on them — so painting the code with the dark palette made it unscannable on
+ * some phones (WALLET-1347). A mostly-dark screen also pushes the phone camera
+ * into a longer exposure, which blooms the bright modules into their darker
+ * neighbours.
+ */
+const QR_FOREGROUND_COLOR = '#000000';
+const QR_BACKGROUND_COLOR = '#FFFFFF';
+
+/**
+ * Quiet zone, in modules. `qrcode.react` leaves it out by default, which left
+ * us relying on the container's padding — and that padding is a fixed number
+ * of pixels, so it silently drops below the 4 modules the spec requires as
+ * soon as the modules get bigger.
+ */
+const QR_MARGIN_SIZE = 4;
+
+/**
+ * On a screen there is nothing to recover from: no print damage, no smudges.
+ * The extra error correction of level `H` only buys density — a 200-char sync
+ * chunk needs 77x77 modules at `H` against 57x57 at `M` — and density is what
+ * actually breaks scanning on a small popup. `boostLevel` (on by default) still
+ * upgrades the level for free whenever it fits in the same version.
+ */
+const QR_ERROR_CORRECTION_LEVEL = 'M';
+
+interface QrCodeProps {
+  value: string;
+  size: number;
+}
+
+export const QrCode = ({ value, size }: QrCodeProps) => (
+  <QRCodeCanvas
+    id="qrCode"
+    value={value}
+    size={size}
+    fgColor={QR_FOREGROUND_COLOR}
+    bgColor={QR_BACKGROUND_COLOR}
+    marginSize={QR_MARGIN_SIZE}
+    level={QR_ERROR_CORRECTION_LEVEL}
+  />
+);


### PR DESCRIPTION
[WALLET-1347](https://make-software.atlassian.net/browse/WALLET-1347)

## Problem

QA reported that Android devices sometimes fail to scan the sync QR code while the extension is in dark theme, with no issues in light theme.

All three QR call sites passed theme colours to `qrcode.react`, so in dark theme the symbol was rendered **inverted** — white modules (`#FFFFFF`) on `#262730`. ISO/IEC 18004 defines a QR symbol as dark modules on a light background; decoding an inverted symbol is an optional extra that scanners cannot be relied on to attempt. A mostly-dark screen also pushes the phone camera into a longer exposure, which blooms the bright modules into their darker neighbours.

Two further problems made the symbol harder to resolve than it needed to be:

- **No quiet zone.** `qrcode.react` v4 defaults `marginSize` to `0`, so the only quiet zone was the container's fixed `16px` padding. That padding is measured in pixels while the quiet zone requirement is measured in modules, so it silently drops below the required 4 modules as soon as the modules get bigger.
- **Error-correction level `H`.** 30% recovery buys nothing on a screen — there is no print damage to recover from — but it pushed a 204-byte sync chunk to 77×77 modules, i.e. 3.84 CSS px per module inside a 360px popup.

## Change

A shared `QrCode` component (`src/libs/ui/components/qr-code/qr-code.tsx`) is now the single place these parameters live. It pins the symbol to black-on-white in both themes, carries its own 4-module quiet zone, and drops to level `M`. Each constant carries a comment explaining *why*, so that "hardcoded colours in a themed component" doesn't get helpfully reverted later.

Because the quiet zone now lives inside the canvas, the container's background colour no longer affects decoding, and its padding became redundant:

- **`wallet-qr-code`** — the card gives its full content width to the symbol (296 → 328px). It no longer needs a background of its own, since the canvas covers it edge to edge.
- **`account-settings`** — this was the smallest QR we render on the screen with the most room to spare. 120 → 240px, and it is now centred; previously the bare `<canvas>` was `display: inline` inside a plain block, so it sat left-aligned.
- **`receive`** — unchanged apart from adopting the shared component.

Module size per screen, before → after:

| Screen | Before | After | |
|---|---|---|---|
| `wallet-qr-code` | 3.84px | **5.05px** | +31% |
| `account-settings` | 2.45px | **5.33px** | +118% |
| `receive` | 6.04px | **6.58px** | +9% |

These figures were computed by running the payloads through the encoder bundled in `qrcode.react`, not estimated.

## Testing

`npm run ci-check` passes. The QR rendering itself has no unit test — `jest.config.js` runs on `testEnvironment: 'node'` with no jsdom, and `QRCodeCanvas` needs a canvas — so this needs a QA pass on the Android device where the original failure was seen, rather than a "looks fine on my machine".

Worth checking during review: the layout changes on `wallet-qr-code` (full-width card) and `account-settings` (240px, centred) were made without a designer, and are the two things most likely to want adjusting.


[WALLET-1347]: https://make-software.atlassian.net/browse/WALLET-1347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ