### PR TITLE
chore: override fast-uri to 3.1.4 to clear the runtime audit gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10206,9 +10206,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,8 @@
     "qs": "^6.15.2",
     "serialize-javascript": "^7.0.5",
     "tmp": "^0.2.7",
-    "brace-expansion@1": "1.1.16"
+    "brace-expansion@1": "1.1.16",
+    "fast-uri": "^3.1.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",


### PR DESCRIPTION
## What

Pin `fast-uri` to `3.1.4` via a `package.json` override.

## Why

`fast-uri` `<=3.1.3` is affected by [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) — host confusion via a literal backslash authority delimiter (high severity). It reaches the **runtime** dependency tree transitively:

```
copy-webpack-plugin -> schema-utils -> ajv -> fast-uri
```

That single vulnerability surfaced as 8 high-severity findings (fast-uri plus its dependents ajv-formats, ajv-keywords, schema-utils, webpack, minimizer-webpack-plugin, dotenv-webpack) and was **failing the blocking `npm run audit:ci` gate** (`npm audit --omit=dev --audit-level=high`).

## How

`3.1.4` is the patch release that fixes the advisory. It satisfies ajv@8's `^3.0.1` range, so only `fast-uri` moves — the lockfile change is a single version bump, nothing else in the tree shifts.

## Result

- Blocking runtime audit (`audit:ci`): **8 high → 0**, gate passes.
- Full-tree audit: **44 high → 9**. The remaining 9 are dev-only tooling (`web-ext`/`adm-zip`, `jest`, `markdownlint-cli`/`js-yaml`) with no forward fix, and stay on the existing non-blocking `npm audit || true` gate.