### PR TITLE
test: stop the popup e2e suite depending on a live cspr.cloud node

### DIFF
--- a/e2e-tests/constants.ts
+++ b/e2e-tests/constants.ts
@@ -131,10 +131,45 @@ export const NEW_VALIDATOR_FOR_STAKE = {
 };
 
 export const URLS = {
-  rpc: 'https://node.testnet.cspr.cloud/rpc'
+  rpc: 'https://node.testnet.cspr.cloud/rpc',
+  // Every cspr.cloud RPC node the suite can end up pointed at. The buy-CSPR specs
+  // switch to Mainnet, which moves the background probe onto `node.cspr.cloud` —
+  // matching only `rpc` above would leave that one reaching the live network.
+  anyRpcNode: /^https:\/\/node\.(\w+\.)?cspr\.cloud\/rpc$/
 };
 
 export const RPC_RESPONSE = {
+  // `checkCasper2NetworkSaga` probes the node for its api_version on every unlock
+  // and on every network switch, to learn whether it is talking to a Casper 2.x
+  // network. It runs in the background service worker, so `page.route` never sees
+  // it — see the context-level route in `fixtures.ts`. The api_version here has to
+  // stay in the 2.x line: it is what flips the send path onto `putTransaction`,
+  // which is the only shape `success` below answers with.
+  getStatus: {
+    status: 200,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1717761373590,
+      result: {
+        api_version: '2.0.0',
+        protocol_version: '2.0.0',
+        build_version: '2.0.0-e2e',
+        chainspec_name: 'casper-test',
+        starting_state_root_hash:
+          '0000000000000000000000000000000000000000000000000000000000000000',
+        our_public_signing_key:
+          '0106ca7c39cd272dbf21a86eeb3b36b7c26e2e9b94af64292419f7862936bca2ca',
+        round_length: null,
+        next_upgrade: null,
+        uptime: '1m 0ms',
+        reactor_state: 'Validate',
+        last_progress: '2026-01-01T00:00:00.000Z',
+        available_block_range: { low: 0, high: 0 },
+        block_sync: {},
+        peers: []
+      }
+    })
+  },
   success: {
     status: 200,
     body: JSON.stringify({

--- a/e2e-tests/fixtures.ts
+++ b/e2e-tests/fixtures.ts
@@ -73,6 +73,27 @@ export const test = base.extend<{
       });
     });
 
+    // `checkCasper2NetworkSaga` asks the node for its api_version on every unlock
+    // and on every network switch. It runs in the background service worker, and
+    // `page.route` does not cover service-worker requests — only `context.route`
+    // does. Until this route existed the suite therefore reached the live
+    // cspr.cloud node on every test. Once that node began answering 429 (daily
+    // organization quota), the probe failed, `casperNetworkApiVersion` stayed on
+    // the pre-2.0 default, `sendSignedTx` fell back to `putDeploy`, and every
+    // submitting test died on a transaction-shaped mock with
+    // "Cannot read properties of undefined (reading 'toHex')".
+    //
+    // Only the status probe is answered here: the per-test `popupPage.route` that
+    // fulfils the submit is a page route, and page routes are matched first.
+    await context.route(URLS.anyRpcNode, async route => {
+      if (route.request().postDataJSON()?.method === 'info_get_status') {
+        await route.fulfill(RPC_RESPONSE.getStatus);
+        return;
+      }
+
+      await route.fallback();
+    });
+
     await use(context);
     await context.close();
 

