### PR TITLE
fix: WALLET-1364 — restore release/2.7.0 by admitting the export-keys saga into SagaErrorSource

### DIFF
--- a/src/background/redux/app-events/reducer.test.ts
+++ b/src/background/redux/app-events/reducer.test.ts
@@ -163,31 +163,37 @@ describe('app-events reducer', () => {
     const seeded: AppEventsState = {
       dismissedEventIds: [],
       errors: [
-        { id: 0, source: 'sagaA', message: 'first' },
-        { id: 1, source: 'sagaB', message: 'other' },
-        { id: 2, source: 'sagaA', message: 'second' }
+        { id: 0, source: 'lockVaultSaga', message: 'first' },
+        { id: 1, source: 'unlockVaultSaga', message: 'other' },
+        { id: 2, source: 'lockVaultSaga', message: 'second' }
       ],
       nextErrorId: 3
     };
 
     it('removes every entry from the given source and leaves the others', () => {
-      const result = reducer(seeded, dismissSagaErrorsBySource('sagaA'));
+      const result = reducer(
+        seeded,
+        dismissSagaErrorsBySource('lockVaultSaga')
+      );
       expect(result.errors).toEqual([
-        { id: 1, source: 'sagaB', message: 'other' }
+        { id: 1, source: 'unlockVaultSaga', message: 'other' }
       ]);
     });
 
     it('does not rewind the id counter, so a later error cannot reuse a retracted id', () => {
-      const cleared = reducer(seeded, dismissSagaErrorsBySource('sagaA'));
+      const cleared = reducer(
+        seeded,
+        dismissSagaErrorsBySource('lockVaultSaga')
+      );
       expect(cleared.nextErrorId).toBe(3);
 
       const next = reducer(
         cleared,
-        sagaError({ source: 'sagaA', message: 'retry' })
+        sagaError({ source: 'lockVaultSaga', message: 'retry' })
       );
       expect(next.errors).toEqual([
-        { id: 1, source: 'sagaB', message: 'other' },
-        { id: 3, source: 'sagaA', message: 'retry' }
+        { id: 1, source: 'unlockVaultSaga', message: 'other' },
+        { id: 3, source: 'lockVaultSaga', message: 'retry' }
       ]);
     });
 

--- a/src/background/redux/app-events/reducer.test.ts
+++ b/src/background/redux/app-events/reducer.test.ts
@@ -197,9 +197,12 @@ describe('app-events reducer', () => {
       ]);
     });
 
-    it('is a no-op for an unknown source', () => {
+    // "Unknown source" is no longer expressible — the payload is the same closed
+    // union as SagaError.source — so what is left to assert is the reachable case:
+    // a real producer that happens to have nothing on screen.
+    it('is a no-op for a source with no errors of its own', () => {
       expect(
-        reducer(seeded, dismissSagaErrorsBySource('sagaZ')).errors
+        reducer(seeded, dismissSagaErrorsBySource('initVaultSaga')).errors
       ).toEqual(seeded.errors);
     });
   });

