### PR TITLE
fix: WALLET-1353 — cancel the abandoned approval request when the approval window is reused

### DIFF
--- a/src/background/handlers/cancel-open-requests-on-close.test.ts
+++ b/src/background/handlers/cancel-open-requests-on-close.test.ts
@@ -6,7 +6,6 @@ import { sdkMethod } from '@content/sdk-method';
 
 import {
   CANCEL_GRACE_MS,
-  buildCancelResponse,
   cancelOpenRequestsForClosedWindow
 } from './cancel-open-requests-on-close';
 
@@ -32,43 +31,6 @@ beforeEach(() => {
   jest.useFakeTimers();
 });
 afterEach(() => jest.useRealTimers());
-
-describe('buildCancelResponse', () => {
-  const c = (m: any) => buildCancelResponse(m, 'r');
-  it('connect', () =>
-    expect(c('connect')).toEqual(
-      sdkMethod.connectResponse(false, { requestId: 'r' })
-    ));
-  it('switchAccount', () =>
-    expect(c('switchAccount')).toEqual(
-      sdkMethod.switchAccountResponse(false, { requestId: 'r' })
-    ));
-  it('sign', () =>
-    expect(c('sign')).toEqual(
-      sdkMethod.signResponse({ cancelled: true }, { requestId: 'r' })
-    ));
-  it('signMessage', () =>
-    expect(c('signMessage')).toEqual(
-      sdkMethod.signMessageResponse({ cancelled: true }, { requestId: 'r' })
-    ));
-  it('signTypedData', () =>
-    expect(c('signTypedData')).toEqual(
-      sdkMethod.signTypedDataResponse(
-        {
-          cancelled: true,
-          signature: null,
-          digest: null,
-          publicKey: null,
-          error: null
-        },
-        { requestId: 'r' }
-      )
-    ));
-  it('decryptMessage', () =>
-    expect(c('decryptMessage')).toEqual(
-      sdkMethod.decryptMessageResponse({ cancelled: true }, { requestId: 'r' })
-    ));
-});
 
 describe('cancelOpenRequestsForClosedWindow', () => {
   const run = async (getState: jest.Mock) => {

--- a/src/background/handlers/cancel-open-requests-on-close.ts
+++ b/src/background/handlers/cancel-open-requests-on-close.ts
@@ -1,57 +1,14 @@
-import { tabs } from 'webextension-polyfill';
-
-import { sagaError } from '@background/redux/app-events/actions';
 import { MainStore } from '@background/redux/get-main-store';
-import {
-  windowIdCleared,
-  windowRequestResponded
-} from '@background/redux/windowManagement/actions';
+import { windowIdCleared } from '@background/redux/windowManagement/actions';
 import {
   selectOpenRequests,
   selectWindowId
 } from '@background/redux/windowManagement/selectors';
-import { CancellableMethod } from '@background/redux/windowManagement/types';
 
-import { SdkMethod, sdkMethod } from '@content/sdk-method';
+import { cancelRequests } from './cancel-requests';
 
-import { deliverViaOrigin } from './deliver-via-origin';
-
-// Grace before assuming a closed window means "cancelled": lets an in-flight genuine
-// response (a button response, or a Ledger success cleanup that closes this window) land
-// and mark itself 'responded' first. ~250 ms >> one in-process runtime.sendMessage hop.
-export const CANCEL_GRACE_MS = 250;
-const delay = (ms: number) =>
-  new Promise<void>(resolve => setTimeout(resolve, ms));
-
-export function buildCancelResponse(
-  method: CancellableMethod,
-  requestId: string
-): SdkMethod {
-  const meta = { requestId };
-  switch (method) {
-    case 'connect':
-      return sdkMethod.connectResponse(false, meta);
-    case 'switchAccount':
-      return sdkMethod.switchAccountResponse(false, meta);
-    case 'sign':
-      return sdkMethod.signResponse({ cancelled: true }, meta);
-    case 'signMessage':
-      return sdkMethod.signMessageResponse({ cancelled: true }, meta);
-    case 'signTypedData':
-      return sdkMethod.signTypedDataResponse(
-        {
-          cancelled: true,
-          signature: null,
-          digest: null,
-          publicKey: null,
-          error: null
-        },
-        meta
-      );
-    case 'decryptMessage':
-      return sdkMethod.decryptMessageResponse({ cancelled: true }, meta);
-  }
-}
+// Re-exported for cancel-open-requests-on-close.test.ts, which asserts this.
+export { CANCEL_GRACE_MS } from './cancel-requests';
 
 export async function cancelOpenRequestsForClosedWindow(
   store: MainStore,
@@ -59,53 +16,20 @@ export async function cancelOpenRequestsForClosedWindow(
 ): Promise<void> {
   const initiallyOpen = selectOpenRequests(store.getState());
 
-  // Null windowId only if the removed window is still the tracked one (no new window took
-  // over during the grace). windowIdCleared touches ONLY windowId — never the requests map —
-  // so it cannot clobber a concurrently-registered request.
+  // Null windowId only if the removed window is still the tracked one (no new
+  // window took over during the grace). windowIdCleared touches ONLY windowId,
+  // never the requests map, so it cannot clobber a concurrently-registered
+  // request.
   const clearIfStillTracked = () => {
     if (selectWindowId(store.getState()) === removedWindowId) {
       store.dispatch(windowIdCleared());
     }
   };
 
-  if (initiallyOpen.length === 0) {
-    clearIfStillTracked();
-    return;
-  }
-
-  await delay(CANCEL_GRACE_MS);
-
-  const stillOpenIds = new Set(
-    selectOpenRequests(store.getState()).map(r => r.requestId)
-  );
-  // Requests open at close AND still open now — excludes answered-during-grace and any new
-  // request opened during the grace.
-  const toCancel = initiallyOpen.filter(r => stillOpenIds.has(r.requestId));
-
-  // Mark synchronously from this snapshot, before the async sends.
-  for (const { requestId } of toCancel) {
-    store.dispatch(windowRequestResponded({ requestId }));
-  }
-  clearIfStillTracked();
-
-  await Promise.all(
-    toCancel.map(async ({ requestId, tabId, origin, method }) => {
-      const action = buildCancelResponse(method, requestId);
-      try {
-        await tabs.sendMessage(tabId, action);
-      } catch {
-        const delivered = await deliverViaOrigin(origin, action);
-        store.dispatch(
-          sagaError({
-            source: 'cancel-on-close',
-            message:
-              `Cancel-on-close delivery to tab ${tabId} failed` +
-              (delivered > 0
-                ? '; delivered via same-origin fallback'
-                : '; not delivered')
-          })
-        );
-      }
-    })
+  await cancelRequests(
+    store,
+    initiallyOpen,
+    'cancel-on-close',
+    clearIfStillTracked
   );
 }

--- a/src/background/handlers/cancel-requests.test.ts
+++ b/src/background/handlers/cancel-requests.test.ts
@@ -1,0 +1,44 @@
+import { sdkMethod } from '@content/sdk-method';
+
+import { buildCancelResponse } from './cancel-requests';
+
+jest.mock('webextension-polyfill', () => ({
+  tabs: { sendMessage: jest.fn() }
+}));
+
+describe('buildCancelResponse', () => {
+  const c = (m: any) => buildCancelResponse(m, 'r');
+  it('connect', () =>
+    expect(c('connect')).toEqual(
+      sdkMethod.connectResponse(false, { requestId: 'r' })
+    ));
+  it('switchAccount', () =>
+    expect(c('switchAccount')).toEqual(
+      sdkMethod.switchAccountResponse(false, { requestId: 'r' })
+    ));
+  it('sign', () =>
+    expect(c('sign')).toEqual(
+      sdkMethod.signResponse({ cancelled: true }, { requestId: 'r' })
+    ));
+  it('signMessage', () =>
+    expect(c('signMessage')).toEqual(
+      sdkMethod.signMessageResponse({ cancelled: true }, { requestId: 'r' })
+    ));
+  it('signTypedData', () =>
+    expect(c('signTypedData')).toEqual(
+      sdkMethod.signTypedDataResponse(
+        {
+          cancelled: true,
+          signature: null,
+          digest: null,
+          publicKey: null,
+          error: null
+        },
+        { requestId: 'r' }
+      )
+    ));
+  it('decryptMessage', () =>
+    expect(c('decryptMessage')).toEqual(
+      sdkMethod.decryptMessageResponse({ cancelled: true }, { requestId: 'r' })
+    ));
+});

--- a/src/background/handlers/cancel-requests.ts
+++ b/src/background/handlers/cancel-requests.ts
@@ -1,0 +1,107 @@
+import { tabs } from 'webextension-polyfill';
+
+import { sagaError } from '@background/redux/app-events/actions';
+import { MainStore } from '@background/redux/get-main-store';
+import { windowRequestResponded } from '@background/redux/windowManagement/actions';
+import { selectOpenRequests } from '@background/redux/windowManagement/selectors';
+import { CancellableMethod } from '@background/redux/windowManagement/types';
+
+import { SdkMethod, sdkMethod } from '@content/sdk-method';
+
+import { deliverViaOrigin } from './deliver-via-origin';
+
+// Grace before cancelling an abandoned request: lets an in-flight genuine
+// response (a button response, or a Ledger success cleanup that closes this
+// window) land and mark itself 'responded' first. ~250 ms >> one in-process
+// runtime.sendMessage hop.
+export const CANCEL_GRACE_MS = 250;
+const delay = (ms: number) =>
+  new Promise<void>(resolve => setTimeout(resolve, ms));
+
+export type OpenRequest = ReturnType<typeof selectOpenRequests>[number];
+
+export function buildCancelResponse(
+  method: CancellableMethod,
+  requestId: string
+): SdkMethod {
+  const meta = { requestId };
+  switch (method) {
+    case 'connect':
+      return sdkMethod.connectResponse(false, meta);
+    case 'switchAccount':
+      return sdkMethod.switchAccountResponse(false, meta);
+    case 'sign':
+      return sdkMethod.signResponse({ cancelled: true }, meta);
+    case 'signMessage':
+      return sdkMethod.signMessageResponse({ cancelled: true }, meta);
+    case 'signTypedData':
+      return sdkMethod.signTypedDataResponse(
+        {
+          cancelled: true,
+          signature: null,
+          digest: null,
+          publicKey: null,
+          error: null
+        },
+        meta
+      );
+    case 'decryptMessage':
+      return sdkMethod.decryptMessageResponse({ cancelled: true }, meta);
+  }
+}
+
+// Cancels a snapshot of open requests after a short grace, delivering the
+// method-correct Cancel response to each dapp tab. Shared by the window-close
+// path and the reuse/supersede path.
+//
+// `afterMark` runs once, synchronously, right after the survivors are marked
+// 'responded' and before the async sends — the close path uses it to null the
+// tracked windowId; the supersede path passes nothing (a new window is being
+// tracked, so windowId must NOT be cleared).
+export async function cancelRequests(
+  store: MainStore,
+  initiallyOpen: OpenRequest[],
+  source: string,
+  afterMark?: () => void
+): Promise<void> {
+  if (initiallyOpen.length === 0) {
+    afterMark?.();
+    return;
+  }
+
+  await delay(CANCEL_GRACE_MS);
+
+  const stillOpenIds = new Set(
+    selectOpenRequests(store.getState()).map(r => r.requestId)
+  );
+  // Open at snapshot AND still open now — excludes answered-during-grace and
+  // any new request opened during the grace.
+  const toCancel = initiallyOpen.filter(r => stillOpenIds.has(r.requestId));
+
+  // Mark synchronously from this snapshot, before the async sends.
+  for (const { requestId } of toCancel) {
+    store.dispatch(windowRequestResponded({ requestId }));
+  }
+  afterMark?.();
+
+  await Promise.all(
+    toCancel.map(async ({ requestId, tabId, origin, method }) => {
+      const action = buildCancelResponse(method, requestId);
+      try {
+        await tabs.sendMessage(tabId, action);
+      } catch {
+        const delivered = await deliverViaOrigin(origin, action);
+        store.dispatch(
+          sagaError({
+            source,
+            message:
+              `Cancel delivery to tab ${tabId} failed` +
+              (delivered > 0
+                ? '; delivered via same-origin fallback'
+                : '; not delivered')
+          })
+        );
+      }
+    })
+  );
+}

--- a/src/background/handlers/cancel-superseded-requests.test.ts
+++ b/src/background/handlers/cancel-superseded-requests.test.ts
@@ -1,0 +1,108 @@
+import { tabs } from 'webextension-polyfill';
+
+import { sdkMethod } from '@content/sdk-method';
+
+import { CANCEL_GRACE_MS } from './cancel-requests';
+import { cancelSupersededRequests } from './cancel-superseded-requests';
+import { deliverViaOrigin } from './deliver-via-origin';
+
+jest.mock('webextension-polyfill', () => ({
+  tabs: { sendMessage: jest.fn() }
+}));
+jest.mock('./deliver-via-origin', () => ({ deliverViaOrigin: jest.fn() }));
+
+const state = (requests: any, pendingRequests: any) => ({
+  windowManagement: { windowId: 1, requests, pendingRequests }
+});
+
+const run = (getState: jest.Mock) => {
+  const dispatch = jest.fn();
+  cancelSupersededRequests({ dispatch, getState } as any);
+  return dispatch;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+});
+afterEach(() => jest.useRealTimers());
+
+it('cancels the abandoned request, sends the method-correct Cancel', async () => {
+  (tabs.sendMessage as jest.Mock).mockResolvedValue(undefined);
+  const s = state(
+    { r1: 'open' },
+    { r1: { tabId: 3, origin: 'https://d', method: 'sign' } }
+  );
+  const dispatch = run(jest.fn().mockReturnValue(s));
+  await jest.advanceTimersByTimeAsync(CANCEL_GRACE_MS);
+
+  expect(tabs.sendMessage).toHaveBeenCalledWith(
+    3,
+    sdkMethod.signResponse({ cancelled: true }, { requestId: 'r1' })
+  );
+  expect(dispatch).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: expect.stringContaining('windowRequestResponded')
+    })
+  );
+});
+
+it('never clears windowId (a new window is being tracked)', async () => {
+  (tabs.sendMessage as jest.Mock).mockResolvedValue(undefined);
+  const s = state(
+    { r1: 'open' },
+    { r1: { tabId: 3, origin: 'https://d', method: 'sign' } }
+  );
+  const dispatch = run(jest.fn().mockReturnValue(s));
+  await jest.advanceTimersByTimeAsync(CANCEL_GRACE_MS);
+
+  expect(dispatch).not.toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: expect.stringContaining('windowIdCleared')
+    })
+  );
+});
+
+it('does NOT cancel a request answered during the grace', async () => {
+  (tabs.sendMessage as jest.Mock).mockResolvedValue(undefined);
+  const getState = jest
+    .fn()
+    .mockReturnValueOnce(
+      state(
+        { r1: 'open' },
+        { r1: { tabId: 3, origin: 'https://d', method: 'sign' } }
+      )
+    )
+    // re-snapshot after grace: r1 already answered
+    .mockReturnValue(state({ r1: 'responded' }, {}));
+  run(getState);
+  await jest.advanceTimersByTimeAsync(CANCEL_GRACE_MS);
+
+  expect(tabs.sendMessage).not.toHaveBeenCalled();
+});
+
+it('falls back to origin delivery and surfaces a cancel-on-supersede error', async () => {
+  (tabs.sendMessage as jest.Mock).mockRejectedValue(new Error('no tab'));
+  (deliverViaOrigin as jest.Mock).mockResolvedValue(1);
+  const s = state(
+    { r1: 'open' },
+    { r1: { tabId: 3, origin: 'https://d', method: 'sign' } }
+  );
+  const dispatch = run(jest.fn().mockReturnValue(s));
+  await jest.advanceTimersByTimeAsync(CANCEL_GRACE_MS);
+  await Promise.resolve();
+
+  expect(deliverViaOrigin).toHaveBeenCalledWith('https://d', expect.anything());
+  expect(dispatch).toHaveBeenCalledWith(
+    expect.objectContaining({
+      payload: expect.objectContaining({ source: 'cancel-on-supersede' })
+    })
+  );
+});
+
+it('is a no-op when there are no open requests', async () => {
+  const dispatch = run(jest.fn().mockReturnValue(state({}, {})));
+  await jest.advanceTimersByTimeAsync(CANCEL_GRACE_MS);
+  expect(tabs.sendMessage).not.toHaveBeenCalled();
+  expect(dispatch).not.toHaveBeenCalled();
+});