--- a/src/fixtures/initial-state-for-popup-tests.ts
+++ b/src/fixtures/initial-state-for-popup-tests.ts
@@ -92,7 +92,7 @@ export const initialStateForPopupTests: RootState = {
   activeOriginFavicon: null,
   settings: {
     activeNetwork: NetworkSetting.Testnet,
-    casperNetworkApiVersion: '1.5.8',
+    casperNetworkApiVersion: '2.0.0',
     activeTimeoutDuration: TimeoutDurationSetting['5 min'],
     isDarkMode: false,
     themeMode: ThemeMode.SYSTEM,


### PR DESCRIPTION
## Problem

All six submitting popup e2e specs (3 stakes + 3 transfers) were failing in CI and locally:

```
Locator: getByRole('heading', { name: 'You submitted a transaction' })
Error: element(s) not found
```

The page snapshot in the CI artifact shows what was actually on screen instead:

```yaml
- alert: "Something went wrong checkCasper2NetworkSaga: Code: 429, err:"
- heading "Cannot read properties of undefined (reading 'toHex')" [level=1]
```

## Root cause

`checkCasper2NetworkSaga` probes the node for its `api_version` on every unlock and on every network switch. It runs in the **background service worker** — and `page.route` does not cover service-worker requests, only `context.route` does. So the per-test `popupPage.route(URLS.rpc, ...)` never reached it, and every test run went out to the live `node.testnet.cspr.cloud`.

Confirmed live:

```
POST https://node.testnet.cspr.cloud/rpc  (Referer: https://casperwallet.io)
→ 429  access limit exceeded: Organization request quota per day per API
        in context of Tier has exceeded, current value: 30000
```

From there:

1. The probe fails → `casperNetworkApiVersion` keeps its pre-2.0 value → `selectIsCasper2Network` is `false`.
2. `sendSignedTx` takes the legacy `putDeploy` branch.
3. But the e2e mock `RPC_RESPONSE.success` returns a Casper **2.0** result (`transaction_hash`, no `deploy_hash`), so `deployResp.deployHash` is `undefined` and `.toHex()` throws.
4. The wallet error screen renders instead of the success screen — every submitting spec fails.

The suite looked hermetic (`MOCK_STATE=true` + a per-test RPC mock) but was not: green runs silently depended on an external node answering and flipping the version to 2.x.

## Fix

- **`e2e-tests/fixtures.ts`** — a context-level route answering the `info_get_status` probe locally, so the background worker never leaves the machine. Everything else `route.fallback()`s, and the per-test page route that fulfils the submit still wins (page routes are matched before context routes).
- **`e2e-tests/constants.ts`** — `RPC_RESPONSE.getStatus`, plus `URLS.anyRpcNode` matching every cspr.cloud node. The buy-CSPR specs switch to Mainnet, which moves the probe off the testnet URL, so an exact-URL match would have left that one reaching the network.
- **`src/fixtures/initial-state-for-popup-tests.ts`** — pin the popup mock state to a 2.x `api_version` so it agrees with the mocked transaction result, instead of relying on the live probe to flip it.

## Verification

| Run | Result |
| --- | --- |
| `e2e-tests/popup` (full) | 46 passed, 1 skipped, 0 flaky |
| `stakes` + `transfers`, `--repeat-each=2` | 15 passed |
| `e2e-tests/onboarding-flow` | 6 passed |
| `prettier --check` / `eslint` / `tsc -p e2e-tests` | exit 0 |

Before the fix the same six specs failed 3/3 attempts (all retries) in CI and locally.

## Out of scope, worth separate tickets

- **The 429 itself is operational, not a code bug.** The cspr.cloud daily organization quota is exhausted, which is why the "Something went wrong — checkCasper2NetworkSaga: Code: 429" banner also shows in the real wallet. This PR stops the test suite depending on that node; it does not and cannot fix the quota.
- **`sendSignedTx` dereferences the response hash unguarded** (`src/libs/services/deployer-service/index.ts`) on both branches — `deployResp.deployHash.toHex()` and `txResp.transactionHash.toHex()`. A node response that does not match the branch the version heuristic picked surfaces a raw `Cannot read properties of undefined` as the user-facing error header.
- **The suite still reaches other live endpoints**: `api.testnet.casperwallet.io` (the stake specs' validator search depends on it), the playground dapp, and the on-ramp redirects in the buy-CSPR flow. Any of those can fail this suite the same way.