### PR TITLE
chore: bump brace-expansion to 1.1.16 to clear the runtime audit gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7025,9 +7025,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,8 @@
     },
     "qs": "^6.15.2",
     "serialize-javascript": "^7.0.5",
-    "tmp": "^0.2.7"
+    "tmp": "^0.2.7",
+    "brace-expansion@1": "1.1.16"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",


### PR DESCRIPTION
The blocking CI step `npm run audit:ci` (`npm audit --omit=dev --audit-level=high`) currently fails on every open PR against `release/2.7.0`, including feature PRs that touch no dependencies. This clears it.

## The advisory

`brace-expansion <1.1.16` — [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp), high severity, DoS via exponential-time expansion of consecutive non-expanding `{}` groups. It became a blocking failure when the advisory database picked it up; the code and lockfile did not change, which is why previously-green PRs started failing on re-run.

It reaches the **runtime** tree transitively:

```
casper-js-sdk@5.0.12 > glob@7.2.3 > minimatch@3.1.5 > brace-expansion@1.1.15
```

The tree also has brace-expansion at 2.1.1 / 2.1.2 / 5.0.7, but those are all **dev-only** (jest, prettier-plugin, typescript-eslint, markdownlint) and already above the fixed version, so the `--omit=dev` gate does not flag them.

## The fix

A **version-scoped** override pins only the 1.x line to the patched 1.1.16:

```json
"brace-expansion@1": "1.1.16"
```

- `@1` matches brace-expansion instances resolving within `>=1.0.0 <2.0.0` and forces 1.1.16; the dev-side 2.x / 5.x instances do not match and are left untouched. A flat `"brace-expansion": "1.1.16"` would have dragged those down to 1.1.16 and risked the dev toolchain (glob/minimatch v9 expect the 2.x line).
- 1.1.16 is the official patch for this advisory — an API-identical patch of 1.x. `minimatch@3.1.5` requests `^1.1.7`, which 1.1.16 satisfies.
- `npm audit fix` was rejected first: it rewrote ~270 lines across unrelated packages (`@babel/runtime`, `css-tree`, `mdn-data`, `source-map`, `yauzl`, `eslint-plugin-no-unsanitized`). This takes the surgical path instead.

## Diff

`package-lock.json` moves the single `node_modules/brace-expansion` node 1.1.15 → 1.1.16 (version + resolved + integrity) and nothing else. `package.json` gains one line in the existing `overrides` block.

## Verification

- `npm run audit:ci` → `found 0 vulnerabilities` (exit 0).
- `npm ci` succeeds — lockfile is consistent with the override.
- `npm run tsc` clean.
- The 7 remaining advisories are all dev-only and outside this blocking gate; not addressed here.

## Scope

No Jira ticket — this is CI hygiene on the release branch so that in-flight PRs (e.g. #1413) can go green. Separate from any feature work.