--- a/src/background/handlers/cancel-superseded-requests.ts
+++ b/src/background/handlers/cancel-superseded-requests.ts
@@ -1,0 +1,14 @@
+import { MainStore } from '@background/redux/get-main-store';
+import { selectOpenRequests } from '@background/redux/windowManagement/selectors';
+
+import { cancelRequests } from './cancel-requests';
+
+// Cancel every currently-open approval request because a new one is about to
+// take over the single reused approval-window slot. Fire-and-forget: the caller
+// (sdk-methods) dispatches windowRequestOpened for the INCOMING request only
+// AFTER this returns, so the synchronous snapshot below cannot include it —
+// which is why no `exceptRequestId` is needed.
+export function cancelSupersededRequests(store: MainStore): void {
+  const initiallyOpen = selectOpenRequests(store.getState());
+  void cancelRequests(store, initiallyOpen, 'cancel-on-supersede');
+}

--- a/src/background/handlers/redux-actions.parity.test.ts
+++ b/src/background/handlers/redux-actions.parity.test.ts
@@ -110,9 +110,6 @@ const EXCLUSIONS: ReadonlySet<string> = new Set(
     // Background-only: dispatched by the sdk-methods handler for an EIP-712
     // signature request. Never dispatched from the UI.
     vaultActions.eip712PayloadReceived,
-    // Background-only: retained for the reducer/parity guard but no longer
-    // dispatched (the close path now uses windowIdCleared). Never from the UI.
-    windowManagementActions.windowClosed,
     // Background-only: dispatched by sdk-methods when opening an approval
     // window (tracks the in-flight request). Never dispatched from the UI.
     windowManagementActions.windowRequestOpened,

--- a/src/background/handlers/sdk-methods.test.ts
+++ b/src/background/handlers/sdk-methods.test.ts
@@ -22,6 +22,7 @@ import { sdkMethod } from '@content/sdk-method';
 
 import { encryptAsHexWithCasperPublicKey } from '@libs/crypto';
 
+import { cancelSupersededRequests } from './cancel-superseded-requests';
 import { handleSdkMethod } from './sdk-methods';
 
 // Heavy / side-effecting dependencies are stubbed so we test PURE routing:
@@ -34,6 +35,9 @@ jest.mock('casper-js-sdk', () => ({
   PublicKey: { fromHex: jest.fn() }
 }));
 jest.mock('@background/open-window', () => ({ openWindow: jest.fn() }));
+jest.mock('./cancel-superseded-requests', () => ({
+  cancelSupersededRequests: jest.fn()
+}));
 jest.mock('@background/utils', () => ({
   emitSdkEventToActiveTabsWithOrigin: jest.fn()
 }));
@@ -161,6 +165,19 @@ describe('connectRequest', () => {
     expect(dispatch).not.toHaveBeenCalled();
   });
 
+  it('does NOT cancel superseded requests on the already-connected fast path', async () => {
+    selectIsConnectedMock.mockReturnValue(true);
+    const { store } = makeStore();
+
+    await handleSdkMethod(
+      sdkMethod.connectRequest({ title: 't' }, META),
+      SENDER,
+      store
+    );
+
+    expect(cancelSupersededRequests).not.toHaveBeenCalled();
+  });
+
   it('not connected → dispatches windowRequestOpened + opens ConnectToApp window (with title)', async () => {
     selectIsConnectedMock.mockReturnValue(false);
     const { store, dispatch } = makeStore();
@@ -282,6 +299,22 @@ describe('signRequest', () => {
     expect(dispatch).not.toHaveBeenCalled();
   });
 
+  it('does NOT cancel superseded requests on the already-signed fast path', async () => {
+    isEqualCIMock.mockReturnValue(true);
+    const { store } = makeStore();
+
+    await handleSdkMethod(
+      sdkMethod.signRequest(
+        { deployJson, signingPublicKeyHex: 'PK-OTHER' },
+        META
+      ),
+      SENDER,
+      store
+    );
+
+    expect(cancelSupersededRequests).not.toHaveBeenCalled();
+  });
+
   it('fresh deploy → dispatches deployPayloadReceived + windowRequestOpened, opens deploy window', async () => {
     isEqualCIMock.mockReturnValue(false);
     const { store, dispatch } = makeStore();
@@ -311,6 +344,26 @@ describe('signRequest', () => {
       })
     );
     expect(result).toEqual({ handled: true, response: undefined });
+  });
+
+  it('cancels superseded requests before registering an opening request', async () => {
+    isEqualCIMock.mockReturnValue(false);
+    const { store, dispatch } = makeStore();
+
+    await handleSdkMethod(
+      sdkMethod.signRequest({ deployJson, signingPublicKeyHex: 'PK-1' }, META),
+      SENDER,
+      store
+    );
+
+    const cancelOrder = (cancelSupersededRequests as jest.Mock).mock
+      .invocationCallOrder[0];
+    const openedDispatchIndex = dispatch.mock.calls.findIndex(([a]) =>
+      String(a?.type).includes('windowRequestOpened')
+    );
+    const openedOrder = dispatch.mock.invocationCallOrder[openedDispatchIndex];
+
+    expect(cancelOrder).toBeLessThan(openedOrder);
   });
 });
 

