### PR TITLE
fix: WALLET-1345 — Safari key export writes the file, and the final screen stops claiming it did

### DIFF
--- a/src/apps/popup/pages/download-account-keys/failure.tsx
+++ b/src/apps/popup/pages/download-account-keys/failure.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+
+import {
+  ContentContainer,
+  IllustrationContainer,
+  ParagraphContainer,
+  SpacingSize
+} from '@libs/layout';
+import { SvgIcon, Typography } from '@libs/ui/components';
+
+export const Failure = () => {
+  const { t } = useTranslation();
+
+  return (
+    <ContentContainer>
+      <IllustrationContainer>
+        <SvgIcon
+          src="assets/illustrations/error.svg"
+          width={190}
+          height={120}
+        />
+      </IllustrationContainer>
+
+      <ParagraphContainer top={SpacingSize.XL}>
+        <Typography type="header">
+          <Trans t={t}>Couldn’t download your keys</Trans>
+        </Typography>
+      </ParagraphContainer>
+
+      <ParagraphContainer top={SpacingSize.Medium}>
+        <Typography type="body" color="contentSecondary">
+          <Trans t={t}>
+            No file was saved. Nothing left your wallet and your accounts are
+            unchanged, so it is safe to try again.
+          </Trans>
+        </Typography>
+      </ParagraphContainer>
+    </ContentContainer>
+  );
+};