--- a/src/background/redux/app-events/reducer.ts
+++ b/src/background/redux/app-events/reducer.ts
@@ -52,7 +52,10 @@ const slice = createSlice({
      * a successful retry opens. A producer dispatches this before re-attempting
      * so what the banner shows is always the current attempt.
      */
-    dismissSagaErrorsBySource: (state, action: PayloadAction<string>) => ({
+    dismissSagaErrorsBySource: (
+      state,
+      action: PayloadAction<SagaErrorSource>
+    ) => ({
       ...state,
       errors: state.errors.filter(error => error.source !== action.payload)
     })

--- a/src/background/redux/app-events/types.ts
+++ b/src/background/redux/app-events/types.ts
@@ -18,6 +18,7 @@ export type SagaErrorSource =
   | 'timeoutCounterSaga'
   | 'updateVaultCipher'
   | 'createAccountSaga'
+  | 'openExportKeysWindowSaga'
   // approval-request lifecycle failures
   | 'cancel-on-close'
   | 'cancel-on-supersede'


### PR DESCRIPTION
Ticket: https://make-software.atlassian.net/browse/WALLET-1364 (fallout of the #1427/#1428 merge order)

## `release/2.7.0` is currently red

`tsc` fails with 8 errors. CI on the branch: #1427 → success, **#1428 → failure**, #1429 → failure.
It has been broken since 10:04 UTC today, and it is why #1432 (already approved) and #1433 fail
CI on code they do not touch.

```
src/background/redux/app-events/reducer.test.ts(166,18): error TS2322: Type '"sagaA"' is not assignable to type 'SagaErrorSource'.
src/background/redux/app-events/reducer.test.ts(167,18): …'"sagaB"'…
src/background/redux/app-events/reducer.test.ts(168,18): …'"sagaA"'…
src/background/redux/app-events/reducer.test.ts(186,21): …'"sagaA"'…
src/background/redux/sagas/export-keys-window-saga.test.ts(103,13): …'"openExportKeysWindowSaga"'…
src/background/redux/sagas/export-keys-window-saga.test.ts(178,13): …'"openExportKeysWindowSaga"'…
src/background/redux/sagas/export-keys-window-saga.ts(62,15): …'"openExportKeysWindowSaga"'…
src/background/redux/sagas/export-keys-window-saga.ts(108,9): …'"openExportKeysWindowSaga"'…
```

## How it happened

A semantic conflict, invisible to both PRs and to git.

- **#1427** replaced `SagaError.source: string` with the closed union `SagaErrorSource`
  (`app-events/types.ts`), updating every producer that existed at the time.
- **#1428** was last validated at 09:04 UTC, against a base whose tip was `308db929` — an hour
  before #1427 landed at 10:03. On that base `source` was still `string`, so its new producer
  `'openExportKeysWindowSaga'` and its `'sagaA'`/`'sagaB'` test fixtures compiled clean.
- #1428 merged at 10:04 carrying that stale green. GitHub does not re-run a PR's checks when its
  **base** moves, and there is no branch protection on `release/2.7.0` — so nothing required a
  re-validation.
- No textual conflict: #1428 never touched `types.ts`. But narrowing a type is a repo-wide
  constraint — it binds every producer of that value, including files the narrowing PR never
  opened.

## What this PR does

**Commit 1 — `fix(app-events)`: makes the branch green again.**

- `'openExportKeysWindowSaga'` joins the union. It is a real producer, not a test artefact: it is
  the `ERROR_SOURCE` constant at `export-keys-window-saga.ts:21`, used for both `sagaError`
  dispatches (`:62`, `:108`) and for `dismissSagaErrorsBySource` (`:29`).
- The invented `'sagaA'`/`'sagaB'` fixtures become real sources (`'lockVaultSaga'` /
  `'unlockVaultSaga'`). The test needs two distinct sources, one appearing twice — nothing about it
  required members the union forbids.

**Commit 2 — `refactor(app-events)`: closes the other half of the same contract.**

`dismissSagaErrorsBySource` still took `PayloadAction<string>` while `SagaError.source` was the
closed union, so errors could be retracted under a spelling no producer can ever write. That is the
exact drift the union exists to prevent, left in place on the retraction side. The only production
caller already passes the saga's `ERROR_SOURCE`, so nothing real is narrowed away.

It costs one test: "is a no-op for an unknown source" asserted a state that is no longer
representable. The reachable case — a real producer that happens to have nothing on screen —
replaces it.

Commit 2 is separable: drop it and commit 1 alone still turns the branch green.

## Verification

- `npm run ci-check` — green: 67 suites, 514 tests, 0 lint errors (171 pre-existing warnings).
- Before the fix, `npx tsc -p ./ --noEmit` on this branch's base reproduced exactly the 8 CI errors.
- The narrowing is load-bearing, not decorative: with commit 2 applied, the old
  `dismissSagaErrorsBySource('sagaZ')` line fails with `TS2345: Argument of type '"sagaZ"' is not
assignable to parameter of type 'SagaErrorSource'`.

## Worth deciding separately

This class of failure will recur. `release/*` has no branch protection at all — enabling
**Require branches to be up to date before merging** with the CI check required (or a merge queue)
is what forces the second PR to be re-validated against the first.