--- a/src/background/handlers/sdk-methods.ts
+++ b/src/background/handlers/sdk-methods.ts
@@ -35,6 +35,7 @@ import { SdkMethod, sdkMethod } from '@content/sdk-method';
 import { encryptAsHexWithCasperPublicKey } from '@libs/crypto';
 
 import { selectVaultIsLocked } from '../redux/session/selectors';
+import { cancelSupersededRequests } from './cancel-superseded-requests';
 import { HandlerResult } from './types';
 
 export async function handleSdkMethod(
@@ -75,6 +76,8 @@ export async function handleSdkMethod(
         response: sdkMethod.connectResponse(true, action.meta)
       };
     } else {
+      cancelSupersededRequests(store);
+
       store.dispatch(
         windowRequestOpened({
           requestId: action.meta.requestId,
@@ -110,6 +113,8 @@ export async function handleSdkMethod(
     if (action.payload.title != null) {
       query.title = action.payload.title;
     }
+
+    cancelSupersededRequests(store);
 
     store.dispatch(
       windowRequestOpened({
@@ -172,6 +177,8 @@ export async function handleSdkMethod(
       })
     );
 
+    cancelSupersededRequests(store);
+
     store.dispatch(
       windowRequestOpened({
         requestId: action.meta.requestId,
@@ -204,6 +211,8 @@ export async function handleSdkMethod(
     }
 
     const { signingPublicKeyHex, message } = action.payload;
+
+    cancelSupersededRequests(store);
 
     store.dispatch(
       windowRequestOpened({
@@ -246,6 +255,8 @@ export async function handleSdkMethod(
       })
     );
 
+    cancelSupersededRequests(store);
+
     store.dispatch(
       windowRequestOpened({
         requestId: action.meta.requestId,
@@ -279,6 +290,8 @@ export async function handleSdkMethod(
     }
 
     const { signingPublicKeyHex, message } = action.payload;
+
+    cancelSupersededRequests(store);
 
     store.dispatch(
       windowRequestOpened({

--- a/src/background/handlers/sdk-response-to-tab.test.ts
+++ b/src/background/handlers/sdk-response-to-tab.test.ts
@@ -155,20 +155,6 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
     expect(result.handled).toBe(true);
   });
 
-  it("'closed' (never responded) → still delivers (must NOT drop — beforeunload-cancel race)", async () => {
-    const { store } = makeStore('closed');
-
-    const result = await handleSdkResponseToTab(
-      makeMessage(),
-      UI_SENDER,
-      store
-    );
-
-    expect(sendMessageMock).toHaveBeenCalledTimes(1);
-    expect(sendMessageMock).toHaveBeenCalledWith(TAB_ID, makeMessage().action);
-    expect(result.handled).toBe(true);
-  });
-
   it('invalid tabId, no origin → surfaces "not delivered" sagaError, no delivery, does not mark responded', async () => {
     const { store, dispatch } = makeStore(undefined);
 

--- a/src/background/handlers/sdk-response-to-tab.ts
+++ b/src/background/handlers/sdk-response-to-tab.ts
@@ -58,8 +58,6 @@ function deliveryFailedError(tabId: unknown, fallbackDelivered: boolean) {
 // request it cancels 'responded' (via `windowRequestResponded`). Dropping only on
 // 'responded' kills the real duplicate (a cancel racing a successful sign, where
 // the sign already set 'responded') without ever suppressing a first response.
-// ('closed' is now dispatch-dead: the close path uses `windowIdCleared`, not
-// `windowClosed`; the never-drop-on-'closed' stance is kept defensively.)
 export async function handleSdkResponseToTab(
   message: unknown,
   sender: Runtime.MessageSender,
@@ -84,8 +82,8 @@ export async function handleSdkResponseToTab(
   const { action, tabId } = candidate as SdkResponseToTabMessage;
   const requestId = action?.meta?.requestId;
 
-  // Dedupe: first response for this requestId wins. Drop ONLY on 'responded'
-  // (see the race rationale above) — never on 'closed'.
+  // Dedupe: first response for this requestId wins. Drop iff 'responded'
+  // (see the race rationale above).
   if (
     requestId != null &&
     selectRequestStatus(store.getState(), requestId) === 'responded'

--- a/src/background/redux/get-main-store.ts
+++ b/src/background/redux/get-main-store.ts
@@ -77,18 +77,14 @@ const selectPopupState = (state: RootState): PopupState => {
     session: { ...state.session, encryptionKeyHash: null },
     loginRetryCount: state.loginRetryCount,
     vault: state.vault,
-    // Narrowed on purpose: `pendingRequests` maps each in-flight requestId to
-    // its dapp origin + tabId. The approval window is a single reused slot, so
-    // requests from two different origins can be open at once — broadcasting
-    // the whole slice would put dapp A's origin into dapp B's UI replica. No
-    // UI reads it (only `selectWindowId` is consumed, in use-window-manager);
-    // the cancel-on-close path reads it in the background, off the real store.
-    // `exportKeysWindowId` is also dropped: the export-window open path is now
-    // a background saga that reads it straight off the real store, so no
-    // replica needs it.
+    // Narrowed on purpose. `pendingRequests` maps each in-flight requestId to
+    // its dapp origin + tabId. `requests` is the status/tombstone map read only
+    // by background dedup (sdk-response-to-tab) and selectOpenRequests. Neither
+    // is read by any UI replica, so broadcasting them would only leak dapp
+    // origins and serialize a lifetime-growing map into every popup update.
+    // `exportKeysWindowId` is background-only for the same reason.
     windowManagement: {
-      windowId: state.windowManagement.windowId,
-      requests: state.windowManagement.requests
+      windowId: state.windowManagement.windowId
     },
     loginRetryLockoutTime: state.loginRetryLockoutTime,
     lastActivityTime: state.lastActivityTime,
@@ -242,15 +238,16 @@ export type MainStore = Awaited<
 >;
 
 export function createMainStoreReplica<T extends PopupState>(state: T) {
-  // `selectPopupState` strips `pendingRequests` and `exportKeysWindowId` (the
-  // background keeps both; no UI reads either). Restore the shape the slice
-  // reducer expects — an empty map is truthful for a replica's request
-  // descriptors, and `null` is truthful since no replica tracks the export
-  // window.
+  // `selectPopupState` strips `pendingRequests`, `requests`, and
+  // `exportKeysWindowId` (the background keeps all three; no UI reads any of
+  // them). Restore the shape the slice reducer expects — empty maps are
+  // truthful for a replica's request descriptors/statuses, and `null` is
+  // truthful since no replica tracks the export window.
   return createStore({
     ...state,
     windowManagement: {
       ...state.windowManagement,
+      requests: {},
       pendingRequests: {},
       exportKeysWindowId: null
     }

--- a/src/background/redux/types.d.ts
+++ b/src/background/redux/types.d.ts
@@ -26,7 +26,7 @@ export type PopupState = {
   // the narrowing in `selectPopupState`.
   windowManagement: Omit<
     WindowManagementState,
-    'pendingRequests' | 'exportKeysWindowId'
+    'pendingRequests' | 'exportKeysWindowId' | 'requests'
   >;
   loginRetryLockoutTime: LoginRetryLockoutTimeState;
   lastActivityTime: LastActivityTimeState;

--- a/src/background/redux/windowManagement/actions.ts
+++ b/src/background/redux/windowManagement/actions.ts
@@ -6,7 +6,6 @@ export {
   onboardingAppInit,
   popupWindowInit,
   signWindowInit,
-  windowClosed,
   windowIdChanged,
   windowIdCleared,
   windowRequestOpened,

--- a/src/background/redux/windowManagement/reducer.test.ts
+++ b/src/background/redux/windowManagement/reducer.test.ts
@@ -166,7 +166,7 @@ describe('windowManagement reducer', () => {
     });
   });
 
-  it('windowRequestResponded flips only the status map', () => {
+  it('windowRequestResponded keeps the status but drops the descriptor', () => {
     const opened = reducer(
       empty,
       windowRequestOpened({
@@ -177,12 +177,43 @@ describe('windowManagement reducer', () => {
       })
     );
     const next = reducer(opened, windowRequestResponded({ requestId: 'r1' }));
+    // The status MUST survive — selectRequestStatus reading back 'responded'
+    // is what makes the server-side dedup drop a duplicate response.
     expect(next.requests.r1).toBe('responded');
-    expect(next.pendingRequests.r1).toEqual({
+    // The descriptor is only read for still-'open' requests, so it is dead
+    // weight once answered.
+    expect(next.pendingRequests.r1).toBeUndefined();
+  });
+
+  it('leaves a still-open sibling untouched when one request is answered', () => {
+    let s = reducer(
+      empty,
+      windowRequestOpened({
+        requestId: 'r1',
+        tabId: 9,
+        origin: 'https://dapp.example',
+        method: 'sign'
+      })
+    );
+    s = reducer(
+      s,
+      windowRequestOpened({
+        requestId: 'r2',
+        tabId: 9,
+        origin: 'https://other.example',
+        method: 'signMessage'
+      })
+    );
+    s = reducer(s, windowRequestResponded({ requestId: 'r1' }));
+    expect(s.pendingRequests.r2).toEqual({
       tabId: 9,
-      origin: 'o',
-      method: 'connect'
+      origin: 'https://other.example',
+      method: 'signMessage'
     });
+    // Responding twice must not throw or resurrect the dropped descriptor.
+    s = reducer(s, windowRequestResponded({ requestId: 'r1' }));
+    expect(s.pendingRequests.r1).toBeUndefined();
+    expect(s.requests.r1).toBe('responded');
   });
 
   it('windowIdCleared nulls only windowId', () => {

--- a/src/background/redux/windowManagement/reducer.test.ts
+++ b/src/background/redux/windowManagement/reducer.test.ts
@@ -6,7 +6,6 @@ import {
   onboardingAppInit,
   popupWindowInit,
   signWindowInit,
-  windowClosed,
   windowIdChanged,
   windowIdCleared,
   windowRequestOpened,
@@ -105,47 +104,6 @@ describe('windowManagement reducer', () => {
 
     s = reducer(s, windowRequestResponded({ requestId: 'r1' }));
     expect(s.requests.r1).toBe('responded');
-  });
-
-  it('closes open requests and clears windowId on windowClosed', () => {
-    let s = reducer(
-      {
-        windowId: 7,
-        exportKeysWindowId: null,
-        requests: {},
-        pendingRequests: {}
-      },
-      windowRequestOpened({
-        requestId: 'r2',
-        tabId: 9,
-        origin: 'https://dapp.example',
-        method: 'sign'
-      })
-    );
-    s = reducer(s, windowClosed());
-    expect(s.requests.r2).toBe('closed');
-    expect(s.windowId).toBeNull();
-  });
-
-  it('leaves a responded request as responded on windowClosed', () => {
-    let s = reducer(
-      {
-        windowId: 7,
-        exportKeysWindowId: null,
-        requests: {},
-        pendingRequests: {}
-      },
-      windowRequestOpened({
-        requestId: 'r3',
-        tabId: 9,
-        origin: 'https://dapp.example',
-        method: 'sign'
-      })
-    );
-    s = reducer(s, windowRequestResponded({ requestId: 'r3' }));
-    s = reducer(s, windowClosed());
-    expect(s.requests.r3).toBe('responded');
-    expect(s.windowId).toBeNull();
   });
 
   it('windowRequestOpened sets status open AND stores the descriptor', () => {

--- a/src/background/redux/windowManagement/reducer.ts
+++ b/src/background/redux/windowManagement/reducer.ts
@@ -58,16 +58,29 @@ const slice = createSlice({
         }
       }
     }),
+    // The status entry is kept forever on purpose: `selectRequestStatus` reading
+    // back 'responded' is what makes the server-side dedup drop a duplicate
+    // response. Deleting it would turn the status into `undefined` and let the
+    // duplicate through. The DESCRIPTOR, on the other hand, is only ever read
+    // for requests still 'open' (selectOpenRequests filters on that), so it is
+    // dead weight once answered — drop it and keep the map proportional to the
+    // number of genuinely in-flight requests rather than to the lifetime total.
     windowRequestResponded: (
       state,
       action: PayloadAction<{ requestId: string }>
-    ) => ({
-      ...state,
-      requests: {
-        ...state.requests,
-        [action.payload.requestId]: 'responded'
-      }
-    }),
+    ) => {
+      const pendingRequests = { ...state.pendingRequests };
+      delete pendingRequests[action.payload.requestId];
+
+      return {
+        ...state,
+        requests: {
+          ...state.requests,
+          [action.payload.requestId]: 'responded'
+        },
+        pendingRequests
+      };
+    },
     windowClosed: state => ({
       ...state,
       windowId: null,

--- a/src/background/redux/windowManagement/reducer.ts
+++ b/src/background/redux/windowManagement/reducer.ts
@@ -1,10 +1,6 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import {
-  CancellableMethod,
-  RequestStatus,
-  WindowManagementState
-} from './types';
+import { CancellableMethod, WindowManagementState } from './types';
 
 const initialState: WindowManagementState = {
   windowId: null,
@@ -80,17 +76,7 @@ const slice = createSlice({
         },
         pendingRequests
       };
-    },
-    windowClosed: state => ({
-      ...state,
-      windowId: null,
-      requests: Object.entries(state.requests).reduce<
-        Record<string, RequestStatus>
-      >((acc, [requestId, status]) => {
-        acc[requestId] = status === 'open' ? 'closed' : status;
-        return acc;
-      }, {})
-    })
+    }
   }
 });
 
@@ -102,7 +88,6 @@ export const {
   onboardingAppInit,
   popupWindowInit,
   signWindowInit,
-  windowClosed,
   windowIdChanged,
   windowIdCleared,
   windowRequestOpened,

--- a/src/background/redux/windowManagement/selectors.test.ts
+++ b/src/background/redux/windowManagement/selectors.test.ts
@@ -3,7 +3,7 @@ import { selectOpenRequests, selectRequestStatus } from './selectors';
 const state = {
   windowManagement: {
     windowId: null,
-    requests: { a: 'open', b: 'responded', c: 'closed' },
+    requests: { a: 'open', b: 'responded', c: 'responded' },
     pendingRequests: {
       a: { tabId: 1, origin: 'o', method: 'sign' },
       b: { tabId: 2, origin: 'o', method: 'connect' },

--- a/src/background/redux/windowManagement/types.ts
+++ b/src/background/redux/windowManagement/types.ts
@@ -1,4 +1,4 @@
-export type RequestStatus = 'open' | 'responded' | 'closed';
+export type RequestStatus = 'open' | 'responded';
 
 export type CancellableMethod =
   | 'connect'


### PR DESCRIPTION
## What & why

Follow-up to WALLET-1344 (PR #1405), implementing "Option A" from its pre-merge review.

The approval window is a single reused slot. When a dapp sends a second approval request while an earlier one is still open, all six SDK handlers reuse the window (navigating the same tab to the new request's page). Before this branch, the abandoned earlier request got **no response** — it stayed `'open'` and was only cancelled later, when the window was finally closed. For the sign→sign overlap this was a latency regression introduced by WALLET-1344 (before it, the signature pages cancelled via `beforeunload`).

This branch cancels the abandoned request **immediately at reuse time**, in the background, delivering the method-correct Cancel response to the dapp.

## How

- **Shared core** (`cancel-requests.ts`): extracted `CANCEL_GRACE_MS`, `buildCancelResponse`, and `cancelRequests(store, initiallyOpen, source, afterMark?)` out of `cancel-open-requests-on-close.ts`, which becomes a thin wrapper. The window-close path's observable behaviour is unchanged (pure refactor).
- **Supersede path** (`cancel-superseded-requests.ts`): `cancelSupersededRequests(store)` snapshots the open requests **synchronously**, then the six SDK handlers dispatch `windowRequestOpened` for the incoming request. Because the snapshot precedes that dispatch with no `await` in between, the incoming request cannot be in the snapshot — so **no `exceptRequestId` flag is needed**, and `openWindow`/`createOpenWindow` are left untouched. The same 250 ms grace + re-snapshot as the close path protects a genuine last-millisecond user response.
- **Housekeeping A**: `windowRequestResponded` now deletes the answered request's `pendingRequests` descriptor; `requests` is removed from the popup broadcast (`selectPopupState`) instead of pruned from the store.
- **Housekeeping B**: removed the dispatch-dead `windowClosed` action and narrowed `RequestStatus` to `'open' | 'responded'`.

## Deviations from the ticket text (intentional — flagging for the reporter)

1. **`exceptRequestId` not used.** The ticket suggested threading `exceptRequestId` through `openWindow`/`createOpenWindow`. We rely on snapshot **ordering** instead — strictly less surface area, and `openWindow` never needs to know about cancellation.
2. **`requests` is not pruned from the store.** The ticket asked to prune terminal `'responded'` entries from **both** maps. But the `'responded'` tombstone in `requests` is exactly what powers the duplicate-response dedup in `sdk-response-to-tab.ts` (`selectRequestStatus(...) === 'responded'`) — pruning it would reopen that dedup hole, whose main scenario is the cancel-vs-real-response race this very ticket concerns. So `pendingRequests` **is** pruned, and for `requests` we eliminate the real cost (per-broadcast serialization into every UI replica, which no UI reads) rather than the negligible heap growth.

## Known edges (accepted; QA awareness)

- **Live-store `requests` growth**: the map still grows for the service-worker lifetime (only broadcast cost was eliminated). Growth is ~tens of bytes per dapp request over a session — negligible; Chrome tears the SW down periodically. Accepted as-is.
- **Approve-then-supersede race**: if a user clicks Approve on request A and its signing is still computing when dapp B supersedes the window, the 250 ms grace can mark A `cancelled` and the genuine signature is silently discarded inside the extension. Security-reviewed: **no secret leak and no double-action** (dedup drops the late real response). The underlying window-reuse navigation race pre-dates this branch. Accepted as-is; noted for QA.

## Testing

- `npm run ci-check` green on the integrated branch (format, lint, tsc, knip, test:coverage; 100% on all touched handler/reducer files).
- New unit tests: supersede cancels the abandoned request but not the incoming one; answered-during-grace is not cancelled; delivery fallback + error surfacing; no-op with no open requests; call-ordering (`invocationCallOrder`) at the SDK handlers; fast-path (already-connected / already-signed) skips supersede.
- Reviews: per-task spec+quality gates, a whole-branch review, plus dedicated security and download-account-keys-interaction reviews — all clean (no Critical/High).
- **Manual extension QA pending.**

Jira: https://make-software.atlassian.net/browse/WALLET-1353