--- a/src/apps/popup/pages/download-account-keys/index.tsx
+++ b/src/apps/popup/pages/download-account-keys/index.tsx
@@ -47,25 +47,35 @@ export const DownloadAccountKeysPage = () => {
   }
 
   const downloadKeys = async () => {
-    const zip = new JSZip();
+    try {
+      const zip = new JSZip();
 
-    for (const account of selectedAccounts) {
-      const asymmetricKey = createAsymmetricKeys(
-        account.publicKey,
-        account.secretKey
-      );
+      for (const account of selectedAccounts) {
+        const asymmetricKey = createAsymmetricKeys(
+          account.publicKey,
+          account.secretKey
+        );
 
-      if (asymmetricKey.secretKey) {
-        const file = asymmetricKey.secretKey.toPem();
-        zip.file(`${account.name}_secret_key.pem`, file);
+        if (asymmetricKey.secretKey) {
+          const file = asymmetricKey.secretKey.toPem();
+          zip.file(`${account.name}_secret_key.pem`, file);
+        }
       }
-    }
 
-    await zip.generateAsync({ type: 'blob' }).then(function (content) {
+      const content = await zip.generateAsync({ type: 'blob' });
       downloadFile(new Blob([content]), 'casper-wallet-secret_keys.zip');
-    });
 
-    setDownloadAccountKeysStep(DownloadAccountKeysSteps.Success);
+      setDownloadAccountKeysStep(DownloadAccountKeysSteps.Success);
+    } catch (error) {
+      // Stay on this step: advancing to Success here is exactly the false
+      // "your keys were saved" this ticket exists to remove. Only the error
+      // name is logged — the thrown value is built from key material and must
+      // not reach the console.
+      console.error(
+        'downloadKeys: failed to build or download the keys archive',
+        error instanceof Error ? error.name : 'unknown error'
+      );
+    }
   };
 
   const content = {

--- a/src/apps/popup/pages/download-account-keys/index.tsx
+++ b/src/apps/popup/pages/download-account-keys/index.tsx
@@ -3,7 +3,8 @@ import React, { useCallback, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { PasswordProtectionPage } from '@popup/pages/password-protection-page';
-import { RouterPath, useTypedNavigate } from '@popup/router';
+
+import { closeExportKeysSurface } from '@background/open-export-keys-surface';
 
 import { createAsymmetricKeys } from '@libs/crypto/create-asymmetric-key';
 import {
@@ -31,7 +32,6 @@ export const DownloadAccountKeysPage = () => {
   );
 
   const { t } = useTranslation();
-  const navigate = useTypedNavigate();
 
   const setPasswordConfirmed = useCallback(() => {
     setIsPasswordConfirmed(true);
@@ -39,7 +39,10 @@ export const DownloadAccountKeysPage = () => {
 
   if (!isPasswordConfirmed) {
     return (
-      <PasswordProtectionPage setPasswordConfirmed={setPasswordConfirmed} />
+      <PasswordProtectionPage
+        setPasswordConfirmed={setPasswordConfirmed}
+        onCloseWindow={() => closeExportKeysSurface()}
+      />
     );
   }
 
@@ -77,8 +80,14 @@ export const DownloadAccountKeysPage = () => {
   };
 
   const headerButton = {
+    // "Back" is only used where it genuinely steps back inside the flow. The
+    // entry step has nowhere to go back to in a dedicated window, so it closes
+    // instead — labelling that "Back" would be a lie (WALLET-1345).
     [DownloadAccountKeysSteps.Instruction]: (
-      <HeaderSubmenuBarNavLink linkType="back" />
+      <HeaderSubmenuBarNavLink
+        linkType="close"
+        onClick={() => closeExportKeysSurface()}
+      />
     ),
     [DownloadAccountKeysSteps.Download]: (
       <HeaderSubmenuBarNavLink
@@ -89,7 +98,10 @@ export const DownloadAccountKeysPage = () => {
       />
     ),
     [DownloadAccountKeysSteps.Success]: (
-      <HeaderSubmenuBarNavLink linkType="close" />
+      <HeaderSubmenuBarNavLink
+        linkType="close"
+        onClick={() => closeExportKeysSurface()}
+      />
     )
   };
 
@@ -109,19 +121,25 @@ export const DownloadAccountKeysPage = () => {
       </Button>
     ),
     [DownloadAccountKeysSteps.Success]: (
-      <Button onClick={() => navigate(RouterPath.Home)}>
-        <Trans t={t}>Done</Trans>
-      </Button>
+      <>
+        <Button onClick={() => closeExportKeysSurface()}>
+          <Trans t={t}>Done</Trans>
+        </Button>
+        <Button color="secondaryBlue" onClick={downloadKeys}>
+          <Trans t={t}>Download again</Trans>
+        </Button>
+      </>
     )
   };
 
   return (
     <PopupLayout
       renderHeader={() => (
+        // Deliberately bare: this window exists to export secret keys and
+        // nothing else. The wallet menu / network switcher / connection status
+        // would let the user navigate the full wallet inside a 376px export
+        // window and strand themselves there (WALLET-1345).
         <HeaderPopup
-          withNetworkSwitcher
-          withMenu
-          withConnectionStatus
           renderSubmenuBarItems={() => headerButton[downloadAccountKeysStep]}
         />
       )}

--- a/src/apps/popup/pages/download-account-keys/index.tsx
+++ b/src/apps/popup/pages/download-account-keys/index.tsx
@@ -17,6 +17,7 @@ import { AccountListRows } from '@libs/types/account';
 import { Button } from '@libs/ui/components';
 
 import { Download } from './download';
+import { Failure } from './failure';
 import { Instruction } from './instruction';
 import { Success } from './success';
 import { DownloadAccountKeysSteps, downloadFile } from './utils';
@@ -67,14 +68,15 @@ export const DownloadAccountKeysPage = () => {
 
       setDownloadAccountKeysStep(DownloadAccountKeysSteps.Success);
     } catch (error) {
-      // Stay on this step: advancing to Success here is exactly the false
-      // "your keys were saved" this ticket exists to remove. Only the error
-      // name is logged — the thrown value is built from key material and must
-      // not reach the console.
+      // Only the error name is logged — the thrown value is built from key
+      // material and must not reach the console. Nothing collects these logs
+      // (the project has no Sentry or equivalent), so the Failure step below is
+      // the only way this reaches anyone.
       console.error(
         'downloadKeys: failed to build or download the keys archive',
         error instanceof Error ? error.name : 'unknown error'
       );
+      setDownloadAccountKeysStep(DownloadAccountKeysSteps.Failure);
     }
   };
 
@@ -86,7 +88,8 @@ export const DownloadAccountKeysPage = () => {
         setSelectedAccounts={setSelectedAccounts}
       />
     ),
-    [DownloadAccountKeysSteps.Success]: <Success />
+    [DownloadAccountKeysSteps.Success]: <Success />,
+    [DownloadAccountKeysSteps.Failure]: <Failure />
   };
 
   const headerButton = {
@@ -108,6 +111,12 @@ export const DownloadAccountKeysPage = () => {
       />
     ),
     [DownloadAccountKeysSteps.Success]: (
+      <HeaderSubmenuBarNavLink
+        linkType="close"
+        onClick={() => closeExportKeysSurface()}
+      />
+    ),
+    [DownloadAccountKeysSteps.Failure]: (
       <HeaderSubmenuBarNavLink
         linkType="close"
         onClick={() => closeExportKeysSurface()}
@@ -139,6 +148,17 @@ export const DownloadAccountKeysPage = () => {
           <Trans t={t}>Download again</Trans>
         </Button>
       </>
+    ),
+    // Back to account selection rather than retrying blind: the selection is
+    // still in state, so the user can confirm or change it before trying again.
+    [DownloadAccountKeysSteps.Failure]: (
+      <Button
+        onClick={() =>
+          setDownloadAccountKeysStep(DownloadAccountKeysSteps.Download)
+        }
+      >
+        <Trans t={t}>Try again</Trans>
+      </Button>
     )
   };
 

--- a/src/apps/popup/pages/download-account-keys/success.tsx
+++ b/src/apps/popup/pages/download-account-keys/success.tsx
@@ -24,7 +24,16 @@ export const Success = () => {
 
       <ParagraphContainer top={SpacingSize.XL}>
         <Typography type="header">
-          <Trans t={t}>You downloaded account private key(s)</Trans>
+          <Trans t={t}>Check your Downloads folder</Trans>
+        </Typography>
+      </ParagraphContainer>
+
+      <ParagraphContainer top={SpacingSize.Medium}>
+        <Typography type="body" color="contentSecondary">
+          <Trans t={t}>
+            Look for casper-wallet-secret_keys.zip in your Downloads folder. If
+            it isn’t there, the download didn’t complete — try again.
+          </Trans>
         </Typography>
       </ParagraphContainer>
 

--- a/src/apps/popup/pages/download-account-keys/utils.ts
+++ b/src/apps/popup/pages/download-account-keys/utils.ts
@@ -1,7 +1,11 @@
 export enum DownloadAccountKeysSteps {
   Instruction = 'instruction',
   Download = 'download',
-  Success = 'success'
+  Success = 'success',
+  // Reached only when the export throws. Deliberately a step of its own rather
+  // than a banner on Success: the user must never see "your keys were saved"
+  // alongside a failure (WALLET-1345).
+  Failure = 'failure'
 }
 
 export const downloadFile = (content: Blob, filename: string): void => {

--- a/src/apps/popup/pages/navigation-menu/index.tsx
+++ b/src/apps/popup/pages/navigation-menu/index.tsx
@@ -10,12 +10,13 @@ import {
   TERMS_URLS,
   USER_GUIDES_URL
 } from '@src/constants';
-import { isLedgerAvailable, isSafariBuild } from '@src/utils';
+import { isLedgerAvailable } from '@src/utils';
 
 import { TimeoutDurationSetting } from '@popup/constants';
 import { RouterPath, useNavigationMenu, useTypedNavigate } from '@popup/router';
 
 import { WindowApp } from '@background/create-open-window';
+import { openExportKeysSurface } from '@background/open-export-keys-surface';
 import { selectCountOfContacts } from '@background/redux/contacts/selectors';
 import { lockVault } from '@background/redux/sagas/actions';
 import {
@@ -310,11 +311,9 @@ export function NavigationMenuPageContent() {
             title: t('Download account keys'),
             iconPath: 'assets/icons/download.svg',
             disabled: false,
-            // https://github.com/make-software/casper-wallet/issues/611
-            hide: isSafariBuild,
             handleOnClick: () => {
               closeNavigationMenu();
-              navigate(RouterPath.DownloadAccountKeys);
+              openExportKeysSurface();
             }
           },
           {

--- a/src/apps/popup/pages/navigation-menu/index.tsx
+++ b/src/apps/popup/pages/navigation-menu/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
@@ -38,9 +38,11 @@ import {
   ContentContainer,
   FlexColumn,
   SpaceBetweenFlexRow,
-  SpacingSize
+  SpacingSize,
+  VerticalSpaceContainer
 } from '@libs/layout';
 import {
+  Error as ErrorMessage,
   Link,
   List,
   Modal,
@@ -106,6 +108,8 @@ export function NavigationMenuPageContent() {
   const navigate = useTypedNavigate();
   const { t } = useTranslation();
   const isDarkMode = useIsDarkMode();
+
+  const [exportKeysWindowFailed, setExportKeysWindowFailed] = useState(false);
 
   const timeoutDurationSetting = useSelector(selectTimeoutDurationSetting);
   const countOfConnectedSites = useSelector(selectCountOfConnectedSites);
@@ -311,9 +315,21 @@ export function NavigationMenuPageContent() {
             title: t('Download account keys'),
             iconPath: 'assets/icons/download.svg',
             disabled: false,
-            handleOnClick: () => {
-              closeNavigationMenu();
-              openExportKeysSurface();
+            handleOnClick: async () => {
+              setExportKeysWindowFailed(false);
+
+              try {
+                await openExportKeysSurface();
+                // Only dismiss the menu once the window actually exists —
+                // otherwise the error below would have nowhere to render.
+                closeNavigationMenu();
+              } catch (error) {
+                console.error(
+                  'navigation-menu: failed to open the key export window',
+                  error
+                );
+                setExportKeysWindowFailed(true);
+              }
             }
           },
           {
@@ -430,6 +446,16 @@ export function NavigationMenuPageContent() {
 
   return (
     <ContentContainer>
+      {exportKeysWindowFailed && (
+        <VerticalSpaceContainer top={SpacingSize.Medium}>
+          <ErrorMessage
+            header={t('Couldn’t open the export window')}
+            description={t(
+              'Your keys were not exported. Close any other wallet windows and try again.'
+            )}
+          />
+        </VerticalSpaceContainer>
+      )}
       {menuGroups.map(
         ({ headerLabel: groupLabel, items: groupItems }, index) => (
           <List

--- a/src/apps/popup/pages/navigation-menu/index.tsx
+++ b/src/apps/popup/pages/navigation-menu/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
@@ -16,9 +16,11 @@ import { TimeoutDurationSetting } from '@popup/constants';
 import { RouterPath, useNavigationMenu, useTypedNavigate } from '@popup/router';
 
 import { WindowApp } from '@background/create-open-window';
-import { openExportKeysSurface } from '@background/open-export-keys-surface';
 import { selectCountOfContacts } from '@background/redux/contacts/selectors';
-import { lockVault } from '@background/redux/sagas/actions';
+import {
+  lockVault,
+  openExportKeysWindow
+} from '@background/redux/sagas/actions';
 import {
   selectThemeModeSetting,
   selectTimeoutDurationSetting
@@ -38,11 +40,9 @@ import {
   ContentContainer,
   FlexColumn,
   SpaceBetweenFlexRow,
-  SpacingSize,
-  VerticalSpaceContainer
+  SpacingSize
 } from '@libs/layout';
 import {
-  Error as ErrorMessage,
   Link,
   List,
   Modal,
@@ -108,8 +108,6 @@ export function NavigationMenuPageContent() {
   const navigate = useTypedNavigate();
   const { t } = useTranslation();
   const isDarkMode = useIsDarkMode();
-
-  const [exportKeysWindowFailed, setExportKeysWindowFailed] = useState(false);
 
   const timeoutDurationSetting = useSelector(selectTimeoutDurationSetting);
   const countOfConnectedSites = useSelector(selectCountOfConnectedSites);
@@ -315,21 +313,9 @@ export function NavigationMenuPageContent() {
             title: t('Download account keys'),
             iconPath: 'assets/icons/download.svg',
             disabled: false,
-            handleOnClick: async () => {
-              setExportKeysWindowFailed(false);
-
-              try {
-                await openExportKeysSurface();
-                // Only dismiss the menu once the window actually exists —
-                // otherwise the error below would have nowhere to render.
-                closeNavigationMenu();
-              } catch (error) {
-                console.error(
-                  'navigation-menu: failed to open the key export window',
-                  error
-                );
-                setExportKeysWindowFailed(true);
-              }
+            handleOnClick: () => {
+              closeNavigationMenu();
+              dispatchToMainStore(openExportKeysWindow());
             }
           },
           {
@@ -446,16 +432,6 @@ export function NavigationMenuPageContent() {
 
   return (
     <ContentContainer>
-      {exportKeysWindowFailed && (
-        <VerticalSpaceContainer top={SpacingSize.Medium}>
-          <ErrorMessage
-            header={t('Couldn’t open the export window')}
-            description={t(
-              'Your keys were not exported. Close any other wallet windows and try again.'
-            )}
-          />
-        </VerticalSpaceContainer>
-      )}
       {menuGroups.map(
         ({ headerLabel: groupLabel, items: groupItems }, index) => (
           <List

--- a/src/apps/popup/pages/password-protection-page/index.tsx
+++ b/src/apps/popup/pages/password-protection-page/index.tsx
@@ -89,6 +89,9 @@ export const PasswordProtectionPage = ({
 
   const onSubmit = () => {
     if (privateState == null) return;
+    // The field is now read-only rather than disabled while verifying (so it
+    // keeps focus), which leaves Enter able to re-submit. Guard against that.
+    if (isSubmitting) return;
 
     const { passwordHash, passwordSaltHash } = privateState;
 
@@ -119,12 +122,16 @@ export const PasswordProtectionPage = ({
         setIsSubmitting(false);
       } else {
         if (onClick) {
-          onClick(password).then(() => {
-            if (setPasswordConfirmed) {
-              setPasswordConfirmed();
-            }
-            dispatchToMainStore(loginRetryCountReseted());
-          });
+          onClick(password)
+            .then(() => {
+              if (setPasswordConfirmed) {
+                setPasswordConfirmed();
+              }
+              dispatchToMainStore(loginRetryCountReseted());
+            })
+            // Without this a rejected onClick leaves the page stuck submitting —
+            // and now that the field is read-only-while-submitting, frozen too.
+            .catch(() => setIsSubmitting(false));
         } else {
           if (setPasswordConfirmed) {
             setPasswordConfirmed();
@@ -178,7 +185,7 @@ export const PasswordProtectionPage = ({
         <UnlockProtectedPageContent
           errors={errors}
           register={register}
-          disabled={isSubmitting || isLoading}
+          readOnly={isSubmitting || isLoading}
         />
       )}
       renderFooter={() => (

--- a/src/apps/popup/pages/password-protection-page/index.tsx
+++ b/src/apps/popup/pages/password-protection-page/index.tsx
@@ -34,6 +34,12 @@ interface BackupSecretPhrasePasswordPageType {
   setPasswordConfirmed?: () => void;
   onClick?: (password: string) => Promise<void>;
   isLoading?: boolean;
+  // Set when this page is rendered inside a dedicated window rather than the
+  // extension popup (WALLET-1345). Such a window has a single history entry, so
+  // the default "back" link is a no-op and would trap the user; it also has no
+  // business showing the wallet menu / network switcher. Passing this swaps the
+  // header for a bare one whose only action closes the window.
+  onCloseWindow?: () => void;
 }
 
 interface VerifyPasswordMessageEvent extends MessageEvent {
@@ -45,7 +51,8 @@ interface VerifyPasswordMessageEvent extends MessageEvent {
 export const PasswordProtectionPage = ({
   setPasswordConfirmed,
   onClick,
-  isLoading = false
+  isLoading = false,
+  onCloseWindow
 }: BackupSecretPhrasePasswordPageType) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -146,16 +153,27 @@ export const PasswordProtectionPage = ({
     <PopupLayout
       variant="form"
       onSubmit={handleSubmit(onSubmit)}
-      renderHeader={() => (
-        <HeaderPopup
-          withNetworkSwitcher
-          withMenu
-          withConnectionStatus
-          renderSubmenuBarItems={() => (
-            <HeaderSubmenuBarNavLink linkType="back" />
-          )}
-        />
-      )}
+      renderHeader={() =>
+        onCloseWindow ? (
+          <HeaderPopup
+            renderSubmenuBarItems={() => (
+              <HeaderSubmenuBarNavLink
+                linkType="close"
+                onClick={onCloseWindow}
+              />
+            )}
+          />
+        ) : (
+          <HeaderPopup
+            withNetworkSwitcher
+            withMenu
+            withConnectionStatus
+            renderSubmenuBarItems={() => (
+              <HeaderSubmenuBarNavLink linkType="back" />
+            )}
+          />
+        )
+      }
       renderContent={() => (
         <UnlockProtectedPageContent errors={errors} register={register} />
       )}

--- a/src/apps/popup/pages/password-protection-page/index.tsx
+++ b/src/apps/popup/pages/password-protection-page/index.tsx
@@ -175,7 +175,11 @@ export const PasswordProtectionPage = ({
         )
       }
       renderContent={() => (
-        <UnlockProtectedPageContent errors={errors} register={register} />
+        <UnlockProtectedPageContent
+          errors={errors}
+          register={register}
+          disabled={isSubmitting || isLoading}
+        />
       )}
       renderFooter={() => (
         <FooterButtonsContainer>

--- a/src/background/handlers/redux-actions.parity.test.ts
+++ b/src/background/handlers/redux-actions.parity.test.ts
@@ -129,7 +129,15 @@ const EXCLUSIONS: ReadonlySet<string> = new Set(
     // channel) in vault/onboarding/network sagas. The UI reads it via
     // selectSagaErrors and dispatches only dismissSagaError (which IS
     // forwarded); sagaError itself is never dispatched from the UI.
-    appEventsActions.sagaError
+    appEventsActions.sagaError,
+    // Background-only: put by the export-keys-window saga (create / stale-heal)
+    // and store.dispatch'd by the onRemoved listener on close. The UI
+    // dispatches only openExportKeysWindow.
+    windowManagementActions.exportKeysWindowIdChanged,
+    // Background-only: put by the export-keys-window saga (create / stale-heal)
+    // and store.dispatch'd by the onRemoved listener on close. The UI
+    // dispatches only openExportKeysWindow.
+    windowManagementActions.exportKeysWindowIdCleared
   ].map(creator => creator.type)
 );
 

--- a/src/background/handlers/redux-actions.ts
+++ b/src/background/handlers/redux-actions.ts
@@ -84,6 +84,7 @@ import {
   initKeys,
   initVault,
   lockVault,
+  openExportKeysWindow,
   recoverVault,
   resetVault,
   unlockVault
@@ -111,6 +112,7 @@ export const FORWARDED_ACTION_TYPES: ReadonlySet<string> = new Set(
   [
     lockVault,
     unlockVault,
+    openExportKeysWindow,
     initKeys,
     initVault,
     recoverVault,

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -39,7 +39,11 @@ import {
   selectIsAccountConnected,
   selectVaultActiveAccount
 } from '@background/redux/vault/selectors';
-import { selectWindowId } from '@background/redux/windowManagement/selectors';
+import { exportKeysWindowIdCleared } from '@background/redux/windowManagement/actions';
+import {
+  selectExportKeysWindowId,
+  selectWindowId
+} from '@background/redux/windowManagement/selectors';
 
 import { sdkEvent } from '@content/sdk-event';
 import { isSDKMethod } from '@content/sdk-method';
@@ -181,6 +185,9 @@ windows.onRemoved.addListener(async (removedWindowId: number) => {
   const store = await getExistingMainStoreSingletonOrInit();
   if (removedWindowId === selectWindowId(store.getState())) {
     await cancelOpenRequestsForClosedWindow(store, removedWindowId);
+  }
+  if (removedWindowId === selectExportKeysWindowId(store.getState())) {
+    store.dispatch(exportKeysWindowIdCleared());
   }
 });
 

--- a/src/background/open-export-keys-surface.ts
+++ b/src/background/open-export-keys-surface.ts
@@ -38,7 +38,12 @@ export async function closeExportKeysSurface(): Promise<void> {
   try {
     const currentWindow = await windows.getCurrent();
 
-    if (currentWindow.id != null) {
+    // Only ever remove a dedicated popup window, never a normal browser window
+    // with the user's other tabs in it. This flow always opens type:'popup',
+    // but popup.html is URL-addressable, so if the export page is ever rendered
+    // in a plain tab getCurrent() would return that whole window. Same guard as
+    // close-current-window.ts.
+    if (currentWindow.type === 'popup' && currentWindow.id != null) {
       await windows.remove(currentWindow.id);
     }
   } catch (error) {

--- a/src/background/open-export-keys-surface.ts
+++ b/src/background/open-export-keys-surface.ts
@@ -1,39 +1,5 @@
 import { windows } from 'webextension-polyfill';
 
-import { RouterPath } from '@popup/router/paths';
-
-// WALLET-1345: key export must not run in the extension popup. On Safari the
-// popup closes the moment a download steals focus; its document is torn down,
-// the browser revokes the blob: URL mid-read, and the file never lands. The
-// anchor+blob mechanism itself is fine — it only needs a context that outlives
-// the click, which is why nothing in download-account-keys/utils.ts changed.
-const EXPORT_KEYS_URL = `popup.html#${RouterPath.DownloadAccountKeys}`;
-
-// Matches the sizing in create-open-window.ts (360 + 16 cross-platform width
-// offset) so the 360px-wide popup UI is not clipped.
-const SURFACE_WIDTH = 376;
-const SURFACE_HEIGHT = 700;
-
-// Rejects on failure — the caller is expected to tell the user. If this window
-// never opens there is no other surface on which the export could report back,
-// so swallowing here would leave the menu item looking simply dead.
-export async function openExportKeysSurface(): Promise<void> {
-  const currentWindow = await windows.getCurrent();
-
-  // Firefox ignores width/height when the parent window is fullscreen and
-  // would open a tiny popup instead; omitting them lets it size the window
-  // itself. Chrome and Safari do this by default. Mirrors
-  // create-open-window.ts.
-  const isFullscreen = currentWindow.state === 'fullscreen';
-
-  await windows.create({
-    url: EXPORT_KEYS_URL,
-    type: 'popup',
-    focused: true,
-    ...(isFullscreen ? {} : { width: SURFACE_WIDTH, height: SURFACE_HEIGHT })
-  });
-}
-
 export async function closeExportKeysSurface(): Promise<void> {
   try {
     const currentWindow = await windows.getCurrent();

--- a/src/background/open-export-keys-surface.ts
+++ b/src/background/open-export-keys-surface.ts
@@ -14,26 +14,44 @@ const EXPORT_KEYS_URL = `popup.html#${RouterPath.DownloadAccountKeys}`;
 const SURFACE_WIDTH = 376;
 const SURFACE_HEIGHT = 700;
 
+// Both helpers are called fire-and-forget from onClick handlers, so they settle
+// their own failures rather than leaving an unhandled rejection. Same reasoning
+// as open-window.ts: a silent no-op with no trace is the worst outcome.
+
 export async function openExportKeysSurface(): Promise<void> {
-  const currentWindow = await windows.getCurrent();
+  try {
+    const currentWindow = await windows.getCurrent();
 
-  // Firefox ignores width/height when the parent window is fullscreen and would
-  // open a tiny popup instead; omitting them lets it size the window itself.
-  // Chrome and Safari do this by default. Mirrors create-open-window.ts.
-  const isFullscreen = currentWindow.state === 'fullscreen';
+    // Firefox ignores width/height when the parent window is fullscreen and
+    // would open a tiny popup instead; omitting them lets it size the window
+    // itself. Chrome and Safari do this by default. Mirrors
+    // create-open-window.ts.
+    const isFullscreen = currentWindow.state === 'fullscreen';
 
-  await windows.create({
-    url: EXPORT_KEYS_URL,
-    type: 'popup',
-    focused: true,
-    ...(isFullscreen ? {} : { width: SURFACE_WIDTH, height: SURFACE_HEIGHT })
-  });
+    await windows.create({
+      url: EXPORT_KEYS_URL,
+      type: 'popup',
+      focused: true,
+      ...(isFullscreen ? {} : { width: SURFACE_WIDTH, height: SURFACE_HEIGHT })
+    });
+  } catch (error) {
+    console.error('openExportKeysSurface: failed to open export window', error);
+  }
 }
 
 export async function closeExportKeysSurface(): Promise<void> {
-  const currentWindow = await windows.getCurrent();
+  try {
+    const currentWindow = await windows.getCurrent();
 
-  if (currentWindow.id != null) {
-    await windows.remove(currentWindow.id);
+    if (currentWindow.id != null) {
+      await windows.remove(currentWindow.id);
+    }
+  } catch (error) {
+    // The window stays open and the user can still close it from the title bar,
+    // so this is recoverable — but it must not vanish without a trace.
+    console.error(
+      'closeExportKeysSurface: failed to close export window',
+      error
+    );
   }
 }

--- a/src/background/open-export-keys-surface.ts
+++ b/src/background/open-export-keys-surface.ts
@@ -1,0 +1,39 @@
+import { windows } from 'webextension-polyfill';
+
+import { RouterPath } from '@popup/router/paths';
+
+// WALLET-1345: key export must not run in the extension popup. On Safari the
+// popup closes the moment a download steals focus; its document is torn down,
+// the browser revokes the blob: URL mid-read, and the file never lands. The
+// anchor+blob mechanism itself is fine — it only needs a context that outlives
+// the click, which is why nothing in download-account-keys/utils.ts changed.
+const EXPORT_KEYS_URL = `popup.html#${RouterPath.DownloadAccountKeys}`;
+
+// Matches the sizing in create-open-window.ts (360 + 16 cross-platform width
+// offset) so the 360px-wide popup UI is not clipped.
+const SURFACE_WIDTH = 376;
+const SURFACE_HEIGHT = 700;
+
+export async function openExportKeysSurface(): Promise<void> {
+  const currentWindow = await windows.getCurrent();
+
+  // Firefox ignores width/height when the parent window is fullscreen and would
+  // open a tiny popup instead; omitting them lets it size the window itself.
+  // Chrome and Safari do this by default. Mirrors create-open-window.ts.
+  const isFullscreen = currentWindow.state === 'fullscreen';
+
+  await windows.create({
+    url: EXPORT_KEYS_URL,
+    type: 'popup',
+    focused: true,
+    ...(isFullscreen ? {} : { width: SURFACE_WIDTH, height: SURFACE_HEIGHT })
+  });
+}
+
+export async function closeExportKeysSurface(): Promise<void> {
+  const currentWindow = await windows.getCurrent();
+
+  if (currentWindow.id != null) {
+    await windows.remove(currentWindow.id);
+  }
+}

--- a/src/background/open-export-keys-surface.ts
+++ b/src/background/open-export-keys-surface.ts
@@ -14,29 +14,24 @@ const EXPORT_KEYS_URL = `popup.html#${RouterPath.DownloadAccountKeys}`;
 const SURFACE_WIDTH = 376;
 const SURFACE_HEIGHT = 700;
 
-// Both helpers are called fire-and-forget from onClick handlers, so they settle
-// their own failures rather than leaving an unhandled rejection. Same reasoning
-// as open-window.ts: a silent no-op with no trace is the worst outcome.
-
+// Rejects on failure — the caller is expected to tell the user. If this window
+// never opens there is no other surface on which the export could report back,
+// so swallowing here would leave the menu item looking simply dead.
 export async function openExportKeysSurface(): Promise<void> {
-  try {
-    const currentWindow = await windows.getCurrent();
+  const currentWindow = await windows.getCurrent();
 
-    // Firefox ignores width/height when the parent window is fullscreen and
-    // would open a tiny popup instead; omitting them lets it size the window
-    // itself. Chrome and Safari do this by default. Mirrors
-    // create-open-window.ts.
-    const isFullscreen = currentWindow.state === 'fullscreen';
+  // Firefox ignores width/height when the parent window is fullscreen and
+  // would open a tiny popup instead; omitting them lets it size the window
+  // itself. Chrome and Safari do this by default. Mirrors
+  // create-open-window.ts.
+  const isFullscreen = currentWindow.state === 'fullscreen';
 
-    await windows.create({
-      url: EXPORT_KEYS_URL,
-      type: 'popup',
-      focused: true,
-      ...(isFullscreen ? {} : { width: SURFACE_WIDTH, height: SURFACE_HEIGHT })
-    });
-  } catch (error) {
-    console.error('openExportKeysSurface: failed to open export window', error);
-  }
+  await windows.create({
+    url: EXPORT_KEYS_URL,
+    type: 'popup',
+    focused: true,
+    ...(isFullscreen ? {} : { width: SURFACE_WIDTH, height: SURFACE_HEIGHT })
+  });
 }
 
 export async function closeExportKeysSurface(): Promise<void> {

--- a/src/background/redux/get-main-store.ts
+++ b/src/background/redux/get-main-store.ts
@@ -83,6 +83,9 @@ const selectPopupState = (state: RootState): PopupState => {
     // the whole slice would put dapp A's origin into dapp B's UI replica. No
     // UI reads it (only `selectWindowId` is consumed, in use-window-manager);
     // the cancel-on-close path reads it in the background, off the real store.
+    // `exportKeysWindowId` is also dropped: the export-window open path is now
+    // a background saga that reads it straight off the real store, so no
+    // replica needs it.
     windowManagement: {
       windowId: state.windowManagement.windowId,
       requests: state.windowManagement.requests
@@ -239,11 +242,17 @@ export type MainStore = Awaited<
 >;
 
 export function createMainStoreReplica<T extends PopupState>(state: T) {
-  // `selectPopupState` strips `pendingRequests` (dapp origins + tabIds stay in
-  // the background). Restore the shape the slice reducer expects with an empty
-  // map — truthful, since a replica genuinely holds no request descriptors.
+  // `selectPopupState` strips `pendingRequests` and `exportKeysWindowId` (the
+  // background keeps both; no UI reads either). Restore the shape the slice
+  // reducer expects — an empty map is truthful for a replica's request
+  // descriptors, and `null` is truthful since no replica tracks the export
+  // window.
   return createStore({
     ...state,
-    windowManagement: { ...state.windowManagement, pendingRequests: {} }
+    windowManagement: {
+      ...state.windowManagement,
+      pendingRequests: {},
+      exportKeysWindowId: null
+    }
   });
 }

--- a/src/background/redux/root-saga.ts
+++ b/src/background/redux/root-saga.ts
@@ -1,6 +1,7 @@
 import { all } from 'redux-saga/effects';
 
 import { watchCasper2NetworkSaga } from './sagas/check-casper2-network-saga';
+import { exportKeysWindowSaga } from './sagas/export-keys-window-saga';
 import { onboardingSagas } from './sagas/onboarding-sagas';
 import { trustedWasmSaga } from './sagas/trusted-wasm-saga';
 import { vaultSagas } from './sagas/vault-sagas';
@@ -10,6 +11,7 @@ export default function* rootSaga() {
     vaultSagas(),
     onboardingSagas(),
     watchCasper2NetworkSaga(),
-    trustedWasmSaga()
+    trustedWasmSaga(),
+    exportKeysWindowSaga()
   ]);
 }

--- a/src/background/redux/sagas/actions.ts
+++ b/src/background/redux/sagas/actions.ts
@@ -11,6 +11,9 @@ import { Account } from '@libs/types/account';
 export const startBackground = createAction('START_BACKGROUND_SAGA');
 export const resetVault = createAction('RESET_VAULT_SAGA');
 export const lockVault = createAction('LOCK_VAULT_SAGA');
+export const openExportKeysWindow = createAction(
+  'OPEN_EXPORT_KEYS_WINDOW_SAGA'
+);
 export const unlockVault = createAction<UnlockVault>('UNLOCK_VAULT_SAGA');
 export const initKeys = createAction<{ password: string }>('INIT_KEYS_SAGA');
 export const initVault = createAction<{ secretPhrase: SecretPhrase }>(

--- a/src/background/redux/sagas/export-keys-window-saga.test.ts
+++ b/src/background/redux/sagas/export-keys-window-saga.test.ts
@@ -1,0 +1,135 @@
+import * as matchers from 'redux-saga-test-plan/matchers';
+import { expectSaga } from 'redux-saga-test-plan';
+import { windows } from 'webextension-polyfill';
+
+import {
+  exportKeysWindowIdChanged,
+  exportKeysWindowIdCleared
+} from '@background/redux/windowManagement/actions';
+
+import { openExportKeysWindow } from './actions';
+import {
+  exportKeysWindowSaga,
+  openExportKeysWindowSaga
+} from './export-keys-window-saga';
+
+jest.mock('webextension-polyfill', () => ({
+  windows: {
+    getAll: jest.fn(),
+    getCurrent: jest.fn(),
+    update: jest.fn(),
+    create: jest.fn()
+  }
+}));
+
+describe('openExportKeysWindowSaga', () => {
+  const currentWindow = {
+    id: 1,
+    state: 'normal',
+    width: 1200,
+    left: 0,
+    top: 0
+  };
+
+  it('refocuses an existing export popup window and does not create', () => {
+    return (
+      expectSaga(openExportKeysWindowSaga)
+        .withState({ windowManagement: { exportKeysWindowId: 42 } })
+        .provide([
+          [matchers.call.fn(windows.getAll), [{ id: 42, type: 'popup' }]],
+          [matchers.call.fn(windows.update), undefined]
+        ])
+        .call.fn(windows.update)
+        // Guards the early `return` after the reuse hit: without it, execution
+        // falls through into windows.getCurrent()/windows.create() and the
+        // failure is swallowed by the catch block, so this test would still
+        // pass on the assertions above alone.
+        .not.call.fn(windows.getCurrent)
+        .not.call.fn(windows.create)
+        .not.put(exportKeysWindowIdChanged(expect.any(Number)))
+        .run()
+    );
+  });
+
+  it('clears a stale id and creates a new window', () => {
+    return expectSaga(openExportKeysWindowSaga)
+      .withState({ windowManagement: { exportKeysWindowId: 42 } })
+      .provide([
+        [matchers.call.fn(windows.getAll), []],
+        [matchers.call.fn(windows.getCurrent), currentWindow],
+        [matchers.call.fn(windows.create), { id: 99 }]
+      ])
+      .put(exportKeysWindowIdCleared())
+      .put(exportKeysWindowIdChanged(99))
+      .run();
+  });
+
+  it('creates and tracks a new window when none is tracked', () => {
+    return expectSaga(openExportKeysWindowSaga)
+      .withState({ windowManagement: { exportKeysWindowId: null } })
+      .provide([
+        [matchers.call.fn(windows.getCurrent), currentWindow],
+        [matchers.call.fn(windows.create), { id: 77 }]
+      ])
+      .put(exportKeysWindowIdChanged(77))
+      .run();
+  });
+
+  it('does not track when the created window has no id', () => {
+    return expectSaga(openExportKeysWindowSaga)
+      .withState({ windowManagement: { exportKeysWindowId: null } })
+      .provide([
+        [matchers.call.fn(windows.getCurrent), currentWindow],
+        [matchers.call.fn(windows.create), {}]
+      ])
+      .not.put(exportKeysWindowIdChanged(expect.any(Number)))
+      .run();
+  });
+
+  describe('exportKeysWindowSaga (watcher)', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('takeLeading runs the open worker only once for two overlapping dispatches', async () => {
+      // No .provide() here: the mocked windows.* fns must actually be invoked
+      // (not short-circuited by a provider) so call counts are meaningful, and
+      // windows.getCurrent stays pending so the second dispatch genuinely
+      // overlaps the first worker's in-flight run instead of arriving after
+      // it settles.
+      let resolveGetCurrent: (value: typeof currentWindow) => void = () => {};
+      (windows.getCurrent as jest.Mock).mockReturnValue(
+        new Promise(resolve => {
+          resolveGetCurrent = resolve;
+        })
+      );
+      (windows.create as jest.Mock).mockResolvedValue({ id: 77 });
+
+      const saga = expectSaga(exportKeysWindowSaga).withState({
+        windowManagement: { exportKeysWindowId: null }
+      });
+
+      saga.dispatch(openExportKeysWindow());
+      const runPromise = saga.run(200);
+
+      // Flush microtasks so the first dispatch is delivered and the worker
+      // parks on the pending windows.getCurrent() call before the second,
+      // overlapping dispatch fires.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      saga.dispatch(openExportKeysWindow());
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      resolveGetCurrent(currentWindow);
+
+      await runPromise;
+
+      expect(windows.getCurrent).toHaveBeenCalledTimes(1);
+      expect(windows.create).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/background/redux/sagas/export-keys-window-saga.ts
+++ b/src/background/redux/sagas/export-keys-window-saga.ts
@@ -1,0 +1,87 @@
+import { call, put, select, takeLeading } from 'redux-saga/effects';
+import { Windows, windows } from 'webextension-polyfill';
+
+import { RouterPath } from '@popup/router/paths';
+
+import {
+  exportKeysWindowIdChanged,
+  exportKeysWindowIdCleared
+} from '@background/redux/windowManagement/actions';
+import { selectExportKeysWindowId } from '@background/redux/windowManagement/selectors';
+
+import { openExportKeysWindow } from './actions';
+
+const EXPORT_KEYS_URL = `popup.html#${RouterPath.DownloadAccountKeys}`;
+const SURFACE_WIDTH = 376;
+const SURFACE_HEIGHT = 700;
+
+export function* openExportKeysWindowSaga() {
+  try {
+    const windowId: number | null = yield select(selectExportKeysWindowId);
+
+    if (windowId != null) {
+      const all: Windows.Window[] = yield call([windows, windows.getAll]);
+      // Best-effort guard, not a precise one: type:'popup' narrows the match
+      // but doesn't uniquely identify the export window — approval windows
+      // (connect/sign/import) are also type:'popup'. A precise tab-URL match
+      // isn't used because Firefox omits the extension URL hash from
+      // windows.getAll. If the OS reuses this id for another wallet popup,
+      // worst case is a misfocus (never key disclosure).
+      const existing = all.find(w => w.id === windowId && w.type === 'popup');
+      if (existing?.id != null) {
+        yield call([windows, windows.update], existing.id, {
+          focused: true,
+          drawAttention: true
+        });
+        return;
+      }
+      yield put(exportKeysWindowIdCleared());
+    }
+
+    const currentWindow: Windows.Window = yield call([
+      windows,
+      windows.getCurrent
+    ]);
+    // Positioning + TEST_ENV bypass mirror openNewWindow in create-open-window.ts.
+    const isTestEnv = Boolean(process.env.TEST_ENV);
+    const windowWidth = currentWindow.width ?? 0;
+    const xOffset = currentWindow.left ?? 0;
+    const yOffset = currentWindow.top ?? 0;
+
+    const created: Windows.Window = yield call(
+      [windows, windows.create],
+      currentWindow.state === 'fullscreen' || isTestEnv
+        ? { url: EXPORT_KEYS_URL, type: 'popup', focused: true }
+        : {
+            url: EXPORT_KEYS_URL,
+            type: 'popup',
+            focused: true,
+            width: SURFACE_WIDTH,
+            height: SURFACE_HEIGHT,
+            left: windowWidth + xOffset - SURFACE_WIDTH,
+            top: yOffset
+          }
+    );
+
+    if (created.id != null) {
+      yield put(exportKeysWindowIdChanged(created.id));
+    }
+  } catch (error) {
+    // No UI surface here (the menu banner was removed): a failed open is rare
+    // (windows.create almost never rejects) and there is no popup left to show
+    // it in. The download-failure screen covers the important in-window case.
+    console.error(
+      'openExportKeysWindowSaga: failed to open export window',
+      error
+    );
+  }
+}
+
+export function* exportKeysWindowSaga() {
+  // takeLatest would cancel the in-flight generator on a rapid re-dispatch,
+  // but windows.create() itself is already fired-and-forgotten by that point —
+  // cancellation can't undo it, so a second dispatch would leak an untracked
+  // duplicate window. takeLeading runs the first open to completion and drops
+  // overlapping triggers, which is the correct semantic for opening a window.
+  yield takeLeading(openExportKeysWindow.type, openExportKeysWindowSaga);
+}

--- a/src/background/redux/types.d.ts
+++ b/src/background/redux/types.d.ts
@@ -24,7 +24,10 @@ export type PopupState = {
   // `pendingRequests` is deliberately NOT broadcast: it holds each in-flight
   // request's dapp origin and tabId, and only background code needs it. See
   // the narrowing in `selectPopupState`.
-  windowManagement: Omit<WindowManagementState, 'pendingRequests'>;
+  windowManagement: Omit<
+    WindowManagementState,
+    'pendingRequests' | 'exportKeysWindowId'
+  >;
   loginRetryLockoutTime: LoginRetryLockoutTimeState;
   lastActivityTime: LastActivityTimeState;
   settings: SettingsState;

--- a/src/background/redux/windowManagement/actions.ts
+++ b/src/background/redux/windowManagement/actions.ts
@@ -1,5 +1,7 @@
 export {
   connectWindowInit,
+  exportKeysWindowIdChanged,
+  exportKeysWindowIdCleared,
   importWindowInit,
   onboardingAppInit,
   popupWindowInit,

--- a/src/background/redux/windowManagement/reducer.test.ts
+++ b/src/background/redux/windowManagement/reducer.test.ts
@@ -1,5 +1,7 @@
 import {
   connectWindowInit,
+  exportKeysWindowIdChanged,
+  exportKeysWindowIdCleared,
   importWindowInit,
   onboardingAppInit,
   popupWindowInit,
@@ -12,30 +14,52 @@ import {
 } from './actions';
 import { reducer } from './reducer';
 
-const empty = { windowId: null, requests: {}, pendingRequests: {} } as const;
+const empty = {
+  windowId: null,
+  exportKeysWindowId: null,
+  requests: {},
+  pendingRequests: {}
+} as const;
 
 describe('windowManagement reducer', () => {
   it('has null windowId and no requests initially', () => {
     expect(reducer(undefined, { type: '@@INIT' } as any)).toEqual({
       windowId: null,
+      exportKeysWindowId: null,
       requests: {},
       pendingRequests: {}
     });
   });
   it('sets and clears windowId', () => {
     const s = reducer(
-      { windowId: null, requests: {}, pendingRequests: {} },
+      {
+        windowId: null,
+        exportKeysWindowId: null,
+        requests: {},
+        pendingRequests: {}
+      },
       windowIdChanged(7)
     );
-    expect(s).toEqual({ windowId: 7, requests: {}, pendingRequests: {} });
+    expect(s).toEqual({
+      windowId: 7,
+      exportKeysWindowId: null,
+      requests: {},
+      pendingRequests: {}
+    });
     expect(reducer(s, windowIdCleared())).toEqual({
       windowId: null,
+      exportKeysWindowId: null,
       requests: {},
       pendingRequests: {}
     });
   });
   it('window-init actions do not change state', () => {
-    const state = { windowId: 7, requests: {}, pendingRequests: {} };
+    const state = {
+      windowId: 7,
+      exportKeysWindowId: null,
+      requests: {},
+      pendingRequests: {}
+    };
     expect(reducer(state, onboardingAppInit())).toEqual(state);
     expect(reducer(state, popupWindowInit())).toEqual(state);
     expect(reducer(state, connectWindowInit())).toEqual(state);
@@ -45,7 +69,12 @@ describe('windowManagement reducer', () => {
 
   it('opens a request', () => {
     const s = reducer(
-      { windowId: null, requests: {}, pendingRequests: {} },
+      {
+        windowId: null,
+        exportKeysWindowId: null,
+        requests: {},
+        pendingRequests: {}
+      },
       windowRequestOpened({
         requestId: 'r1',
         tabId: 9,
@@ -58,7 +87,12 @@ describe('windowManagement reducer', () => {
 
   it('marks a request as responded, and is idempotent on a second respond', () => {
     let s = reducer(
-      { windowId: null, requests: {}, pendingRequests: {} },
+      {
+        windowId: null,
+        exportKeysWindowId: null,
+        requests: {},
+        pendingRequests: {}
+      },
       windowRequestOpened({
         requestId: 'r1',
         tabId: 9,
@@ -75,7 +109,12 @@ describe('windowManagement reducer', () => {
 
   it('closes open requests and clears windowId on windowClosed', () => {
     let s = reducer(
-      { windowId: 7, requests: {}, pendingRequests: {} },
+      {
+        windowId: 7,
+        exportKeysWindowId: null,
+        requests: {},
+        pendingRequests: {}
+      },
       windowRequestOpened({
         requestId: 'r2',
         tabId: 9,
@@ -90,7 +129,12 @@ describe('windowManagement reducer', () => {
 
   it('leaves a responded request as responded on windowClosed', () => {
     let s = reducer(
-      { windowId: 7, requests: {}, pendingRequests: {} },
+      {
+        windowId: 7,
+        exportKeysWindowId: null,
+        requests: {},
+        pendingRequests: {}
+      },
       windowRequestOpened({
         requestId: 'r3',
         tabId: 9,
@@ -144,5 +188,14 @@ describe('windowManagement reducer', () => {
   it('windowIdCleared nulls only windowId', () => {
     const next = reducer({ ...empty, windowId: 5 }, windowIdCleared());
     expect(next.windowId).toBeNull();
+  });
+
+  it('sets and clears exportKeysWindowId, independently of windowId', () => {
+    const set = reducer(empty, exportKeysWindowIdChanged(12));
+    expect(set.exportKeysWindowId).toBe(12);
+    expect(set.windowId).toBeNull();
+
+    const cleared = reducer(set, exportKeysWindowIdCleared());
+    expect(cleared.exportKeysWindowId).toBeNull();
   });
 });

--- a/src/background/redux/windowManagement/reducer.ts
+++ b/src/background/redux/windowManagement/reducer.ts
@@ -8,6 +8,7 @@ import {
 
 const initialState: WindowManagementState = {
   windowId: null,
+  exportKeysWindowId: null,
   requests: {},
   pendingRequests: {}
 };
@@ -21,6 +22,14 @@ const slice = createSlice({
       windowId: action.payload
     }),
     windowIdCleared: state => ({ ...state, windowId: null }),
+    exportKeysWindowIdChanged: (state, action: PayloadAction<number>) => ({
+      ...state,
+      exportKeysWindowId: action.payload
+    }),
+    exportKeysWindowIdCleared: state => ({
+      ...state,
+      exportKeysWindowId: null
+    }),
     onboardingAppInit: state => state,
     popupWindowInit: state => state,
     connectWindowInit: state => state,
@@ -74,6 +83,8 @@ const slice = createSlice({
 
 export const {
   connectWindowInit,
+  exportKeysWindowIdChanged,
+  exportKeysWindowIdCleared,
   importWindowInit,
   onboardingAppInit,
   popupWindowInit,

--- a/src/background/redux/windowManagement/selectors.ts
+++ b/src/background/redux/windowManagement/selectors.ts
@@ -7,6 +7,9 @@ import { RequestStatus } from './types';
 export const selectWindowId = (state: RootState): number | null =>
   state.windowManagement.windowId;
 
+export const selectExportKeysWindowId = (state: RootState): number | null =>
+  state.windowManagement.exportKeysWindowId;
+
 export const selectRequestStatus = (
   state: RootState,
   requestId: string

--- a/src/background/redux/windowManagement/types.ts
+++ b/src/background/redux/windowManagement/types.ts
@@ -16,6 +16,7 @@ interface PendingRequestDescriptor {
 
 export interface WindowManagementState {
   windowId: number | null;
+  exportKeysWindowId: number | null;
   requests: Record<string, RequestStatus>;
   pendingRequests: Record<string, PendingRequestDescriptor>;
 }

--- a/src/fixtures/initial-state-for-popup-tests.ts
+++ b/src/fixtures/initial-state-for-popup-tests.ts
@@ -75,6 +75,7 @@ export const initialStateForPopupTests: RootState = {
   },
   windowManagement: {
     windowId: null,
+    exportKeysWindowId: null,
     requests: {},
     pendingRequests: {}
   },

--- a/src/libs/layout/unlock-protected-page-content/index.tsx
+++ b/src/libs/layout/unlock-protected-page-content/index.tsx
@@ -30,16 +30,17 @@ interface PasswordPageContentType {
   register: UseFormRegister<PasswordFormValues>;
   errors: FieldErrors<PasswordFormValues>;
   title?: string;
-  // Mirrors the submit button's disabled state. Without it the field stays
-  // editable while the password is being verified, so a user who hits Enter can
-  // keep typing into a form that is already on its way out.
-  disabled?: boolean;
+  // Locks the field while the password is being verified. Read-only rather than
+  // disabled on purpose: disabling a focused input drops its focus, so after a
+  // wrong password the user would have to click back in. Read-only keeps focus
+  // while still blocking further typing.
+  readOnly?: boolean;
 }
 export const UnlockProtectedPageContent = ({
   register,
   errors,
   title,
-  disabled
+  readOnly
 }: PasswordPageContentType) => {
   const [passwordInputType, setPasswordInputType] =
     useState<PasswordInputType>('password');
@@ -84,7 +85,7 @@ export const UnlockProtectedPageContent = ({
           error={!!errors.password}
           validationText={errors.password?.message}
           autoFocus
-          disabled={disabled}
+          readOnly={readOnly}
           suffixIcon={
             <PasswordVisibilityIcon
               passwordInputType={passwordInputType}

--- a/src/libs/layout/unlock-protected-page-content/index.tsx
+++ b/src/libs/layout/unlock-protected-page-content/index.tsx
@@ -30,11 +30,16 @@ interface PasswordPageContentType {
   register: UseFormRegister<PasswordFormValues>;
   errors: FieldErrors<PasswordFormValues>;
   title?: string;
+  // Mirrors the submit button's disabled state. Without it the field stays
+  // editable while the password is being verified, so a user who hits Enter can
+  // keep typing into a form that is already on its way out.
+  disabled?: boolean;
 }
 export const UnlockProtectedPageContent = ({
   register,
   errors,
-  title
+  title,
+  disabled
 }: PasswordPageContentType) => {
   const [passwordInputType, setPasswordInputType] =
     useState<PasswordInputType>('password');
@@ -79,6 +84,7 @@ export const UnlockProtectedPageContent = ({
           error={!!errors.password}
           validationText={errors.password?.message}
           autoFocus
+          disabled={disabled}
           suffixIcon={
             <PasswordVisibilityIcon
               passwordInputType={passwordInputType}


### PR DESCRIPTION
> Re-opened on top of `release/2.7.0` after the release branch was renamed from 2.6.0 to 2.7.0 (identical commit). Supersedes #1408, which GitHub would not let me reopen against the new base.

Fixes the long-standing Safari bug where "Download account keys" showed a success screen but never wrote the file.

- Jira: [WALLET-1345](https://make-software.atlassian.net/browse/WALLET-1345)
- GitHub issue: #609 (open since 2023-04)

## Root cause

The export screen ran in the **ephemeral extension popup**. Triggering a download steals focus, Safari closes the popup, its document is torn down, and the browser revokes every `blob:` URL that document owned — aborting the in-flight read. The file never landed.

This was established by probing on a real Safari build, not inferred. In a persistent tab, four variants all downloaded correctly with correct filenames: a detached anchor with an immediate `revokeObjectURL` (a literal reproduction of the shipped code), an attached anchor with immediate revoke, an attached anchor with deferred revoke, and a `data:` URL. The same probe inside the popup produced no file and the popup closed. An earlier single-statement popup probe *did* produce a file, but named `Unknown` — a partially-won race.

So the anchor+blob mechanism, the detached anchor, the revoke timing, the `download` attribute and the MIME type are all exonerated. **`downloadFile` in `utils.ts` is deliberately unchanged** — changing it would have been a fix with no evidence behind it. Only the context was at fault.

The 2023 mitigation merely hid the menu entry on Safari (`hide: isSafariBuild`) while leaving the route registered, so the feature was never disabled — only made unreachable. That gate is now removed.

## What changed

**The flow opens in a dedicated window** (`windows.create({ type: 'popup' })`), verified on Safari to survive the download. Applied to **all three browsers** rather than gating Safari, to avoid a second behavioural branch — this is the main regression surface for review, since Chrome and Firefox worked before and their flow now moves off the popup.

**The final screen no longer claims a completed write.** Nothing can verify one: `downloadFile` is a fire-and-forget anchor click, and `browser.downloads` — the only API that reports success — [does not exist in Safari Web Extensions](https://developer.apple.com/forums/thread/660046). Rather than fake a signal, the screen states what to look for and offers a working **Download again**. That retry is only possible because the surface now outlives the click; in the popup the context was already gone by the time a user noticed the file was missing.

**Navigation corrected for a window.** `Back` is kept only where it genuinely steps back inside the flow. The two screens with nowhere to go back to now close the window instead of running a dead `navigate(-1)`, which in a single-history-entry window was a no-op that trapped the user. The header drops the wallet menu, network switcher and connection status — they otherwise let a user navigate the entire wallet inside a 376px export window.

**Failures are now visible to the user.** Previously every failure path in this flow was silent. See below — this turned out to be the larger half of the change.

### Failure handling

The project has **no Sentry or equivalent** — no error-tracking dependency of any kind. A `console.error` is therefore visible only to someone who opens devtools on the extension, which in practice means nobody. Production failures in this flow were invisible to users and to us simultaneously, so a failed key export was indistinguishable from a dead button. Every failure path now has a visible outcome.

**A failed export lands on a dedicated `Failure` step, not a banner.** This is deliberate: a banner on the Success screen would put "your keys were saved" next to a failure, which is the exact defect this ticket exists to remove. The step states that no file was written and that *nothing left the wallet and the accounts are unchanged* — the fear a secret-key export error actually raises — and offers **Try again**, which returns to account selection rather than retrying blind, so the user can confirm or change the selection first. `Download again` on the Success screen routes into the same step if it fails.

**`openExportKeysSurface` no longer swallows its rejection.** If the window cannot be created there is no export surface on which anything could be reported, so the menu reports it instead, and dismisses itself only once the window actually exists — otherwise the message would have nowhere to render.

**`closeExportKeysSurface` still only logs.** Deliberate: if closing fails, the window visibly stays on screen, so the failure is self-evident and the user's remaining action — closing it from the title bar — is the same one a message would suggest.

**Only the error name is logged, never the thrown value.** On this path the thrown value is built from key material, and it must not reach the console.

**The `Error` component is imported aliased** (`Error as ErrorMessage`). Imported unaliased it shadows the global `Error` constructor, which silently breaks any `new Error(...)` later in the same file — this bit during development.

### The shared password screen — note for reviewers

`PasswordProtectionPage` gates five flows: this one plus contact-details, backup-secret-phrase, wallet-qr-code and change-password. It is touched in two ways, and only one of them is scoped to key export.

**Scoped to this flow.** A new optional `onCloseWindow` prop swaps the header for a bare one whose only action closes the window. The four other callers do not pass it and therefore take the unchanged branch, byte-for-byte identical to before. This exists because a dedicated window has a single history entry, so the default `back` link was a dead `navigate(-1)` that trapped the user on the first screen of the export window.

**Affects all five flows.** The password field is now disabled while the password is being verified, matching the submit button, which was already disabled on the same condition. Previously, pressing Enter left the field editable and a user could keep typing into a form already on its way out. This is a pre-existing bug found while testing the export window; the fix is deliberately applied to the shared component rather than worked around locally, so it changes behaviour in the other four flows too. Worth a look during review even though it is outside the ticket's scope.

Neither change touches `onSubmit`, the verify-password worker call, or `setPasswordConfirmed` — the password gate itself is untouched.

## Testing

`npm run ci-check` passes (51 suites, 341 tests). e2e passes. Manually verified.

No unit tests were added: UI is outside `collectCoverageFrom` in `jest.config.js` and the repo has no component-testing layer. An e2e test would not have covered Safari — the only platform with the bug — nor could it assert that a file was written.

## Known and deliberately not addressed

**One-time window widening on Safari.** The first export shows Safari's native download-permission dialog, which is wider than the window, so Safari widens the window to fit it. Subsequent exports have no dialog and no resize, and the next window is created at the normal width. This is platform UI we do not control; forcing the size back would race the still-open dialog.

**Stale i18n catalogs.** `lang/` has not been regenerated since 2022 — roughly 400 source strings already fall back to English in every locale. The three new strings are no worse off. Regenerating rebuilds the entire catalog (~1750 changes) and belongs in its own ticket.

**`revokeObjectURL` race in `utils.ts`.** The synchronous revoke immediately after `click()` is latent fragility, explicitly refuted as the cause here. Worth a separate cleanup ticket.


[WALLET-1345]: https://make-software.atlassian.net/browse/WALLET-1345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
