### PR TITLE
fix: WALLET-1384 — keep the payload of every in-flight signature request

### DIFF
--- a/src/apps/signature-request/pages/sign-eip712/index.tsx
+++ b/src/apps/signature-request/pages/sign-eip712/index.tsx
@@ -17,6 +17,7 @@ import { SignatureRequestLoading } from '@signature-request/pages/sign-transacti
 import { SignatureRequestRawJson } from '@signature-request/pages/sign-transaction/signature-request-raw-json';
 
 import { closeCurrentWindow } from '@background/close-current-window';
+import { getPayload } from '@background/redux/vault/payload-map';
 import {
   selectConnectedAccountNamesByOrigin,
   selectEip712JsonById,
@@ -81,7 +82,9 @@ export function SignEip712Page() {
     options?: IEIP712SignTypedDataOptions;
     isInvalidPayload?: boolean;
   }>(() => {
-    const raw = eip712JsonById[requestId];
+    // `getPayload`, never a bare index — `requestId` is dapp-controlled and an
+    // inherited Object.prototype member would parse as anything but typed data.
+    const raw = getPayload(eip712JsonById, requestId);
 
     if (!raw) {
       return {};

--- a/src/apps/signature-request/pages/sign-transaction/index.tsx
+++ b/src/apps/signature-request/pages/sign-transaction/index.tsx
@@ -403,8 +403,14 @@ export function SignTransactionPage() {
           <Button
             color="primaryRed"
             flexWidth
+            // `!signatureRequest` mirrors the eip712 page. `transaction` is
+            // local state that outlives the payload it was parsed from, so
+            // once the answered request's payload is dropped from the vault
+            // this button would stay enabled over the empty pane the content
+            // branch below renders without a `signatureRequest`.
             disabled={
               !transaction ||
+              !signatureRequest ||
               isLoadingSignatureRequest ||
               (additionalApproveRequired && !wasmApproved)
             }

--- a/src/apps/signature-request/pages/sign-transaction/index.tsx
+++ b/src/apps/signature-request/pages/sign-transaction/index.tsx
@@ -469,7 +469,12 @@ export function SignTransactionPage() {
           );
         }
 
-        return isLoadingSignatureRequest ? (
+        // `!signatureRequest` mirrors sign-eip712. `isLoadingSignatureRequest`
+        // is the query's `isFetching`, which is false for a DISABLED query — so
+        // once the answered request's payload is gone every child below is
+        // guarded away and this branch rendered an empty pane. Per-request
+        // deletion makes that routine, not hypothetical.
+        return isLoadingSignatureRequest || !signatureRequest ? (
           <SignatureRequestLoading />
         ) : (
           <>

--- a/src/apps/signature-request/pages/sign-transaction/index.tsx
+++ b/src/apps/signature-request/pages/sign-transaction/index.tsx
@@ -230,6 +230,23 @@ export function SignTransactionPage() {
     let signature: Uint8Array | null = null;
 
     if (!transaction) {
+      // Every signing route funnels through here, including the Ledger footer's
+      // Connect, which is outside the `disabled` gate on the main footer. If the
+      // payload is gone the request can never be answered from this window, so
+      // returning silently strands both the window and the dapp.
+      // Keyed on `transactionJson`: a payload present but not yet parsed is an
+      // ordinary in-flight state and must not error out.
+      if (!transactionJson) {
+        const error = Error(
+          ErrorMessages.signTransaction.REQUEST_NO_LONGER_AVAILABLE.description
+        );
+        sendSdkResponseToSpecificTab(
+          sdkMethod.signError(error, { requestId }),
+          requestTabId
+        );
+        closeCurrentWindow();
+      }
+
       return;
     }
 
@@ -266,6 +283,7 @@ export function SignTransactionPage() {
     closeCurrentWindow();
   }, [
     transaction,
+    transactionJson,
     signingAccount.hardware,
     signingAccount.derivationIndex,
     signingAccount.publicKey,

--- a/src/apps/signature-request/pages/sign-transaction/index.tsx
+++ b/src/apps/signature-request/pages/sign-transaction/index.tsx
@@ -33,6 +33,7 @@ import {
 } from '@background/redux/trusted-wasm/actions';
 import { selectTrustedWasmByOrigin } from '@background/redux/trusted-wasm/selectors';
 import { dispatchToMainStore } from '@background/redux/utils';
+import { getPayload } from '@background/redux/vault/payload-map';
 import {
   selectConnectedAccountNamesByOrigin,
   selectDeploysJsonById,
@@ -138,8 +139,11 @@ export function SignTransactionPage() {
     [accounts, signingPublicKeyHex]
   );
 
+  // `getPayload`, never a bare index: `requestId` is dapp-controlled, so
+  // `deployJsonById['constructor']` would hand this page an inherited
+  // Object.prototype member instead of transaction JSON.
   const transactionJson = useMemo<string | undefined>(
-    () => deployJsonById[requestId],
+    () => getPayload(deployJsonById, requestId),
     [deployJsonById, requestId]
   );
 

--- a/src/apps/signature-request/pages/sign-transaction/index.tsx
+++ b/src/apps/signature-request/pages/sign-transaction/index.tsx
@@ -469,12 +469,20 @@ export function SignTransactionPage() {
           );
         }
 
-        // `!signatureRequest` mirrors sign-eip712. `isLoadingSignatureRequest`
-        // is the query's `isFetching`, which is false for a DISABLED query — so
-        // once the answered request's payload is gone every child below is
-        // guarded away and this branch rendered an empty pane. Per-request
-        // deletion makes that routine, not hypothetical.
-        return isLoadingSignatureRequest || !signatureRequest ? (
+        // `isLoadingSignatureRequest` is the query's `isFetching`, which is
+        // false for a DISABLED query — so once the answered request's payload
+        // is gone the two content children below are guarded away and this
+        // branch rendered an empty pane. Per-request deletion makes that
+        // routine, not hypothetical.
+        //
+        // `LedgerEventView` is the exception and is excluded from the added
+        // term: it carries no `signatureRequest`, and it is the only thing the
+        // Ledger permission window — the second window, the one that survives a
+        // supersede — has to show while the device is being read. Replacing it
+        // with a skeleton would blank exactly the screen this fix protects.
+        return isLoadingSignatureRequest ||
+          (!signatureRequest &&
+            signingPageState !== SigningPageState.LedgerConfirmation) ? (
           <SignatureRequestLoading />
         ) : (
           <>

--- a/src/background/redux/sagas/vault-sagas.test.ts
+++ b/src/background/redux/sagas/vault-sagas.test.ts
@@ -43,6 +43,7 @@ import {
   selectVaultActiveAccount
 } from '../vault/selectors';
 import { VaultState } from '../vault/types';
+import { windowRequestResponded } from '../windowManagement/actions';
 import { lockVault, startBackground, unlockVault } from './actions';
 import {
   VAULT_REENCRYPT_DEBOUNCE_MS,
@@ -444,6 +445,27 @@ describe('updateVaultCipher debounce', () => {
       .dispatch(accountRenamed({ oldName: 'a', newName: 'b' }))
       .dispatch(accountRenamed({ oldName: 'b', newName: 'c' }))
       .dispatch(accountRenamed({ oldName: 'c', newName: 'd' }))
+      .silentRun(VAULT_REENCRYPT_DEBOUNCE_MS + 200);
+
+    expect(encryptSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // WALLET-1384: the vault reducer deletes an answered request's signing
+  // payload, and that deletion must reach the cipher. Otherwise an MV3
+  // service-worker restart re-loads the entry from a stale blob through
+  // `vaultLoaded`, for a requestId whose `windowRequestResponded` has already
+  // fired — so nothing but the FIFO cap would ever remove it.
+  it('re-encrypts when an answered request drops its payload', async () => {
+    const encryptSpy = jest
+      .spyOn(vaultCryptoModule, 'encryptVault')
+      .mockResolvedValue('cipher-blob');
+
+    await expectSaga(vaultSagas)
+      .provide([
+        [matchers.select.selector(selectEncryptionKeyHash), 'key-hash'],
+        [matchers.select.selector(selectVault), EMPTY_VAULT]
+      ])
+      .dispatch(windowRequestResponded({ requestId: 'answered' }))
       .silentRun(VAULT_REENCRYPT_DEBOUNCE_MS + 200);
 
     expect(encryptSpy).toHaveBeenCalledTimes(1);

--- a/src/background/redux/sagas/vault-sagas.test.ts
+++ b/src/background/redux/sagas/vault-sagas.test.ts
@@ -1,4 +1,5 @@
 import * as matchers from 'redux-saga-test-plan/matchers';
+import { combineReducers } from '@reduxjs/toolkit';
 import { expectSaga } from 'redux-saga-test-plan';
 import { storage, tabs } from 'webextension-polyfill';
 
@@ -37,6 +38,7 @@ import { selectTimeoutDurationSetting } from '../settings/selectors';
 import { vaultCipherCreated } from '../vault-cipher/actions';
 import { selectVaultCipherDoesExist } from '../vault-cipher/selectors';
 import { accountRenamed, vaultLoaded } from '../vault/actions';
+import { reducer as vaultReducer } from '../vault/reducer';
 import {
   selectAccountNamesByOriginDict,
   selectVault,
@@ -454,21 +456,43 @@ describe('updateVaultCipher debounce', () => {
   // payload, and that deletion must reach the cipher. Otherwise an MV3
   // service-worker restart re-loads the entry from a stale blob through
   // `vaultLoaded`, for a requestId whose `windowRequestResponded` has already
-  // fired — so nothing but the FIFO cap would ever remove it.
-  it('re-encrypts when an answered request drops its payload', async () => {
+  // fired — so nothing would ever remove it.
+  //
+  // Driven through the REAL vault reducer (`withReducer`) and asserted on the
+  // value handed to `encryptVault`, not on a call count. Providing `selectVault`
+  // instead would pin only that `windowRequestResponded.type` sits in the
+  // debounce array — the reducer half of the contract would go unobserved, and
+  // deleting the whole `extraReducers` block would leave the test green.
+  it('re-encrypts the vault WITHOUT the answered payload', async () => {
     const encryptSpy = jest
       .spyOn(vaultCryptoModule, 'encryptVault')
       .mockResolvedValue('cipher-blob');
 
+    const seeded: VaultState = {
+      ...EMPTY_VAULT,
+      jsonById: { answered: 'gone', other: 'kept' },
+      eip712ById: { answered: 'gone' }
+    };
+
     await expectSaga(vaultSagas)
+      .withReducer(
+        combineReducers({ vault: vaultReducer }) as never,
+        {
+          vault: seeded
+        } as never
+      )
       .provide([
-        [matchers.select.selector(selectEncryptionKeyHash), 'key-hash'],
-        [matchers.select.selector(selectVault), EMPTY_VAULT]
+        [matchers.select.selector(selectEncryptionKeyHash), 'key-hash']
       ])
       .dispatch(windowRequestResponded({ requestId: 'answered' }))
       .silentRun(VAULT_REENCRYPT_DEBOUNCE_MS + 200);
 
     expect(encryptSpy).toHaveBeenCalledTimes(1);
+    // `toEqual` on each map, not `toMatchObject` on the vault: a recursive
+    // subset match tolerates the very key this test exists to prove is gone.
+    const encrypted = encryptSpy.mock.calls[0][1];
+    expect(encrypted.jsonById).toEqual({ other: 'kept' });
+    expect(encrypted.eip712ById).toEqual({});
   });
 
   it('re-encrypts once per edit when edits are spaced beyond the debounce window', async () => {

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -72,7 +72,10 @@ import {
   selectVaultActiveAccount,
   selectVaultDerivedAccounts
 } from '../vault/selectors';
-import { popupWindowInit } from '../windowManagement/actions';
+import {
+  popupWindowInit,
+  windowRequestResponded
+} from '../windowManagement/actions';
 import {
   createAccount,
   lockVault,
@@ -122,6 +125,17 @@ export function* vaultSagas() {
       activeTimeoutDurationSettingChanged.type,
       deployPayloadReceived.type,
       eip712PayloadReceived.type,
+      // The deletion belongs here for the same reason the two writes above do.
+      // The vault reducer drops an answered request's payload from
+      // `jsonById`/`eip712ById`, but that is an in-memory edit: without a
+      // re-encryption the cipher still holds the entry, and an MV3
+      // service-worker restart before the next vault write would resurrect it
+      // through `vaultLoaded` — for a requestId `windowRequestResponded` has
+      // already fired for, so nothing but the FIFO cap would ever remove it.
+      // Most responses have no payload entry, so this usually re-encrypts an
+      // unchanged vault; at ~2ms behind a 500ms debounce that is cheaper than
+      // the alternative of persisting writes but not deletes.
+      windowRequestResponded.type,
       hideAccountFromListChanged.type
     ],
     updateVaultCipher

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -131,7 +131,8 @@ export function* vaultSagas() {
       // re-encryption the cipher still holds the entry, and an MV3
       // service-worker restart before the next vault write would resurrect it
       // through `vaultLoaded` — for a requestId `windowRequestResponded` has
-      // already fired for, so nothing but the FIFO cap would ever remove it.
+      // already fired for — and nothing removes it: the map has a ceiling, but
+      // the ceiling refuses new writes rather than evicting stored ones.
       // Most responses have no payload entry, so this usually re-encrypts an
       // unchanged vault; at ~2ms behind a 500ms debounce that is cheaper than
       // the alternative of persisting writes but not deletes.

--- a/src/background/redux/vault/payload-map.test.ts
+++ b/src/background/redux/vault/payload-map.test.ts
@@ -1,0 +1,27 @@
+import { getPayload } from './payload-map';
+
+describe('getPayload', () => {
+  it('returns the stored payload for an own key', () => {
+    expect(getPayload({ req: 'json' }, 'req')).toBe('json');
+  });
+
+  it('returns undefined for a key the map does not hold', () => {
+    expect(getPayload({ req: 'json' }, 'other')).toBeUndefined();
+  });
+
+  it.each([
+    '__proto__',
+    'toString',
+    'constructor',
+    'valueOf',
+    'hasOwnProperty'
+  ])('returns undefined for the inherited Object.prototype member %p', name => {
+    expect(getPayload({}, name)).toBeUndefined();
+  });
+
+  it('still returns an own property that shadows an inherited name', () => {
+    expect(getPayload({ ...{}, ['toString']: 'json' }, 'toString')).toBe(
+      'json'
+    );
+  });
+});

--- a/src/background/redux/vault/payload-map.ts
+++ b/src/background/redux/vault/payload-map.ts
@@ -1,0 +1,32 @@
+import { VaultState } from './types';
+
+type PayloadMap = VaultState['jsonById'] | VaultState['eip712ById'];
+
+/**
+ * The only sanctioned way to read `jsonById` / `eip712ById`.
+ *
+ * Both are keyed by `requestId`, which is page-generated (`generateRequestId`,
+ * src/content/sdk.ts) i.e. dapp-controlled, so a bare `map[requestId]` can read
+ * an INHERITED `Object.prototype` member for `__proto__`, `toString`,
+ * `constructor`, `valueOf` or `hasOwnProperty`. A dapp asking to sign with
+ * `requestId: 'constructor'` would hand the signature page a function where it
+ * expects transaction JSON, and `Transaction.fromJSON` would throw inside the
+ * query — surfacing as INVALID_TRANSACTION_JSON for a request the store never
+ * held a payload for.
+ *
+ * Own properties only, so "is there a payload for this request" has one answer.
+ * Mirrors `getRequest` in windowManagement/request-map.ts, which exists for the
+ * same reason on the same key space.
+ *
+ * Writes need no equivalent guard: every write here goes through an object
+ * literal with a computed key (`{ ...map, [id]: json }`), which defines an own
+ * property even for `__proto__` rather than setting the prototype.
+ */
+export function getPayload(
+  payloads: PayloadMap,
+  requestId: string
+): string | undefined {
+  return Object.prototype.hasOwnProperty.call(payloads, requestId)
+    ? payloads[requestId]
+    : undefined;
+}

--- a/src/background/redux/vault/payload-map.ts
+++ b/src/background/redux/vault/payload-map.ts
@@ -18,9 +18,14 @@ type PayloadMap = VaultState['jsonById'] | VaultState['eip712ById'];
  * Mirrors `getRequest` in windowManagement/request-map.ts, which exists for the
  * same reason on the same key space.
  *
- * Writes need no equivalent guard: every write here goes through an object
- * literal with a computed key (`{ ...map, [id]: json }`), which defines an own
- * property even for `__proto__` rather than setting the prototype.
+ * Writes need no equivalent guard, for a different reason than the shape of the
+ * write suggests. `{ ...map, [id]: json }` does define an own property, but the
+ * copy immer makes when it finalizes the returned state ASSIGNS the keys, and
+ * assigning a string to `__proto__` is a silent no-op — so a `__proto__`
+ * payload is dropped rather than stored, and the map's prototype is untouched
+ * either way (pinned in reducer.test.ts). It cannot arise regardless:
+ * `handleSdkMethod` rejects that id at the message boundary for every approval
+ * type, before anything is dispatched.
  */
 export function getPayload(
   payloads: PayloadMap,

--- a/src/background/redux/vault/payload-map.ts
+++ b/src/background/redux/vault/payload-map.ts
@@ -18,14 +18,11 @@ type PayloadMap = VaultState['jsonById'] | VaultState['eip712ById'];
  * Mirrors `getRequest` in windowManagement/request-map.ts, which exists for the
  * same reason on the same key space.
  *
- * Writes need no equivalent guard, for a different reason than the shape of the
- * write suggests. `{ ...map, [id]: json }` does define an own property, but the
- * copy immer makes when it finalizes the returned state ASSIGNS the keys, and
- * assigning a string to `__proto__` is a silent no-op — so a `__proto__`
- * payload is dropped rather than stored, and the map's prototype is untouched
- * either way (pinned in reducer.test.ts). It cannot arise regardless:
- * `handleSdkMethod` rejects that id at the message boundary for every approval
- * type, before anything is dispatched.
+ * The write side is guarded separately and deliberately, in `storePayload`:
+ * `__proto__` is refused there rather than left to the shape of the write. What
+ * the source looks like does not decide it — `tsconfig.json` targets es2017, so
+ * the spread is emitted as `Object.assign`, and assignment runs the `__proto__`
+ * setter instead of adding an entry. See the rationale on `storePayload`.
  */
 export function getPayload(
   payloads: PayloadMap,

--- a/src/background/redux/vault/reducer.test.ts
+++ b/src/background/redux/vault/reducer.test.ts
@@ -452,21 +452,29 @@ describe('vault reducer', () => {
       expect(s.eip712ById).toEqual({ other: 'keep', same: 'fresh' });
     });
 
-    // Measured, not assumed. `__proto__` never reaches here in production —
-    // `handleSdkMethod` rejects it at the message boundary for every approval
-    // type (sdk-methods.ts, `isStorableRequestId`) — but the reducer must be
-    // safe on its own: immer's copy ASSIGNS the returned object's keys, and
-    // assigning a string to `__proto__` is a silent no-op, so the entry is
-    // dropped rather than stored, and the map's prototype is untouched.
-    it('drops a __proto__ payload without touching the prototype', () => {
+    // Asserted on what the reducer owns, so a `target` bump cannot move it.
+    // `tsconfig.json` is es2017 today, which emits the spread as `Object.assign`
+    // and makes `__proto__` run the setter rather than add an entry; at es2018
+    // the native spread would store it as an own property instead. Either way
+    // `storePayload` refuses the id, so the map stays empty and keeps its
+    // prototype — and `getPayload` agrees with the map about both.
+    //
+    // The object case is not a variation for its own sake: the deploy path
+    // dispatches `JSON.parse(...)`, i.e. an object, into a map declared
+    // `Record<string, string>` (sdk-methods.ts), and an object value is what
+    // makes the setter actually replace this map's prototype.
+    it.each([
+      ['a string', 'poison'],
+      ['an object, as the deploy path dispatches', { poisoned: true }]
+    ])('refuses a __proto__ payload carrying %s', (_label, json) => {
       const s = reducer(
         initialState,
-        deployPayloadReceived({ id: '__proto__', json: 'poison' })
+        deployPayloadReceived({ id: '__proto__', json: json as string })
       );
 
       expect(Object.keys(s.jsonById)).toEqual([]);
       expect(Object.getPrototypeOf(s.jsonById)).toBe(Object.prototype);
-      expect(({} as Record<string, unknown>).poison).toBeUndefined();
+      expect(getPayload(s.jsonById, '__proto__')).toBeUndefined();
     });
 
     // The ceiling must never cost an ALREADY STORED request its payload: the

--- a/src/background/redux/vault/reducer.test.ts
+++ b/src/background/redux/vault/reducer.test.ts
@@ -22,6 +22,7 @@ import {
   vaultLoaded,
   vaultReseted
 } from './actions';
+import { getPayload } from './payload-map';
 import { MAX_STORED_PAYLOADS, reducer } from './reducer';
 import { VaultState } from './types';
 
@@ -451,46 +452,77 @@ describe('vault reducer', () => {
       expect(s.eip712ById).toEqual({ other: 'keep', same: 'fresh' });
     });
 
-    it('evicts the oldest entries past MAX_STORED_PAYLOADS', () => {
-      const overflowing = Array.from(
-        { length: MAX_STORED_PAYLOADS + 1 },
-        (_, i) => `id-${i}`
+    // Measured, not assumed. `__proto__` never reaches here in production —
+    // `handleSdkMethod` rejects it at the message boundary for every approval
+    // type (sdk-methods.ts, `isStorableRequestId`) — but the reducer must be
+    // safe on its own: immer's copy ASSIGNS the returned object's keys, and
+    // assigning a string to `__proto__` is a silent no-op, so the entry is
+    // dropped rather than stored, and the map's prototype is untouched.
+    it('drops a __proto__ payload without touching the prototype', () => {
+      const s = reducer(
+        initialState,
+        deployPayloadReceived({ id: '__proto__', json: 'poison' })
       );
 
-      const s = overflowing.reduce(
-        (state, id) =>
-          reducer(
-            reducer(state, deployPayloadReceived({ id, json: `d-${id}` })),
-            eip712PayloadReceived({ id, json: `e-${id}` })
-          ),
-        initialState
-      );
-
-      expect(Object.keys(s.jsonById)).toHaveLength(MAX_STORED_PAYLOADS);
-      expect(Object.keys(s.eip712ById)).toHaveLength(MAX_STORED_PAYLOADS);
-      expect(s.jsonById['id-0']).toBeUndefined();
-      expect(s.eip712ById['id-0']).toBeUndefined();
-      expect(s.jsonById[`id-${MAX_STORED_PAYLOADS}`]).toBe(
-        `d-id-${MAX_STORED_PAYLOADS}`
-      );
-      expect(s.eip712ById[`id-${MAX_STORED_PAYLOADS}`]).toBe(
-        `e-id-${MAX_STORED_PAYLOADS}`
-      );
+      expect(Object.keys(s.jsonById)).toEqual([]);
+      expect(Object.getPrototypeOf(s.jsonById)).toBe(Object.prototype);
+      expect(({} as Record<string, unknown>).poison).toBeUndefined();
     });
 
-    // Re-writing an existing key keeps its original insertion position, so a
-    // refreshed payload must NOT be treated as the newest one by the FIFO
-    // eviction above — otherwise a long-lived request could outlive a newer one.
-    it('does not move an entry to the back of the queue on rewrite', () => {
-      const seeded: VaultState = {
+    // The ceiling must never cost an ALREADY STORED request its payload: the
+    // oldest entry is the long-lived one — a request being confirmed on a
+    // Ledger while a page pushes a burst of its own — and dropping it would
+    // reproduce, behind a threshold, exactly the failure this reducer fixes.
+    describe('at MAX_STORED_PAYLOADS', () => {
+      const atCapacity = (map: 'jsonById' | 'eip712ById'): VaultState => ({
         ...initialState,
-        jsonById: { first: 'a', second: 'b' }
-      };
-      const s = reducer(
-        seeded,
-        deployPayloadReceived({ id: 'first', json: 'a2' })
-      );
-      expect(Object.keys(s.jsonById)).toEqual(['first', 'second']);
+        [map]: Object.fromEntries(
+          Array.from({ length: MAX_STORED_PAYLOADS }, (_, i) => [
+            `id-${i}`,
+            `json-${i}`
+          ])
+        )
+      });
+
+      it.each([
+        ['jsonById', deployPayloadReceived] as const,
+        ['eip712ById', eip712PayloadReceived] as const
+      ])('refuses an incoming %s write instead of evicting', (map, action) => {
+        const full = atCapacity(map);
+
+        const s = reducer(full, action({ id: 'incoming', json: 'refused' }));
+
+        expect(s[map]).toEqual(full[map]);
+        expect(Object.keys(s[map])).toHaveLength(MAX_STORED_PAYLOADS);
+        expect(s[map]['id-0']).toBe('json-0');
+        expect(s[map].incoming).toBeUndefined();
+      });
+
+      it.each([
+        ['jsonById', deployPayloadReceived] as const,
+        ['eip712ById', eip712PayloadReceived] as const
+      ])('still applies a rewrite of an id already in %s', (map, action) => {
+        const full = atCapacity(map);
+
+        const s = reducer(full, action({ id: 'id-0', json: 'refreshed' }));
+
+        expect(s[map]['id-0']).toBe('refreshed');
+        expect(Object.keys(s[map])).toHaveLength(MAX_STORED_PAYLOADS);
+      });
+
+      // A burst answering one request must hand the freed slot to the next
+      // write, or the refusal above would be permanent rather than a ceiling.
+      it('accepts a new payload once an answered request frees a slot', () => {
+        const full = atCapacity('jsonById');
+
+        const s = reducer(
+          reducer(full, windowRequestResponded({ requestId: 'id-3' })),
+          deployPayloadReceived({ id: 'incoming', json: 'accepted' })
+        );
+
+        expect(s.jsonById.incoming).toBe('accepted');
+        expect(s.jsonById['id-3']).toBeUndefined();
+      });
     });
   });
 
@@ -521,6 +553,38 @@ describe('vault reducer', () => {
       );
       expect(s.eip712ById).toEqual({ other: 'kept' });
     });
+
+    // `requestId` is dapp-controlled, so an id naming an inherited
+    // Object.prototype member must be answered from OWN properties only — the
+    // same reason windowManagement/request-map.ts exists, on the same key space.
+    it.each(['toString', 'constructor', 'valueOf', 'hasOwnProperty'])(
+      'drops a stored payload under the inherited name %s',
+      key => {
+        const seeded = reducer(
+          initialState,
+          deployPayloadReceived({ id: key, json: 'stored' })
+        );
+        expect(getPayload(seeded.jsonById, key)).toBe('stored');
+
+        const s = reducer(seeded, windowRequestResponded({ requestId: key }));
+
+        expect(getPayload(s.jsonById, key)).toBeUndefined();
+      }
+    );
+
+    it.each(['toString', 'constructor', 'valueOf', 'hasOwnProperty'])(
+      'leaves the map alone for an unstored inherited name %s',
+      key => {
+        const state: VaultState = {
+          ...initialState,
+          jsonById: { other: 'kept' }
+        };
+
+        expect(reducer(state, windowRequestResponded({ requestId: key }))).toBe(
+          state
+        );
+      }
+    );
 
     // Every `windows.onRemoved` in the browser can reach this reducer, and the
     // store subscriber does no state-change comparison: a fresh object means a

--- a/src/background/redux/vault/reducer.test.ts
+++ b/src/background/redux/vault/reducer.test.ts
@@ -1,3 +1,5 @@
+import { windowRequestResponded } from '@background/redux/windowManagement/actions';
+
 import {
   accountAdded,
   accountDisconnected,
@@ -20,7 +22,7 @@ import {
   vaultLoaded,
   vaultReseted
 } from './actions';
-import { reducer } from './reducer';
+import { MAX_STORED_PAYLOADS, reducer } from './reducer';
 import { VaultState } from './types';
 
 // Compact fixture — never real key material.
@@ -400,22 +402,138 @@ describe('vault reducer', () => {
 
   // 16
   describe('deployPayloadReceived / eip712PayloadReceived', () => {
-    it('replaces the whole jsonById dict with a single-entry dict', () => {
+    // The regression WALLET-1384 is about: these used to build a NEW
+    // single-entry dict, so a second request erased the first one's payload.
+    // `cancelRequestsDisplacedBy` spares a request another window still shows
+    // (the Ledger permission window), so that survivor stayed 'open' on screen
+    // with no transaction to sign.
+    it('keeps an earlier deploy payload when a second request arrives', () => {
       const state: VaultState = {
         ...initialState,
-        jsonById: { old: 'x' }
+        jsonById: { first: 'json-first' }
       };
-      const s = reducer(state, deployPayloadReceived({ id: 'new', json: 'j' }));
-      expect(s.jsonById).toEqual({ new: 'j' });
+      const s = reducer(
+        state,
+        deployPayloadReceived({ id: 'second', json: 'json-second' })
+      );
+      expect(s.jsonById).toEqual({
+        first: 'json-first',
+        second: 'json-second'
+      });
     });
 
-    it('replaces the whole eip712ById dict with a single-entry dict', () => {
+    it('keeps an earlier eip712 payload when a second request arrives', () => {
       const state: VaultState = {
         ...initialState,
-        eip712ById: { old: 'x' }
+        eip712ById: { first: 'eip-first' }
       };
-      const s = reducer(state, eip712PayloadReceived({ id: 'new', json: 'j' }));
-      expect(s.eip712ById).toEqual({ new: 'j' });
+      const s = reducer(
+        state,
+        eip712PayloadReceived({ id: 'second', json: 'eip-second' })
+      );
+      expect(s.eip712ById).toEqual({
+        first: 'eip-first',
+        second: 'eip-second'
+      });
+    });
+
+    it('overwrites only its own entry when the same id is sent twice', () => {
+      const state: VaultState = {
+        ...initialState,
+        jsonById: { other: 'keep', same: 'stale' },
+        eip712ById: { other: 'keep', same: 'stale' }
+      };
+      const s = reducer(
+        reducer(state, deployPayloadReceived({ id: 'same', json: 'fresh' })),
+        eip712PayloadReceived({ id: 'same', json: 'fresh' })
+      );
+      expect(s.jsonById).toEqual({ other: 'keep', same: 'fresh' });
+      expect(s.eip712ById).toEqual({ other: 'keep', same: 'fresh' });
+    });
+
+    it('evicts the oldest entries past MAX_STORED_PAYLOADS', () => {
+      const overflowing = Array.from(
+        { length: MAX_STORED_PAYLOADS + 1 },
+        (_, i) => `id-${i}`
+      );
+
+      const s = overflowing.reduce(
+        (state, id) =>
+          reducer(
+            reducer(state, deployPayloadReceived({ id, json: `d-${id}` })),
+            eip712PayloadReceived({ id, json: `e-${id}` })
+          ),
+        initialState
+      );
+
+      expect(Object.keys(s.jsonById)).toHaveLength(MAX_STORED_PAYLOADS);
+      expect(Object.keys(s.eip712ById)).toHaveLength(MAX_STORED_PAYLOADS);
+      expect(s.jsonById['id-0']).toBeUndefined();
+      expect(s.eip712ById['id-0']).toBeUndefined();
+      expect(s.jsonById[`id-${MAX_STORED_PAYLOADS}`]).toBe(
+        `d-id-${MAX_STORED_PAYLOADS}`
+      );
+      expect(s.eip712ById[`id-${MAX_STORED_PAYLOADS}`]).toBe(
+        `e-id-${MAX_STORED_PAYLOADS}`
+      );
+    });
+
+    // Re-writing an existing key keeps its original insertion position, so a
+    // refreshed payload must NOT be treated as the newest one by the FIFO
+    // eviction above — otherwise a long-lived request could outlive a newer one.
+    it('does not move an entry to the back of the queue on rewrite', () => {
+      const seeded: VaultState = {
+        ...initialState,
+        jsonById: { first: 'a', second: 'b' }
+      };
+      const s = reducer(
+        seeded,
+        deployPayloadReceived({ id: 'first', json: 'a2' })
+      );
+      expect(Object.keys(s.jsonById)).toEqual(['first', 'second']);
+    });
+  });
+
+  // 16b — the per-request cleanup. Without it the maps only ever shrink on
+  // `deploysReseted`, and `lockVaultSaga` flushes the cipher BEFORE that reset,
+  // so `vaultLoaded` restores every stale payload on the next unlock.
+  describe('windowRequestResponded', () => {
+    it('drops the answered request from jsonById and leaves the rest', () => {
+      const state: VaultState = {
+        ...initialState,
+        jsonById: { answered: 'gone', other: 'kept' }
+      };
+      const s = reducer(
+        state,
+        windowRequestResponded({ requestId: 'answered' })
+      );
+      expect(s.jsonById).toEqual({ other: 'kept' });
+    });
+
+    it('drops the answered request from eip712ById and leaves the rest', () => {
+      const state: VaultState = {
+        ...initialState,
+        eip712ById: { answered: 'gone', other: 'kept' }
+      };
+      const s = reducer(
+        state,
+        windowRequestResponded({ requestId: 'answered' })
+      );
+      expect(s.eip712ById).toEqual({ other: 'kept' });
+    });
+
+    // Every `windows.onRemoved` in the browser can reach this reducer, and the
+    // store subscriber does no state-change comparison: a fresh object means a
+    // popupState broadcast to every replica plus a full storage.local rewrite.
+    it('returns the same state object when the id is in neither map', () => {
+      const state: VaultState = {
+        ...initialState,
+        jsonById: { other: 'kept' },
+        eip712ById: { other: 'kept' }
+      };
+      expect(
+        reducer(state, windowRequestResponded({ requestId: 'unknown' }))
+      ).toBe(state);
     });
   });
 

--- a/src/background/redux/vault/reducer.ts
+++ b/src/background/redux/vault/reducer.ts
@@ -1,13 +1,56 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
+import { windowRequestResponded } from '@background/redux/windowManagement/actions';
+
 import { CasperWalletSupports } from '@content/sdk-types';
 
 import { SecretPhrase } from '@libs/crypto';
 import { Account } from '@libs/types/account';
 
+import { getPayload } from './payload-map';
 import { VaultState } from './types';
 
 type State = VaultState;
+
+/**
+ * Ceiling on `jsonById` / `eip712ById`.
+ *
+ * Both maps are cleared per request by the `windowRequestResponded` case in
+ * `extraReducers` below — but a deletion can be MISSED. An MV3 service-worker
+ * restart wipes `windowManagement.requests` (in-memory only) while these maps
+ * come back from the encrypted cipher through `vaultLoaded`, so the response
+ * for a pre-restart id can never arrive. Nothing else deletes a key:
+ * `deploysReseted` is a full-slice reset dispatched on lock, and `lockVaultSaga`
+ * flushes `updateVaultCipher` BEFORE it, so a leaked payload is re-loaded on the
+ * next unlock and lives in `storage.local` for good — while riding along in
+ * every popup-state broadcast, since `selectPopupState` sends `vault` whole.
+ *
+ * Ten is far above real concurrency (one approval window means 1-2 in-flight
+ * requests) and far below anything that costs memory.
+ */
+export const MAX_STORED_PAYLOADS = 10;
+
+type PayloadMap = State['jsonById'];
+
+// Insertion order = the order requests first stored a payload, since re-writing
+// an existing key keeps its original position — so the FIFO eviction below drops
+// the request that has been waiting longest, not one that merely refreshed.
+function storePayload(
+  payloads: PayloadMap,
+  requestId: string,
+  json: string
+): PayloadMap {
+  const next: PayloadMap = { ...payloads, [requestId]: json };
+
+  const overflow = Object.keys(next).length - MAX_STORED_PAYLOADS;
+  if (overflow > 0) {
+    for (const staleId of Object.keys(next).slice(0, overflow)) {
+      delete next[staleId];
+    }
+  }
+
+  return next;
+}
 
 const initialState: State = {
   secretPhrase: null,
@@ -277,19 +320,25 @@ const slice = createSlice({
       })
     }),
     deploysReseted: (): State => initialState,
+    // Merged, not replaced. Building a new single-entry dict here erased the
+    // payload of every other in-flight request — and since #1427 a request can
+    // legitimately outlive the window that displaced it: `cancelRequestsDisplacedBy`
+    // spares one that another window still shows (the Ledger permission window
+    // carries the same requestId). That survivor stayed 'open' on screen with
+    // nothing to sign, because its transaction JSON had just been dropped here.
     deployPayloadReceived: (
       state,
       { payload }: PayloadAction<{ id: string; json: string }>
     ): State => ({
       ...state,
-      jsonById: { [payload.id]: payload.json }
+      jsonById: storePayload(state.jsonById, payload.id, payload.json)
     }),
     eip712PayloadReceived: (
       state,
       { payload }: PayloadAction<{ id: string; json: string }>
     ): State => ({
       ...state,
-      eip712ById: { [payload.id]: payload.json }
+      eip712ById: storePayload(state.eip712ById, payload.id, payload.json)
     }),
     hideAccountFromListChanged: (
       state,
@@ -328,6 +377,40 @@ const slice = createSlice({
         activeAccountName: account.name
       };
     }
+  },
+  // The payload maps are bounded by the request lifecycle, not by a timer: a
+  // request that has been answered — signed, cancelled, superseded, or failed
+  // before its window opened — will never be read again, and every one of those
+  // paths funnels through `windowRequestResponded`.
+  //
+  // Keyed off the ACTION, not off `windowManagement`'s resulting state: that
+  // reducer no-ops the transition unless the request is currently 'open', which
+  // is exactly the orphan case (an MV3 restart between registration and the
+  // response) where a stale payload most needs dropping.
+  extraReducers: builder => {
+    builder.addCase(
+      windowRequestResponded,
+      (state, { payload: { requestId } }): State => {
+        if (
+          getPayload(state.jsonById, requestId) == null &&
+          getPayload(state.eip712ById, requestId) == null
+        ) {
+          // Same reasoning as the `displaced.length > 0` gate in
+          // cancel-requests.ts: the store subscriber compares nothing, so a new
+          // state object costs a popupState broadcast to every replica plus a
+          // full storage.local rewrite.
+          return state;
+        }
+
+        const jsonById = { ...state.jsonById };
+        const eip712ById = { ...state.eip712ById };
+
+        delete jsonById[requestId];
+        delete eip712ById[requestId];
+
+        return { ...state, jsonById, eip712ById };
+      }
+    );
   }
 });
 

--- a/src/background/redux/vault/reducer.ts
+++ b/src/background/redux/vault/reducer.ts
@@ -26,30 +26,47 @@ type State = VaultState;
  * every popup-state broadcast, since `selectPopupState` sends `vault` whole.
  *
  * Ten is far above real concurrency (one approval window means 1-2 in-flight
- * requests) and far below anything that costs memory.
+ * requests) and far below anything that costs memory. See `storePayload` for
+ * which write loses when the ceiling is reached, and why it is the incoming one.
  */
 export const MAX_STORED_PAYLOADS = 10;
 
 type PayloadMap = State['jsonById'];
 
-// Insertion order = the order requests first stored a payload, since re-writing
-// an existing key keeps its original position — so the FIFO eviction below drops
-// the request that has been waiting longest, not one that merely refreshed.
+// At capacity the INCOMING write is refused; nothing already stored is evicted.
+//
+// The obvious alternative — make room by dropping the oldest entry — puts the
+// loss on the request that has waited longest, which is exactly the one this
+// fix exists to protect: a request the user is confirming on a Ledger while a
+// page pushes ten more. `signRequest` has no connected-site precondition, the
+// message handlers are concurrent, and a supersede only frees a slot after
+// `windows.create` plus `CANCEL_GRACE_MS`, so a burst lands entirely before any
+// `windowRequestResponded` can. Refusing instead puts the loss on the request
+// the caller controls.
+//
+// A rewrite of an id already present is always applied — it cannot grow the map.
+//
+// Residual, accepted: entries leak when a request is never answered at all
+// (auto-lock while an approval window is open, then the MV3 worker dies with no
+// `windows.onRemoved` handler alive to cancel it). Leaks survive lock/unlock,
+// because `lockVaultSaga` flushes the cipher before `deploysReseted` and
+// `vaultLoaded` restores from it — so enough of them would fill the map and
+// refuse every later payload. That needs `MAX_STORED_PAYLOADS` such events on
+// one profile; reclaiming those slots means reconciling the map against the
+// windows actually open, which is a separate change.
 function storePayload(
   payloads: PayloadMap,
   requestId: string,
   json: string
 ): PayloadMap {
-  const next: PayloadMap = { ...payloads, [requestId]: json };
-
-  const overflow = Object.keys(next).length - MAX_STORED_PAYLOADS;
-  if (overflow > 0) {
-    for (const staleId of Object.keys(next).slice(0, overflow)) {
-      delete next[staleId];
-    }
+  if (
+    Object.keys(payloads).length >= MAX_STORED_PAYLOADS &&
+    getPayload(payloads, requestId) == null
+  ) {
+    return payloads;
   }
 
-  return next;
+  return { ...payloads, [requestId]: json };
 }
 
 const initialState: State = {

--- a/src/background/redux/vault/reducer.ts
+++ b/src/background/redux/vault/reducer.ts
@@ -1,6 +1,7 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import { windowRequestResponded } from '@background/redux/windowManagement/actions';
+import { isStorableRequestId } from '@background/redux/windowManagement/request-map';
 
 import { CasperWalletSupports } from '@content/sdk-types';
 
@@ -33,6 +34,21 @@ export const MAX_STORED_PAYLOADS = 10;
 
 type PayloadMap = State['jsonById'];
 
+// `__proto__` is refused outright, for the reason `isStorableRequestId` was
+// written: the map is built by assignment, and assigning `__proto__` runs the
+// setter instead of adding an entry. `tsconfig.json` targets es2017, so
+// `{ ...payloads, [requestId]: json }` is EMITTED as nested `Object.assign` —
+// with a string value that setter is a silent no-op, but the deploy path
+// dispatches a parsed OBJECT (see the note on `deployPayloadReceived`), and an
+// object value sets this map's prototype for every later lookup. Relying on the
+// emit would also make the guarantee a `target` setting: at es2018 the spread is
+// native and the computed key becomes an own property instead. The guard states
+// it here so neither the toolchain nor the value type can move it.
+//
+// Not reachable today either — `handleSdkMethod` rejects that id at the message
+// boundary for every approval type — but the two guards answer to different
+// owners, and this map is the one at risk.
+//
 // At capacity the INCOMING write is refused; nothing already stored is evicted.
 //
 // The obvious alternative — make room by dropping the oldest entry — puts the
@@ -46,19 +62,32 @@ type PayloadMap = State['jsonById'];
 //
 // A rewrite of an id already present is always applied — it cannot grow the map.
 //
-// Residual, accepted: entries leak when a request is never answered at all
-// (auto-lock while an approval window is open, then the MV3 worker dies with no
-// `windows.onRemoved` handler alive to cancel it). Leaks survive lock/unlock,
-// because `lockVaultSaga` flushes the cipher before `deploysReseted` and
-// `vaultLoaded` restores from it — so enough of them would fill the map and
-// refuse every later payload. That needs `MAX_STORED_PAYLOADS` such events on
-// one profile; reclaiming those slots means reconciling the map against the
-// windows actually open, which is a separate change.
+// Residual, accepted: a payload leaks whenever its deletion never reaches the
+// cipher. Two routes, not one — the request is never answered at all (auto-lock
+// while an approval window is open, then the MV3 worker dies with no
+// `windows.onRemoved` handler alive to cancel it), or it IS answered and the
+// worker dies inside the 500ms re-encrypt debounce that would have persisted
+// the deletion. Either way the entry outlives lock/unlock, because
+// `lockVaultSaga` flushes the cipher before `deploysReseted` and `vaultLoaded`
+// restores from it, so enough of them fill the map and refuse every later
+// payload.
+//
+// That state has an exit, and it is worth writing down because nothing in the
+// UI points at it: `vaultLoaded` keeps the IN-MEMORY map whenever it is
+// non-empty and discards the cipher's. `signRequest` has no lock gate, so one
+// request arriving while the vault is locked writes the only entry there is —
+// lock, let a dapp send one request, unlock, and the accumulated entries are
+// gone. Reclaiming the slots without that sequence means reconciling the map
+// against the windows actually open, which is a separate change.
 function storePayload(
   payloads: PayloadMap,
   requestId: string,
   json: string
 ): PayloadMap {
+  if (!isStorableRequestId(requestId)) {
+    return payloads;
+  }
+
   if (
     Object.keys(payloads).length >= MAX_STORED_PAYLOADS &&
     getPayload(payloads, requestId) == null

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -417,6 +417,11 @@ export const ErrorMessages = {
       message: 'Unsupported Target Type',
       description:
         'The target provided in the transfer data is neither an AccountHash nor a PublicKey. Ensure the target type is valid.'
+    },
+    REQUEST_NO_LONGER_AVAILABLE: {
+      message: 'Signature Request No Longer Available',
+      description:
+        'The data for this signature request is no longer available, so it cannot be signed. Please make the request again from the application.'
     }
   },
   decryptMessage: {


### PR DESCRIPTION
[WALLET-1384](https://make-software.atlassian.net/browse/WALLET-1384)

> **Regression already on `release/2.7.0`.** Base is `release/2.7.0`, not `develop`. If the release branch goes to QA before this merges, the bug is reproducible on the build.

## The bug

`deployPayloadReceived` / `eip712PayloadReceived` built a **new single-entry dict**, so `jsonById` and `eip712ById` never held more than one request. Every new signature request erased the payload of whatever else was in flight.

```ts
// src/background/redux/vault/reducer.ts — before
jsonById: { [payload.id]: payload.json }     // replace, not merge
eip712ById: { [payload.id]: payload.json }
```

The `replace` semantics is old (predates 2.7.0). What made it a live defect is #1427: `cancelRequestsDisplacedBy` now deliberately **spares a request another window still displays** —

```ts
const candidates = displaced.filter(r => r.windowIds.length === 1);
```

— and the one thing that attaches a second window is the Ledger permission window, which carries the same `requestId` (`use-ledger.ts` → `registerLedgerPermissionWindow`). Before #1427 (#1419 / WALLET-1353) every displaced request was cancelled, so no survivor existed.

### Reproduction (Chrome, Ledger account)

1. Dapp calls `sign` — request **A**. Approval window opens.
2. Ledger asks for device permission → a **second** window opens for A; `A.windowIds.length === 2`.
3. Dapp calls `sign` again — request **B**. `sdk-methods.ts` synchronously dispatches `deployPayloadReceived({ id: B })`, wiping A's payload.
4. `openWindow` reuses the main window → after the 250 ms grace, A still has another window → **A is not cancelled** (by design).
5. A's Ledger window re-renders: `deployJsonById['A']` is `undefined` → `useFetchDataForSignatureRequest` stays `enabled: false` → `transaction` never parses → `handleSign` returns on `if (!transaction)`.

**Result:** a live, uncancelled request on screen that cannot be signed. The button silently does nothing and the dapp promise hangs until its own 30-minute timeout.

## The fix

**Merge instead of replace**, and **delete the entry once the request is answered**.

The cleanup keys off the `windowRequestResponded` **action**, not off windowManagement's resulting state: that reducer no-ops the transition unless the request is currently `'open'`, which is precisely the orphan case (an MV3 restart between registration and the response) where a stale payload most needs dropping. When the id is in neither map the **same state object** is returned — otherwise an unrelated `windows.onRemoved` would cost a popupState broadcast to every replica plus a full `storage.local` rewrite (same reasoning as the `displaced.length > 0` gate in `cancel-requests.ts`).

The deletion is also added to the `updateVaultCipher` debounce list, where both payload **writes** already are. Without it the deletion is an in-memory edit only: an MV3 service-worker restart before the next vault write resurrects the entry through `vaultLoaded`, for a requestId whose `windowRequestResponded` has already fired. Most responses carry no payload entry, so this usually re-encrypts an unchanged vault — at ~2 ms behind a 500 ms debounce, cheaper than persisting writes but not deletes.

### The ceiling, and which write loses

A deletion can still be missed. An MV3 service-worker restart wipes `windowManagement.requests` (in-memory only) while the payload maps come back from the encrypted cipher through `vaultLoaded`, so the response for a pre-restart id can never arrive. And nothing else deletes a key: the only other clear is `deploysReseted`, a **full-slice reset**, and `lockVaultSaga` flushes `updateVaultCipher` **before** it — so the payload is already in the cipher and `vaultLoaded` restores it on the next unlock. A leaked entry therefore survives lock/unlock, lives in `storage.local` for good, and rides along in every popup-state broadcast (`selectPopupState` sends `vault` whole). Hence `MAX_STORED_PAYLOADS = 10`.

At capacity the **incoming** write is refused; nothing already stored is evicted. Making room by dropping the oldest entry would put the loss on the request that has waited longest — exactly the one this PR protects, a request being confirmed on a Ledger while a page pushes ten more of its own. `signRequest` has no connected-site precondition, the message handlers are concurrent, and a supersede only frees a slot after `windows.create` plus `CANCEL_GRACE_MS`, so a burst lands in full before any `windowRequestResponded` can. Refusing puts the loss on the request the caller controls. A rewrite of an id already stored still applies, since it cannot grow the map.

Residual and accepted, documented at the decision. A payload leaks whenever its deletion never reaches the cipher, by two routes rather than one: the request is never answered at all (auto-lock while an approval window is open, then the MV3 worker dies with no `windows.onRemoved` handler alive to cancel it), or it **is** answered and the worker dies inside the 500 ms re-encrypt debounce that would have persisted the deletion. Either way the entry outlives lock/unlock, so enough of them fill the map and refuse every later payload.

That state has an exit, written down because nothing in the UI points at it: `vaultLoaded` keeps the in-memory map whenever it is non-empty and discards the cipher's, and `signRequest` has no lock gate — so lock, let a dapp send one request, unlock, and the accumulated entries are gone. Reclaiming the slots without that sequence means reconciling the map against the windows actually open, which is a separate change.

### Prototype-chain reads

Both maps are keyed by `requestId`, which is page-generated (`generateRequestId`, `src/content/sdk.ts`) i.e. dapp-controlled, and both read sites indexed them bare. A request id of `constructor` handed the signature page an inherited `Object.prototype` member instead of transaction JSON, surfacing as `INVALID_TRANSACTION_JSON` for a request the store never held a payload for.

New `vault/payload-map.ts` → `getPayload()`, mirroring `getRequest` in `windowManagement/request-map.ts`, which exists for the same reason on the same key space.

`__proto__` is a separate case, and the write side is now guarded explicitly rather than left to the shape of the write. `tsconfig.json` targets **es2017**, so `{ ...payloads, [id]: json }` is *emitted* as nested `Object.assign` — assignment runs the `__proto__` setter instead of adding an entry:

| | string value | **object** value |
| --- | --- | --- |
| es2017 (`Object.assign`) | silent no-op, entry dropped | **sets the map's prototype** |
| es2018+ (native spread) | own property | own property |

Both of those matter here. The deploy path dispatches an **object** — `sdk-methods.ts` puts `JSON.parse(...)` into a map declared `Record<string, string>` — which is the column that replaces the prototype rather than no-opping. And resting on the emit would make the guarantee a `target` setting. So `storePayload` refuses the id through `isStorableRequestId`; the test carries both value types, and the object case is the one that fails without the guard. Still unreachable in production, since `handleSdkMethod` rejects that id at the message boundary for every approval type — but the two guards answer to different owners, and this map is the one at risk.

### Rendering and gating with no payload

`sign-transaction` guarded its loading branch on `isLoadingSignatureRequest` alone — the query's `isFetching`, which is `false` for a **disabled** query — while both content children below it are guarded on `signatureRequest`. With the payload gone the page therefore rendered an empty pane. Per-request deletion makes that state routine rather than hypothetical, so the branch now carries a `!signatureRequest` term.

`LedgerEventView` is excluded from that term. It is guarded on `signingPageState` alone, carries no `signatureRequest`, and is the only thing the Ledger permission window — the second window, the one that survives a supersede — has to show while the device is being read. Replacing it with a skeleton would blank exactly the screen this fix protects.

The Sign button was gated on `transaction`, local state parsed once and kept, so it stayed enabled over that pane. `!signatureRequest` mirrors the eip712 page. A second click was already dropped by the background response dedup, so nothing reached the dapp, but on the Ledger path it could re-prompt the device for a signature that is then discarded.

## Tests

Two existing tests pinned the buggy behaviour (`replaces the whole jsonById dict with a single-entry dict` and its eip712 twin) and were replaced. Every new test was confirmed red against the code it pins.

- an earlier payload survives a second request (both maps)
- the same id sent twice overwrites only its own entry
- at capacity: the incoming write is refused, a rewrite of a stored id still applies, and a slot freed by an answered request is reusable
- `windowRequestResponded` drops the answered id from both maps and leaves the rest; an id in neither returns the identical state object (`toBe`)
- the four inherited `Object.prototype` names, in both directions, mirroring `windowManagement/reducer.test.ts`; plus `__proto__` with both a string and an object value, asserted on what the reducer owns (empty map, prototype intact, `getPayload` agreeing) so a `target` bump cannot reverse it
- `vault-sagas.test.ts`: the deletion reaches the cipher — driven through the real vault reducer with `withReducer` and asserted on the maps handed to `encryptVault`. Verified red both ways: without the `extraReducers` block, and without the debounce-list entry.
- `payload-map.test.ts`: own keys, missing keys, all five inherited names, and an own key shadowing an inherited name

## Verification

- `npm run ci-check` — green (format, lint, tsc, knip, 542 tests). `redux/vault/reducer.ts` stays at 100% across all four metrics.
- `npm run dependency:circular` — 141 cycles before and after; the new `vault → windowManagement/actions` edge adds none (`windowManagement/{actions,reducer,types,request-map}.ts` import nothing from `vault`).
- `npm run lint` — 171 warnings before and after.
- No new action creator, so `FORWARDED_ACTION_TYPES` and `redux-actions.parity.test.ts` are untouched.

## Known gap

Neither `getPayload` call site nor the disabled direction of the Sign gate is covered: `jest.config.js` sets `testEnvironment: 'node'`, there is no React component test in the repo, and `src/apps/**` is outside `collectCoverageFrom`. Closing it means adding jsdom + Testing Library — infrastructure worth its own ticket rather than this PR.

## Out of scope (noted, separate tickets)

- `sdk-methods.ts` stores the **parsed object** in `jsonById` despite the declared `json: string` — it compiles only because `let deployJson;` is an implicit `any`. This makes `getPayload`'s `string | undefined` return type a runtime lie for the deploy map; it works because `Transaction.fromJSON` accepts objects.
- A refused payload still opens an approval window, so the dapp learns nothing until its own timeout. Rejecting the SDK request at the boundary when the map is full would give it a real error.
- `deploysReseted` is effectively a duplicate of `vaultReseted`; the name does not say so.

[WALLET-1384]: https://make-software.atlassian.net/browse/WALLET-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
