### PR TITLE
fix: WALLET-1391 — report and time out an untracked export window, and scope the Ledger close listener to its own window (WALLET-1389)

### DIFF
--- a/src/background/redux/sagas/export-keys-window-saga.test.ts
+++ b/src/background/redux/sagas/export-keys-window-saga.test.ts
@@ -1,6 +1,7 @@
 import * as matchers from 'redux-saga-test-plan/matchers';
 import { expectSaga } from 'redux-saga-test-plan';
-import { throwError } from 'redux-saga-test-plan/providers';
+import { dynamic, throwError } from 'redux-saga-test-plan/providers';
+import { CallEffectDescriptor } from 'redux-saga/effects';
 import { windows } from 'webextension-polyfill';
 
 import {
@@ -11,9 +12,11 @@ import {
   exportKeysWindowIdChanged,
   exportKeysWindowIdCleared
 } from '@background/redux/windowManagement/actions';
+import { selectExportKeysWindowId } from '@background/redux/windowManagement/selectors';
 
 import { openExportKeysWindow } from './actions';
 import {
+  WINDOWS_API_TIMEOUT_MS,
   exportKeysWindowSaga,
   openExportKeysWindowSaga
 } from './export-keys-window-saga';
@@ -23,7 +26,8 @@ jest.mock('webextension-polyfill', () => ({
     getAll: jest.fn(),
     getCurrent: jest.fn(),
     update: jest.fn(),
-    create: jest.fn()
+    create: jest.fn(),
+    remove: jest.fn()
   }
 }));
 
@@ -42,6 +46,12 @@ const countPutsOfType = (allEffects: unknown, type: string) =>
   ).length;
 
 describe('openExportKeysWindowSaga', () => {
+  // The worker is spawned detached, so a test that abandons one leaks its real
+  // windows.* invocations into whatever runs next. Counts must start at zero.
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   const currentWindow = {
     id: 1,
     state: 'normal',
@@ -170,6 +180,14 @@ describe('openExportKeysWindowSaga', () => {
         .not.put.actionType(exportKeysWindowIdCleared.type)
         .run();
 
+      // Exactly one argument. The saga deliberately does not log `created`:
+      // a Windows.Window can carry tabs[].url, which here is the
+      // download-account-keys route. Nothing else in the tree pins that
+      // redaction, so a later "improvement" to console.error(msg, created)
+      // would otherwise ship green.
+      expect(consoleError).toHaveBeenCalledWith(
+        'openExportKeysWindowSaga: the export window resolved without an id'
+      );
       expect(countPutsOfType(allEffects, sagaError.type)).toBe(1);
     } finally {
       consoleError.mockRestore();
@@ -208,28 +226,95 @@ describe('openExportKeysWindowSaga', () => {
     }
   });
 
-  it('reports a timeout instead of leaving the menu item inert', async () => {
+  it('closes a window that arrives after another one was already tracked', async () => {
     const consoleError = jest
       .spyOn(console, 'error')
       .mockImplementation(() => {});
 
     try {
-      // A static `race` provider settles the race deterministically. Letting
-      // the real delay run would mean a 5s test, and driving it with fake
-      // timers would fight redux-saga's own scheduler.
+      // Three selects run in this flow: the reuse guard, the pre-create
+      // snapshot, and the post-create re-read. Only the last one sees a
+      // tracked id — i.e. the retry the timeout banner invited won the race
+      // while this create was still in flight.
+      let selects = 0;
+      const trackedByTheRetry = 55;
+
       const { allEffects } = await expectSaga(openExportKeysWindowSaga)
         .withState({ windowManagement: { exportKeysWindowId: null } })
-        .provide({ race: () => ({ timedOut: true }) })
-        .put(
-          sagaError({
-            source: 'openExportKeysWindowSaga',
-            message: 'The export window did not open in time; try again'
-          })
-        )
+        .provide([
+          [
+            matchers.select.selector(selectExportKeysWindowId),
+            dynamic(() => (selects++ < 2 ? null : trackedByTheRetry))
+          ],
+          [matchers.call.fn(windows.getCurrent), currentWindow],
+          [matchers.call.fn(windows.create), { id: 99 }],
+          [matchers.call.fn(windows.remove), undefined]
+        ])
+        // Overwriting the tracked id would strand the retry's window instead —
+        // two windows rendering key material is exactly what 1391 is about.
         .not.put.actionType(exportKeysWindowIdChanged.type)
+        .call([windows, windows.remove], 99)
         .run();
 
-      expect(countPutsOfType(allEffects, sagaError.type)).toBe(1);
+      expect(countPutsOfType(allEffects, sagaError.type)).toBe(0);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('bounds a hung windows.* call and leaves the menu item usable', async () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const delaysRequested: unknown[] = [];
+
+    try {
+      // The hang the bound exists for: windows.getCurrent never settles.
+      (windows.getCurrent as jest.Mock).mockReturnValue(new Promise(() => {}));
+
+      // Only redux-saga's own delay is short-circuited, so the real race runs
+      // against the real WINDOWS_API_TIMEOUT_MS. A static `race` provider would
+      // be shape-blind — it replaces the whole effect, the worker is never
+      // entered, and the bound under test is never exercised.
+      const saga = expectSaga(exportKeysWindowSaga)
+        .withState({ windowManagement: { exportKeysWindowId: null } })
+        .provide({
+          call: (
+            effect: CallEffectDescriptor<unknown>,
+            next: () => unknown
+          ) => {
+            if (effect.fn?.name !== 'delayP') return next();
+
+            delaysRequested.push(effect.args[0]);
+
+            return true;
+          }
+        });
+
+      saga.dispatch(openExportKeysWindow());
+      const runPromise = saga.silentRun(100);
+
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // The wedged first attempt must not swallow this one — that inert menu
+      // item is the whole point of the ticket's timeout item.
+      saga.dispatch(openExportKeysWindow());
+
+      const { allEffects } = await runPromise;
+
+      expect(windows.getCurrent).toHaveBeenCalledTimes(2);
+      // Literal on purpose. Asserting against the imported constant is a
+      // tautology — both sides move together, and dropping the bound to 50ms
+      // sails straight through. 5000 is a product-visible wait; changing it
+      // should have to change this line too.
+      expect(delaysRequested).toEqual([5000, 5000]);
+      expect(WINDOWS_API_TIMEOUT_MS).toBe(5000);
+      expect(countPutsOfType(allEffects, sagaError.type)).toBe(2);
+      expect(countPutsOfType(allEffects, dismissSagaErrorsBySource.type)).toBe(
+        2
+      );
     } finally {
       consoleError.mockRestore();
     }

--- a/src/background/redux/sagas/export-keys-window-saga.test.ts
+++ b/src/background/redux/sagas/export-keys-window-saga.test.ts
@@ -262,6 +262,55 @@ describe('openExportKeysWindowSaga', () => {
     }
   });
 
+  it('closes a window that arrives after a hang in getCurrent, not only in create', async () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    try {
+      // The sibling test above hangs in `create`, so the retry lands BETWEEN the
+      // pre-create snapshot and the post-create re-read. Here the hang is one
+      // call earlier — in `getCurrent` — so the retry lands BEFORE the snapshot
+      // too. That ordering is what makes the position of the snapshot, rather
+      // than the comparison itself, the thing under test: read it downstream of
+      // the hang and it already holds the retry's id, so `trackedNow !==
+      // trackedBeforeCreate` is false exactly when a straggler must be caught.
+      let trackedId: number | null = null;
+      const trackedByTheRetry = 99;
+      const arrivedLate = 100;
+
+      const { allEffects } = await expectSaga(openExportKeysWindowSaga)
+        .withState({ windowManagement: { exportKeysWindowId: null } })
+        .provide([
+          [
+            matchers.select.selector(selectExportKeysWindowId),
+            dynamic(() => trackedId)
+          ],
+          [
+            matchers.call.fn(windows.getCurrent),
+            dynamic(() => {
+              // While this worker was parked here, the entry saga's bound fired,
+              // the banner invited a retry, and that retry ran to completion.
+              trackedId = trackedByTheRetry;
+
+              return currentWindow;
+            })
+          ],
+          [matchers.call.fn(windows.create), { id: arrivedLate }],
+          [matchers.call.fn(windows.remove), undefined]
+        ])
+        // Tracking the late window would strand window 99 — the one the user is
+        // actually looking at — with no id in the store to focus or close it by.
+        .not.put.actionType(exportKeysWindowIdChanged.type)
+        .call([windows, windows.remove], arrivedLate)
+        .run();
+
+      expect(countPutsOfType(allEffects, sagaError.type)).toBe(0);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it('bounds a hung windows.* call and leaves the menu item usable', async () => {
     const consoleError = jest
       .spyOn(console, 'error')

--- a/src/background/redux/sagas/export-keys-window-saga.test.ts
+++ b/src/background/redux/sagas/export-keys-window-saga.test.ts
@@ -145,15 +145,35 @@ describe('openExportKeysWindowSaga', () => {
       .run();
   });
 
-  it('does not track when the created window has no id', () => {
-    return expectSaga(openExportKeysWindowSaga)
-      .withState({ windowManagement: { exportKeysWindowId: null } })
-      .provide([
-        [matchers.call.fn(windows.getCurrent), currentWindow],
-        [matchers.call.fn(windows.create), {}]
-      ])
-      .not.put.actionType(exportKeysWindowIdChanged.type)
-      .run();
+  it('reports a created window that cannot be tracked', async () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    try {
+      const { allEffects } = await expectSaga(openExportKeysWindowSaga)
+        .withState({ windowManagement: { exportKeysWindowId: null } })
+        .provide([
+          [matchers.call.fn(windows.getCurrent), currentWindow],
+          [matchers.call.fn(windows.create), {}]
+        ])
+        .put(
+          sagaError({
+            source: 'openExportKeysWindowSaga',
+            message:
+              'Could not track the export window; close it before opening another'
+          })
+        )
+        .not.put.actionType(exportKeysWindowIdChanged.type)
+        // Nothing was tracked, so there is nothing to clear: the new branch
+        // must not invent state.
+        .not.put.actionType(exportKeysWindowIdCleared.type)
+        .run();
+
+      expect(countPutsOfType(allEffects, sagaError.type)).toBe(1);
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it('surfaces a saga error when the export window cannot be opened', async () => {

--- a/src/background/redux/sagas/export-keys-window-saga.test.ts
+++ b/src/background/redux/sagas/export-keys-window-saga.test.ts
@@ -208,6 +208,33 @@ describe('openExportKeysWindowSaga', () => {
     }
   });
 
+  it('reports a timeout instead of leaving the menu item inert', async () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    try {
+      // A static `race` provider settles the race deterministically. Letting
+      // the real delay run would mean a 5s test, and driving it with fake
+      // timers would fight redux-saga's own scheduler.
+      const { allEffects } = await expectSaga(openExportKeysWindowSaga)
+        .withState({ windowManagement: { exportKeysWindowId: null } })
+        .provide({ race: () => ({ timedOut: true }) })
+        .put(
+          sagaError({
+            source: 'openExportKeysWindowSaga',
+            message: 'The export window did not open in time; try again'
+          })
+        )
+        .not.put.actionType(exportKeysWindowIdChanged.type)
+        .run();
+
+      expect(countPutsOfType(allEffects, sagaError.type)).toBe(1);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   describe('exportKeysWindowSaga (watcher)', () => {
     afterEach(() => {
       jest.clearAllMocks();

--- a/src/background/redux/sagas/export-keys-window-saga.ts
+++ b/src/background/redux/sagas/export-keys-window-saga.ts
@@ -97,6 +97,23 @@ export function* openExportKeysWindowSaga() {
 
     if (created.id != null) {
       yield put(exportKeysWindowIdChanged(created.id));
+    } else {
+      // windows.create RESOLVED, so the window is on screen — but with no id
+      // the store cannot track it: selectExportKeysWindowId stays null, the
+      // reuse guard above short-circuits, and the next click opens a SECOND
+      // window rendering key material. There is also no id to pass to
+      // windows.remove, so this is reported, not repaired. `created` is
+      // deliberately not logged: a Windows.Window can carry tabs[].url.
+      console.error(
+        'openExportKeysWindowSaga: the export window resolved without an id'
+      );
+      yield put(
+        sagaError({
+          source: ERROR_SOURCE,
+          message:
+            'Could not track the export window; close it before opening another'
+        })
+      );
     }
   } catch (error) {
     console.error(

--- a/src/background/redux/sagas/export-keys-window-saga.ts
+++ b/src/background/redux/sagas/export-keys-window-saga.ts
@@ -1,4 +1,11 @@
-import { call, put, select, takeLeading } from 'redux-saga/effects';
+import {
+  call,
+  delay,
+  put,
+  race,
+  select,
+  takeLeading
+} from 'redux-saga/effects';
 import { Windows, windows } from 'webextension-polyfill';
 
 import { RouterPath } from '@popup/router/paths';
@@ -19,6 +26,98 @@ const EXPORT_KEYS_URL = `popup.html#${RouterPath.DownloadAccountKeys}`;
 const SURFACE_WIDTH = 376;
 const SURFACE_HEIGHT = 700;
 const ERROR_SOURCE = 'openExportKeysWindowSaga';
+const WINDOWS_API_TIMEOUT_MS = 5000;
+
+// Extracted so the whole flow can be raced against a timeout below. Every
+// windows.* call here is unbounded, and a HANG is not what the catch handles.
+function* runOpenExportKeysWindow() {
+  const windowId: number | null = yield select(selectExportKeysWindowId);
+
+  if (windowId != null) {
+    const all: Windows.Window[] = yield call([windows, windows.getAll]);
+    // Best-effort guard, not a precise one: type:'popup' narrows the match
+    // but doesn't uniquely identify the export window — approval windows
+    // (connect/sign/import) are also type:'popup'. A precise tab-URL match
+    // isn't used because Firefox omits the extension URL hash from
+    // windows.getAll. If the OS reuses this id for another wallet popup,
+    // worst case is a misfocus (never key disclosure).
+    const existing = all.find(w => w.id === windowId && w.type === 'popup');
+    if (existing?.id != null) {
+      try {
+        yield call([windows, windows.update], existing.id, {
+          focused: true,
+          drawAttention: true
+        });
+      } catch (error) {
+        // Reported separately from the outer catch: getAll above found the
+        // window, so "could not open" would contradict what is on screen.
+        // The tracked id is deliberately kept — the window exists, and
+        // background/index.ts clears the id on windows.onRemoved. Falling
+        // through to windows.create is equally deliberate to avoid: it would
+        // open a second export window alongside the one already there.
+        console.error(
+          'openExportKeysWindowSaga: failed to focus the export window',
+          error
+        );
+        yield put(
+          sagaError({
+            source: ERROR_SOURCE,
+            message: 'Could not focus the export window'
+          })
+        );
+      }
+
+      return;
+    }
+    yield put(exportKeysWindowIdCleared());
+  }
+
+  const currentWindow: Windows.Window = yield call([
+    windows,
+    windows.getCurrent
+  ]);
+  // Positioning + TEST_ENV bypass mirror openNewWindow in create-open-window.ts.
+  const isTestEnv = Boolean(process.env.TEST_ENV);
+  const windowWidth = currentWindow.width ?? 0;
+  const xOffset = currentWindow.left ?? 0;
+  const yOffset = currentWindow.top ?? 0;
+
+  const created: Windows.Window = yield call(
+    [windows, windows.create],
+    currentWindow.state === 'fullscreen' || isTestEnv
+      ? { url: EXPORT_KEYS_URL, type: 'popup', focused: true }
+      : {
+          url: EXPORT_KEYS_URL,
+          type: 'popup',
+          focused: true,
+          width: SURFACE_WIDTH,
+          height: SURFACE_HEIGHT,
+          left: windowWidth + xOffset - SURFACE_WIDTH,
+          top: yOffset
+        }
+  );
+
+  if (created.id != null) {
+    yield put(exportKeysWindowIdChanged(created.id));
+  } else {
+    // windows.create RESOLVED, so the window is on screen — but with no id
+    // the store cannot track it: selectExportKeysWindowId stays null, the
+    // reuse guard above short-circuits, and the next click opens a SECOND
+    // window rendering key material. There is also no id to pass to
+    // windows.remove, so this is reported, not repaired. `created` is
+    // deliberately not logged: a Windows.Window can carry tabs[].url.
+    console.error(
+      'openExportKeysWindowSaga: the export window resolved without an id'
+    );
+    yield put(
+      sagaError({
+        source: ERROR_SOURCE,
+        message:
+          'Could not track the export window; close it before opening another'
+      })
+    );
+  }
+}
 
 export function* openExportKeysWindowSaga() {
   // Retract what a previous attempt reported before making a new one. Errors
@@ -29,89 +128,27 @@ export function* openExportKeysWindowSaga() {
   yield put(dismissSagaErrorsBySource(ERROR_SOURCE));
 
   try {
-    const windowId: number | null = yield select(selectExportKeysWindowId);
+    // A rejection is what the catch below handles; a HANG is not. takeLeading
+    // drops every overlapping trigger while this worker is in flight, so one
+    // wedged windows.* call makes the menu item permanently inert until the
+    // service worker restarts. The race bounds the worker so the next click
+    // gets a fresh attempt.
+    const outcome: { timedOut?: true } = yield race({
+      completed: call(runOpenExportKeysWindow),
+      timedOut: delay(WINDOWS_API_TIMEOUT_MS)
+    });
 
-    if (windowId != null) {
-      const all: Windows.Window[] = yield call([windows, windows.getAll]);
-      // Best-effort guard, not a precise one: type:'popup' narrows the match
-      // but doesn't uniquely identify the export window — approval windows
-      // (connect/sign/import) are also type:'popup'. A precise tab-URL match
-      // isn't used because Firefox omits the extension URL hash from
-      // windows.getAll. If the OS reuses this id for another wallet popup,
-      // worst case is a misfocus (never key disclosure).
-      const existing = all.find(w => w.id === windowId && w.type === 'popup');
-      if (existing?.id != null) {
-        try {
-          yield call([windows, windows.update], existing.id, {
-            focused: true,
-            drawAttention: true
-          });
-        } catch (error) {
-          // Reported separately from the outer catch: getAll above found the
-          // window, so "could not open" would contradict what is on screen.
-          // The tracked id is deliberately kept — the window exists, and
-          // background/index.ts clears the id on windows.onRemoved. Falling
-          // through to windows.create is equally deliberate to avoid: it would
-          // open a second export window alongside the one already there.
-          console.error(
-            'openExportKeysWindowSaga: failed to focus the export window',
-            error
-          );
-          yield put(
-            sagaError({
-              source: ERROR_SOURCE,
-              message: 'Could not focus the export window'
-            })
-          );
-        }
-
-        return;
-      }
-      yield put(exportKeysWindowIdCleared());
-    }
-
-    const currentWindow: Windows.Window = yield call([
-      windows,
-      windows.getCurrent
-    ]);
-    // Positioning + TEST_ENV bypass mirror openNewWindow in create-open-window.ts.
-    const isTestEnv = Boolean(process.env.TEST_ENV);
-    const windowWidth = currentWindow.width ?? 0;
-    const xOffset = currentWindow.left ?? 0;
-    const yOffset = currentWindow.top ?? 0;
-
-    const created: Windows.Window = yield call(
-      [windows, windows.create],
-      currentWindow.state === 'fullscreen' || isTestEnv
-        ? { url: EXPORT_KEYS_URL, type: 'popup', focused: true }
-        : {
-            url: EXPORT_KEYS_URL,
-            type: 'popup',
-            focused: true,
-            width: SURFACE_WIDTH,
-            height: SURFACE_HEIGHT,
-            left: windowWidth + xOffset - SURFACE_WIDTH,
-            top: yOffset
-          }
-    );
-
-    if (created.id != null) {
-      yield put(exportKeysWindowIdChanged(created.id));
-    } else {
-      // windows.create RESOLVED, so the window is on screen — but with no id
-      // the store cannot track it: selectExportKeysWindowId stays null, the
-      // reuse guard above short-circuits, and the next click opens a SECOND
-      // window rendering key material. There is also no id to pass to
-      // windows.remove, so this is reported, not repaired. `created` is
-      // deliberately not logged: a Windows.Window can carry tabs[].url.
+    if (outcome.timedOut) {
+      // The window may still appear after this point, untracked — there is no
+      // id to remove it by. Bounding the worker is what keeps the menu item
+      // usable; it cannot undo a create that is still in flight.
       console.error(
-        'openExportKeysWindowSaga: the export window resolved without an id'
+        'openExportKeysWindowSaga: the export window did not open in time'
       );
       yield put(
         sagaError({
           source: ERROR_SOURCE,
-          message:
-            'Could not track the export window; close it before opening another'
+          message: 'The export window did not open in time; try again'
         })
       );
     }

--- a/src/background/redux/sagas/export-keys-window-saga.ts
+++ b/src/background/redux/sagas/export-keys-window-saga.ts
@@ -1,9 +1,12 @@
+import { Task } from 'redux-saga';
 import {
   call,
   delay,
+  join,
   put,
   race,
   select,
+  spawn,
   takeLeading
 } from 'redux-saga/effects';
 import { Windows, windows } from 'webextension-polyfill';
@@ -26,94 +29,134 @@ const EXPORT_KEYS_URL = `popup.html#${RouterPath.DownloadAccountKeys}`;
 const SURFACE_WIDTH = 376;
 const SURFACE_HEIGHT = 700;
 const ERROR_SOURCE = 'openExportKeysWindowSaga';
-const WINDOWS_API_TIMEOUT_MS = 5000;
+export const WINDOWS_API_TIMEOUT_MS = 5000;
 
-// Extracted so the whole flow can be raced against a timeout below. Every
-// windows.* call here is unbounded, and a HANG is not what the catch handles.
+// Spawned DETACHED by the entry saga, which bounds only how long it WAITS.
+// windows.create() cannot be aborted once in flight, so this generator must not
+// be cancellable: cancelling it leaves the window on screen with the store never
+// learning its id — the exact state WALLET-1391 exists to close, reached from
+// slowness alone. Being detached, it also owns its error reporting: a throw here
+// would otherwise reach nobody once the entry saga has moved on.
 function* runOpenExportKeysWindow() {
-  const windowId: number | null = yield select(selectExportKeysWindowId);
+  try {
+    const windowId: number | null = yield select(selectExportKeysWindowId);
 
-  if (windowId != null) {
-    const all: Windows.Window[] = yield call([windows, windows.getAll]);
-    // Best-effort guard, not a precise one: type:'popup' narrows the match
-    // but doesn't uniquely identify the export window — approval windows
-    // (connect/sign/import) are also type:'popup'. A precise tab-URL match
-    // isn't used because Firefox omits the extension URL hash from
-    // windows.getAll. If the OS reuses this id for another wallet popup,
-    // worst case is a misfocus (never key disclosure).
-    const existing = all.find(w => w.id === windowId && w.type === 'popup');
-    if (existing?.id != null) {
-      try {
-        yield call([windows, windows.update], existing.id, {
-          focused: true,
-          drawAttention: true
-        });
-      } catch (error) {
-        // Reported separately from the outer catch: getAll above found the
-        // window, so "could not open" would contradict what is on screen.
-        // The tracked id is deliberately kept — the window exists, and
-        // background/index.ts clears the id on windows.onRemoved. Falling
-        // through to windows.create is equally deliberate to avoid: it would
-        // open a second export window alongside the one already there.
+    if (windowId != null) {
+      const all: Windows.Window[] = yield call([windows, windows.getAll]);
+      // Best-effort guard, not a precise one: type:'popup' narrows the match
+      // but doesn't uniquely identify the export window — approval windows
+      // (connect/sign/import) are also type:'popup'. A precise tab-URL match
+      // isn't used because Firefox omits the extension URL hash from
+      // windows.getAll. If the OS reuses this id for another wallet popup,
+      // worst case is a misfocus (never key disclosure).
+      const existing = all.find(w => w.id === windowId && w.type === 'popup');
+      if (existing?.id != null) {
+        try {
+          yield call([windows, windows.update], existing.id, {
+            focused: true,
+            drawAttention: true
+          });
+        } catch (error) {
+          // Reported separately from the outer catch: getAll above found the
+          // window, so "could not open" would contradict what is on screen.
+          // The tracked id is deliberately kept — the window exists, and
+          // background/index.ts clears the id on windows.onRemoved. Falling
+          // through to windows.create is equally deliberate to avoid: it would
+          // open a second export window alongside the one already there.
+          console.error(
+            'openExportKeysWindowSaga: failed to focus the export window',
+            error
+          );
+          yield put(
+            sagaError({
+              source: ERROR_SOURCE,
+              message: 'Could not focus the export window'
+            })
+          );
+        }
+
+        return;
+      }
+      yield put(exportKeysWindowIdCleared());
+    }
+
+    const currentWindow: Windows.Window = yield call([
+      windows,
+      windows.getCurrent
+    ]);
+    // Positioning + TEST_ENV bypass mirror openNewWindow in create-open-window.ts.
+    const isTestEnv = Boolean(process.env.TEST_ENV);
+    const windowWidth = currentWindow.width ?? 0;
+    const xOffset = currentWindow.left ?? 0;
+    const yOffset = currentWindow.top ?? 0;
+
+    // Snapshotted rather than null-checked after the fact: the stale-id path
+    // above may have just cleared the tracked id, and re-reading it below would
+    // otherwise depend on that clear having been applied by the reducer already.
+    const trackedBeforeCreate: number | null = yield select(
+      selectExportKeysWindowId
+    );
+
+    const created: Windows.Window = yield call(
+      [windows, windows.create],
+      currentWindow.state === 'fullscreen' || isTestEnv
+        ? { url: EXPORT_KEYS_URL, type: 'popup', focused: true }
+        : {
+            url: EXPORT_KEYS_URL,
+            type: 'popup',
+            focused: true,
+            width: SURFACE_WIDTH,
+            height: SURFACE_HEIGHT,
+            left: windowWidth + xOffset - SURFACE_WIDTH,
+            top: yOffset
+          }
+    );
+
+    if (created.id != null) {
+      const trackedNow: number | null = yield select(selectExportKeysWindowId);
+
+      if (trackedNow != null && trackedNow !== trackedBeforeCreate) {
+        // We are a straggler: the entry saga stopped waiting on us, told the
+        // user to try again, and that retry already produced a tracked window.
+        // Overwriting the id here would leave THAT window untracked, and two
+        // windows rendering key material is the harm WALLET-1391 is about — so
+        // the late one closes instead.
         console.error(
-          'openExportKeysWindowSaga: failed to focus the export window',
-          error
+          'openExportKeysWindowSaga: closing an export window that arrived after the timeout'
         );
-        yield put(
-          sagaError({
-            source: ERROR_SOURCE,
-            message: 'Could not focus the export window'
-          })
-        );
+        yield call([windows, windows.remove], created.id);
+
+        return;
       }
 
-      return;
+      yield put(exportKeysWindowIdChanged(created.id));
+    } else {
+      // windows.create RESOLVED, so the window is on screen — but with no id
+      // the store cannot track it: selectExportKeysWindowId stays null, the
+      // reuse guard above short-circuits, and the next click opens a SECOND
+      // window rendering key material. There is also no id to pass to
+      // windows.remove, so this is reported, not repaired. `created` is
+      // deliberately not logged: a Windows.Window can carry tabs[].url.
+      console.error(
+        'openExportKeysWindowSaga: the export window resolved without an id'
+      );
+      yield put(
+        sagaError({
+          source: ERROR_SOURCE,
+          message:
+            'Could not track the export window; close it before opening another'
+        })
+      );
     }
-    yield put(exportKeysWindowIdCleared());
-  }
-
-  const currentWindow: Windows.Window = yield call([
-    windows,
-    windows.getCurrent
-  ]);
-  // Positioning + TEST_ENV bypass mirror openNewWindow in create-open-window.ts.
-  const isTestEnv = Boolean(process.env.TEST_ENV);
-  const windowWidth = currentWindow.width ?? 0;
-  const xOffset = currentWindow.left ?? 0;
-  const yOffset = currentWindow.top ?? 0;
-
-  const created: Windows.Window = yield call(
-    [windows, windows.create],
-    currentWindow.state === 'fullscreen' || isTestEnv
-      ? { url: EXPORT_KEYS_URL, type: 'popup', focused: true }
-      : {
-          url: EXPORT_KEYS_URL,
-          type: 'popup',
-          focused: true,
-          width: SURFACE_WIDTH,
-          height: SURFACE_HEIGHT,
-          left: windowWidth + xOffset - SURFACE_WIDTH,
-          top: yOffset
-        }
-  );
-
-  if (created.id != null) {
-    yield put(exportKeysWindowIdChanged(created.id));
-  } else {
-    // windows.create RESOLVED, so the window is on screen — but with no id
-    // the store cannot track it: selectExportKeysWindowId stays null, the
-    // reuse guard above short-circuits, and the next click opens a SECOND
-    // window rendering key material. There is also no id to pass to
-    // windows.remove, so this is reported, not repaired. `created` is
-    // deliberately not logged: a Windows.Window can carry tabs[].url.
+  } catch (error) {
     console.error(
-      'openExportKeysWindowSaga: the export window resolved without an id'
+      'openExportKeysWindowSaga: failed to open export window',
+      error
     );
     yield put(
       sagaError({
         source: ERROR_SOURCE,
-        message:
-          'Could not track the export window; close it before opening another'
+        message: 'Could not open the export window'
       })
     );
   }
@@ -127,40 +170,29 @@ export function* openExportKeysWindowSaga() {
   // the key-download screen, and repeated failures stack identical rows.
   yield put(dismissSagaErrorsBySource(ERROR_SOURCE));
 
-  try {
-    // A rejection is what the catch below handles; a HANG is not. takeLeading
-    // drops every overlapping trigger while this worker is in flight, so one
-    // wedged windows.* call makes the menu item permanently inert until the
-    // service worker restarts. The race bounds the worker so the next click
-    // gets a fresh attempt.
-    const outcome: { timedOut?: true } = yield race({
-      completed: call(runOpenExportKeysWindow),
-      timedOut: delay(WINDOWS_API_TIMEOUT_MS)
-    });
+  // spawn, not fork: a forked child keeps THIS task alive until it settles,
+  // which is the very takeLeading wedge being lifted. Detaching lets the wait
+  // be abandoned while the work runs on to a tracked id.
+  const task: Task = yield spawn(runOpenExportKeysWindow);
 
-    if (outcome.timedOut) {
-      // The window may still appear after this point, untracked — there is no
-      // id to remove it by. Bounding the worker is what keeps the menu item
-      // usable; it cannot undo a create that is still in flight.
-      console.error(
-        'openExportKeysWindowSaga: the export window did not open in time'
-      );
-      yield put(
-        sagaError({
-          source: ERROR_SOURCE,
-          message: 'The export window did not open in time; try again'
-        })
-      );
-    }
-  } catch (error) {
+  // A rejection is what the worker's own catch handles; a HANG is not.
+  // takeLeading drops every overlapping trigger while this task is in flight,
+  // so one wedged windows.* call makes the menu item permanently inert until
+  // the service worker restarts. Bounding the wait gives the next click a
+  // fresh attempt.
+  const outcome: { timedOut?: true } = yield race({
+    completed: join(task),
+    timedOut: delay(WINDOWS_API_TIMEOUT_MS)
+  });
+
+  if (outcome.timedOut) {
     console.error(
-      'openExportKeysWindowSaga: failed to open export window',
-      error
+      'openExportKeysWindowSaga: the export window did not open in time'
     );
     yield put(
       sagaError({
         source: ERROR_SOURCE,
-        message: 'Could not open the export window'
+        message: 'The export window did not open in time; try again'
       })
     );
   }

--- a/src/background/redux/sagas/export-keys-window-saga.ts
+++ b/src/background/redux/sagas/export-keys-window-saga.ts
@@ -80,6 +80,20 @@ function* runOpenExportKeysWindow() {
       yield put(exportKeysWindowIdCleared());
     }
 
+    // Snapshotted rather than null-checked after the fact: the stale-id path
+    // above may have just cleared the tracked id, and re-reading it below would
+    // otherwise depend on that clear having been applied by the reducer already.
+    //
+    // Taken BEFORE the first unbounded windows.* call rather than just before
+    // create: the entry saga stops waiting after WINDOWS_API_TIMEOUT_MS, so
+    // every call below can resume in a world where the retry that timeout
+    // invited already tracked a window of its own. A snapshot read downstream
+    // of the hang would already hold that retry's id, leaving the comparison
+    // below always false — silent, and precisely when it must fire.
+    const trackedBeforeCreate: number | null = yield select(
+      selectExportKeysWindowId
+    );
+
     const currentWindow: Windows.Window = yield call([
       windows,
       windows.getCurrent
@@ -89,13 +103,6 @@ function* runOpenExportKeysWindow() {
     const windowWidth = currentWindow.width ?? 0;
     const xOffset = currentWindow.left ?? 0;
     const yOffset = currentWindow.top ?? 0;
-
-    // Snapshotted rather than null-checked after the fact: the stale-id path
-    // above may have just cleared the tracked id, and re-reading it below would
-    // otherwise depend on that clear having been applied by the reducer already.
-    const trackedBeforeCreate: number | null = yield select(
-      selectExportKeysWindowId
-    );
 
     const created: Windows.Window = yield call(
       [windows, windows.create],

--- a/src/hooks/ledger-window-close-listener.test.ts
+++ b/src/hooks/ledger-window-close-listener.test.ts
@@ -1,0 +1,55 @@
+import { windows } from 'webextension-polyfill';
+
+import { ledgerStateCleared } from '@background/redux/ledger/actions';
+import { dispatchToMainStore } from '@background/redux/utils';
+
+import { makeLedgerWindowCloseListener } from './ledger-window-close-listener';
+
+jest.mock('@background/redux/utils', () => ({
+  dispatchToMainStore: jest.fn()
+}));
+
+// webextension-polyfill throws on import outside an extension context, and
+// only onRemoved.removeListener is reached from here.
+jest.mock('webextension-polyfill', () => ({
+  windows: { onRemoved: { removeListener: jest.fn() } }
+}));
+
+const dispatchMock = dispatchToMainStore as jest.Mock;
+const removeListenerMock = windows.onRemoved.removeListener as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it('ignores a window that is not the tracked permission window', () => {
+  const listener = makeLedgerWindowCloseListener(9);
+
+  listener(10);
+
+  // The whole ledger slice is what ledgerStateCleared resets, so a close
+  // anywhere else in the browser must not reach the store — and must not
+  // consume the listener either, or the real close clears nothing.
+  expect(dispatchMock).not.toHaveBeenCalled();
+  expect(removeListenerMock).not.toHaveBeenCalled();
+});
+
+it('clears the ledger state when the tracked window is removed', () => {
+  const listener = makeLedgerWindowCloseListener(9);
+
+  listener(9);
+
+  expect(dispatchMock).toHaveBeenCalledTimes(1);
+  expect(dispatchMock).toHaveBeenCalledWith(ledgerStateCleared());
+});
+
+it('detaches itself once the tracked window has been removed', () => {
+  const listener = makeLedgerWindowCloseListener(9);
+
+  listener(9);
+
+  expect(removeListenerMock).toHaveBeenCalledTimes(1);
+  // The same function object, or windows.onRemoved keeps a listener that
+  // outlives the window it was registered for.
+  expect(removeListenerMock).toHaveBeenCalledWith(listener);
+});

--- a/src/hooks/ledger-window-close-listener.test.ts
+++ b/src/hooks/ledger-window-close-listener.test.ts
@@ -3,48 +3,56 @@ import { windows } from 'webextension-polyfill';
 import { ledgerStateCleared } from '@background/redux/ledger/actions';
 import { dispatchToMainStore } from '@background/redux/utils';
 
-import { makeLedgerWindowCloseListener } from './ledger-window-close-listener';
+import { createLedgerWindowCloseTracker } from './ledger-window-close-listener';
 
 jest.mock('@background/redux/utils', () => ({
   dispatchToMainStore: jest.fn()
 }));
 
-// webextension-polyfill throws on import outside an extension context, and
-// only onRemoved.removeListener is reached from here.
+// webextension-polyfill throws on import outside an extension context, and only
+// these two members are reached from here.
 jest.mock('webextension-polyfill', () => ({
-  windows: { onRemoved: { removeListener: jest.fn() } }
+  windows: { onRemoved: { addListener: jest.fn(), removeListener: jest.fn() } }
 }));
 
 const dispatchMock = dispatchToMainStore as jest.Mock;
+const addListenerMock = windows.onRemoved.addListener as jest.Mock;
 const removeListenerMock = windows.onRemoved.removeListener as jest.Mock;
+
+const armedListener = (nth = 0) =>
+  addListenerMock.mock.calls[nth][0] as (removedWindowId: number) => void;
 
 beforeEach(() => {
   jest.clearAllMocks();
 });
 
 it('ignores a window that is not the tracked permission window', () => {
-  const listener = makeLedgerWindowCloseListener(9);
+  const tracker = createLedgerWindowCloseTracker();
+  tracker.arm(9);
 
-  listener(10);
+  armedListener()(10);
 
-  // The whole ledger slice is what ledgerStateCleared resets, so a close
-  // anywhere else in the browser must not reach the store — and must not
-  // consume the listener either, or the real close clears nothing.
+  // ledgerStateCleared resets the whole slice, so a close anywhere else in the
+  // browser must not reach the store — and must not consume the listener
+  // either, or the real close clears nothing.
   expect(dispatchMock).not.toHaveBeenCalled();
   expect(removeListenerMock).not.toHaveBeenCalled();
 });
 
 it('clears the ledger state when the tracked window is removed', () => {
-  const listener = makeLedgerWindowCloseListener(9);
+  const tracker = createLedgerWindowCloseTracker();
+  tracker.arm(9);
 
-  listener(9);
+  armedListener()(9);
 
   expect(dispatchMock).toHaveBeenCalledTimes(1);
   expect(dispatchMock).toHaveBeenCalledWith(ledgerStateCleared());
 });
 
 it('detaches itself once the tracked window has been removed', () => {
-  const listener = makeLedgerWindowCloseListener(9);
+  const tracker = createLedgerWindowCloseTracker();
+  tracker.arm(9);
+  const listener = armedListener();
 
   listener(9);
 
@@ -52,4 +60,42 @@ it('detaches itself once the tracked window has been removed', () => {
   // The same function object, or windows.onRemoved keeps a listener that
   // outlives the window it was registered for.
   expect(removeListenerMock).toHaveBeenCalledWith(listener);
+});
+
+it('detaches a listener whose window is never closed', () => {
+  const tracker = createLedgerWindowCloseTracker();
+  tracker.arm(9);
+  const listener = armedListener();
+
+  tracker.detach();
+
+  // The id guard makes self-removal correct, not guaranteed: ledgerStateCleared
+  // reaches the store from paths that never close this window, and a listener
+  // left armed would later wipe whatever flow replaced this one.
+  expect(removeListenerMock).toHaveBeenCalledWith(listener);
+
+  // Already gone: a second detach must not re-remove, and nothing was
+  // dispatched — detaching is not the same as the window having closed.
+  tracker.detach();
+
+  expect(removeListenerMock).toHaveBeenCalledTimes(1);
+  expect(dispatchMock).not.toHaveBeenCalled();
+});
+
+it('drops the previous listener when armed again', () => {
+  const tracker = createLedgerWindowCloseTracker();
+  tracker.arm(9);
+  const first = armedListener(0);
+
+  tracker.arm(11);
+
+  expect(removeListenerMock).toHaveBeenCalledWith(first);
+  expect(addListenerMock).toHaveBeenCalledTimes(2);
+
+  // Only the current window is watched; the abandoned one is inert.
+  armedListener(1)(9);
+  expect(dispatchMock).not.toHaveBeenCalled();
+
+  armedListener(1)(11);
+  expect(dispatchMock).toHaveBeenCalledTimes(1);
 });

--- a/src/hooks/ledger-window-close-listener.ts
+++ b/src/hooks/ledger-window-close-listener.ts
@@ -1,0 +1,31 @@
+import { windows } from 'webextension-polyfill';
+
+import { ledgerStateCleared } from '@background/redux/ledger/actions';
+import { dispatchToMainStore } from '@background/redux/utils';
+
+/**
+ * `windows.onRemoved` passes the removed window's id, and a zero-arg listener
+ * is arity-assignable to it — so the previous inline handler fired for the
+ * FIRST window closed anywhere in the browser, cleared the whole ledger slice
+ * mid-flow, and then removed itself so the real close cleared nothing.
+ *
+ * Extracted from `useLedger` for the same reason as
+ * `registerLedgerPermissionWindow`: the repo has no React-hook harness, and
+ * inline the id comparison is one line that can be deleted with the suite
+ * staying green.
+ *
+ * Takes the id as an argument rather than reading it from the effect's scope:
+ * the redux `windowId` the effect depends on is `null` for the whole body (the
+ * body only runs when it is), so comparing against it would early-return
+ * forever.
+ */
+export function makeLedgerWindowCloseListener(permissionWindowId: number) {
+  const handleCloseWindow = (removedWindowId: number): void => {
+    if (removedWindowId !== permissionWindowId) return;
+
+    dispatchToMainStore(ledgerStateCleared());
+    windows.onRemoved.removeListener(handleCloseWindow);
+  };
+
+  return handleCloseWindow;
+}

--- a/src/hooks/ledger-window-close-listener.ts
+++ b/src/hooks/ledger-window-close-listener.ts
@@ -3,29 +3,58 @@ import { windows } from 'webextension-polyfill';
 import { ledgerStateCleared } from '@background/redux/ledger/actions';
 import { dispatchToMainStore } from '@background/redux/utils';
 
-/**
- * `windows.onRemoved` passes the removed window's id, and a zero-arg listener
- * is arity-assignable to it — so the previous inline handler fired for the
- * FIRST window closed anywhere in the browser, cleared the whole ledger slice
- * mid-flow, and then removed itself so the real close cleared nothing.
- *
- * Extracted from `useLedger` for the same reason as
- * `registerLedgerPermissionWindow`: the repo has no React-hook harness, and
- * inline the id comparison is one line that can be deleted with the suite
- * staying green.
- *
- * Takes the id as an argument rather than reading it from the effect's scope:
- * the redux `windowId` the effect depends on is `null` for the whole body (the
- * body only runs when it is), so comparing against it would early-return
- * forever.
- */
-export function makeLedgerWindowCloseListener(permissionWindowId: number) {
-  const handleCloseWindow = (removedWindowId: number): void => {
-    if (removedWindowId !== permissionWindowId) return;
+export interface LedgerWindowCloseTracker {
+  /** Watch `permissionWindowId`, replacing whatever was watched before. */
+  arm(permissionWindowId: number): void;
+  /** Stop watching. Safe to call when nothing is armed. */
+  detach(): void;
+}
 
-    dispatchToMainStore(ledgerStateCleared());
-    windows.onRemoved.removeListener(handleCloseWindow);
+/**
+ * Owns the `windows.onRemoved` registration for a Ledger permission window.
+ *
+ * Two failures live here, which is why the lifecycle is a unit rather than two
+ * lines inside the effect that opens the window:
+ *
+ * 1. `windows.onRemoved` passes the removed window's id, and a zero-arg
+ *    listener is arity-assignable to it — so an unguarded handler fires for the
+ *    FIRST window closed anywhere in the browser, clears the whole ledger slice
+ *    mid-flow, and then removes itself so the real close clears nothing.
+ * 2. The id guard makes self-removal correct, not guaranteed. A window that is
+ *    never closed leaves the listener armed for the life of the document, and
+ *    `ledgerStateCleared()` reaches the store from paths that do not close it
+ *    (the Connect CTA in `LedgerDisconnectedFooter`, which `renderLedgerFooter`
+ *    shows for `LedgerAskPermission` too). Another `useLedger` instance then
+ *    opens its own permission window and takes over the slice — and closing the
+ *    stale window afterwards wipes THAT flow's deploy/transaction, silently.
+ *    `detach` is what the owner calls on unmount and when the slice is cleared.
+ */
+export function createLedgerWindowCloseTracker(): LedgerWindowCloseTracker {
+  let armed: ((removedWindowId: number) => void) | null = null;
+
+  const detach = () => {
+    if (armed == null) return;
+
+    windows.onRemoved.removeListener(armed);
+    armed = null;
   };
 
-  return handleCloseWindow;
+  return {
+    arm(permissionWindowId: number) {
+      // Never hold two: a second registration would outlive the first window
+      // and clear the slice out from under whatever replaced it.
+      detach();
+
+      const handleCloseWindow = (removedWindowId: number): void => {
+        if (removedWindowId !== permissionWindowId) return;
+
+        dispatchToMainStore(ledgerStateCleared());
+        detach();
+      };
+
+      armed = handleCloseWindow;
+      windows.onRemoved.addListener(handleCloseWindow);
+    },
+    detach
+  };
 }

--- a/src/hooks/use-ledger.ts
+++ b/src/hooks/use-ledger.ts
@@ -12,6 +12,7 @@ import {
 import { selectLedgerNewWindowId } from '@background/redux/ledger/selectors';
 import { dispatchToMainStore } from '@background/redux/utils';
 
+import { makeLedgerWindowCloseListener } from '@hooks/ledger-window-close-listener';
 import { registerLedgerPermissionWindow } from '@hooks/register-ledger-permission-window';
 
 import {
@@ -230,12 +231,7 @@ export const useLedger = ({
 
         triggeredRef.current = true;
 
-        const handleCloseWindow = () => {
-          dispatchToMainStore(ledgerStateCleared());
-          windows.onRemoved.removeListener(handleCloseWindow);
-        };
-
-        windows.onRemoved.addListener(handleCloseWindow);
+        windows.onRemoved.addListener(makeLedgerWindowCloseListener(w.id));
       }
     })().catch(error => {
       // `openNewSeparateWindow` is an awaited call that can reject, and without

--- a/src/hooks/use-ledger.ts
+++ b/src/hooks/use-ledger.ts
@@ -12,7 +12,7 @@ import {
 import { selectLedgerNewWindowId } from '@background/redux/ledger/selectors';
 import { dispatchToMainStore } from '@background/redux/utils';
 
-import { makeLedgerWindowCloseListener } from '@hooks/ledger-window-close-listener';
+import { createLedgerWindowCloseTracker } from '@hooks/ledger-window-close-listener';
 import { registerLedgerPermissionWindow } from '@hooks/register-ledger-permission-window';
 
 import {
@@ -197,6 +197,10 @@ export const useLedger = ({
     }
   }, [isLedgerConnected, makeSubmitLedgerAction]);
 
+  // One per hook instance, stable across renders: the effect below arms it and
+  // the two effects after it are the only things that take it back down.
+  const closeTracker = useMemo(() => createLedgerWindowCloseTracker(), []);
+
   /** We have to open new browser window to handle device permission */
   useEffect(() => {
     (async () => {
@@ -231,7 +235,7 @@ export const useLedger = ({
 
         triggeredRef.current = true;
 
-        windows.onRemoved.addListener(makeLedgerWindowCloseListener(w.id));
+        closeTracker.arm(w.id);
       }
     })().catch(error => {
       // `openNewSeparateWindow` is an awaited call that can reject, and without
@@ -254,10 +258,29 @@ export const useLedger = ({
   }, [
     askPermissionUrlData.domain,
     askPermissionUrlData.params?.requestId,
+    closeTracker,
     ledgerEventStatusToRender.status,
     url,
     windowId
   ]);
+
+  // Unmount only — deliberately NOT the cleanup of the effect above. `windowId`
+  // is one of that effect's dependencies and the arm path dispatches
+  // ledgerNewWindowIdChanged, so its cleanup would run a broadcast round-trip
+  // after arming and remove the listener that was just registered.
+  useEffect(() => () => closeTracker.detach(), [closeTracker]);
+
+  // The slice can be cleared without this window ever closing —
+  // LedgerDisconnectedFooter's Connect CTA does it, and renderLedgerFooter
+  // shows that footer for LedgerAskPermission as well as Disconnected. Once
+  // that happens another useLedger instance can open its own permission window
+  // and take over the slice; a listener still watching ours would wipe that
+  // flow's deploy/transaction the moment our stale window is closed.
+  useEffect(() => {
+    if (windowId != null) return;
+
+    closeTracker.detach();
+  }, [closeTracker, windowId]);
 
   const closeNewLedgerWindowsAndClearState = useCallback(async () => {
     if (windowId) {


### PR DESCRIPTION
Two independent defects, both surfaced while reviewing the WALLET-1364 lifecycle PRs. Both are pre-existing on `release/2.7.0`.

- https://make-software.atlassian.net/browse/WALLET-1391
- https://make-software.atlassian.net/browse/WALLET-1389

## The bug

### WALLET-1391 — an export window that is created but never tracked

`export-keys-window-saga.ts` had no `else` on `if (created.id != null)`. When `windows.create` **resolves without an id** — as opposed to rejecting, which #1428 already handles — the window is on screen but the store never learns of it: no `exportKeysWindowIdChanged`, no `sagaError`, no log. The reuse guard then sees `selectExportKeysWindowId === null`, skips the `windows.getAll` lookup entirely, and goes straight to creating another window. A second window rendering secret key material opens beside the first untracked one, and the pattern repeats on every subsequent click.

Separately (ticket comment, item 1): none of the four `windows.*` calls was bounded. The `catch` added by #1428 handles a rejection, not a hang — and because the watcher uses `takeLeading`, one wedged call drops every subsequent dispatch, leaving the menu item permanently inert until the service worker restarts.

The test named for this defect passed with the defect live, and would have kept passing after a fix: `.not.put.actionType(...)` cannot fail on a missing branch.

### WALLET-1389 — the Ledger close listener fired for every window

`use-ledger.ts` registered `windows.onRemoved.addListener(handleCloseWindow)` with a zero-arg handler. `Windows.onRemoved` is `Events.Event<(windowId: number) => void>`, and a zero-arg listener is arity-assignable to it, so tsc never saw this. The handler fired for the **first window closed anywhere in the browser** and then removed itself, so the real close of the permission window afterwards cleared nothing. It fired both ways: cleared when it should not, then failed to clear when it should.

`ledgerStateCleared` resets the whole slice, so mid-flow this nulls `windowId`, `deploy`, `transaction` and `recipientToSaveOnSuccess`. In dapp flows the auto-close effect and `closeNewLedgerWindowsAndClearState` are both gated on `windowId` and become no-ops, leaving an orphaned Ledger window on screen. In popup flows the permission window *is* the signing screen: `SignWithLedgerInNewWindowPage` reads the cleared selectors and `ledgerAction` returns early, so pressing Continue does nothing — no error, no log.

## The fix

**WALLET-1391, commit 1** — the missing `else`: log and dispatch a `sagaError`, on the same surface #1428 introduced. `ERROR_SOURCE` and the `sagaError` import already existed and `'openExportKeysWindowSaga'` is already a member of `SagaErrorSource`, so this adds no import and no type change. The message deliberately differs from `'Could not open the export window'` — the window *is* on screen. `created` is not logged: a `Windows.Window` can carry `tabs[].url`.

This is report-only. With no id the saga can neither track nor `windows.remove` the first window, so the duplicate is surfaced, not prevented.

**WALLET-1391, commit 2** — one `race` around the whole flow rather than four per-call timeouts: it covers all four call sites plus any future one, needs one user-facing string instead of four, and targets the actual impact (an inert menu item). The `try` body moves into a module-local `runOpenExportKeysWindow`; errors still propagate through `call` into the existing `catch`, so #1428's behaviour is unchanged. `WINDOWS_API_TIMEOUT_MS = 5000` follows `PRIVATE_STATE_FETCH_TIMEOUT_MS`.

> **Reviewing the saga:** the raw diff is dominated by re-indentation from extracting the worker. Read it with `git diff -w`.

**WALLET-1389, commit 3** — the listener moves into `src/hooks/ledger-window-close-listener.ts` and takes the tracked id as an argument.

Note that the ticket's suggested direction names the wrong binding. It proposes comparing against the redux `windowId` "already in scope … a dependency of the same effect", but the effect body only runs when `!windowId`, and the closure is not updated by the `ledgerNewWindowIdChanged(w.id)` dispatch below it — so `removedWindowId !== windowId` is `!== null`, always true, and the listener would early-return forever. Green CI, dead feature. The correct binding is `w.id`, the id of the window this effect just created. Passing it as an argument also keeps the narrowing straightforward instead of relying on a guard narrowing a property inside a later closure.

Extracting rather than fixing in place is what makes it testable: the repo has no React-hook harness (zero `.test.tsx` files, no `@testing-library/react`, no jsdom) and `use-ledger.ts` pulls in `@libs/services/ledger`, which constructs a `Ledger` and touches `navigator.hid` at module scope. Same reasoning as `registerLedgerPermissionWindow`, which was extracted from this same effect. The honest limit: the seam is covered, the wiring is not.

## Verification

`npm run ci-check` — 68 suites / 518 tests green, knip clean, tsc clean. Coverage moved up: `redux/sagas` aggregate 67.57 / 63.21 / 54.05 / 67.59 against its 45 / 35 / 45 / 45 floor; `export-keys-window-saga.ts` at 100 / 86.66 / 100 / 100.

Each new test was mutation-checked — delete the fix, the test goes red:

| Deletion | Red test |
| --- | --- |
| the `else` branch | `reports a created window that cannot be tracked` |
| `console.error(msg, created)` (i.e. logging the window) | `reports a created window that cannot be tracked` |
| `timedOut: delay(WINDOWS_API_TIMEOUT_MS)` from the race | `bounds a hung windows.* call and leaves the menu item usable` |
| `WINDOWS_API_TIMEOUT_MS` 5000 → 50 | `bounds a hung windows.* call and leaves the menu item usable` |
| `spawn` → `fork` | `bounds a hung windows.* call and leaves the menu item usable` |
| the straggler `windows.remove` guard | `closes a window that arrives after another one was already tracked` |
| `if (removedWindowId !== permissionWindowId) return;` | `ignores a window that is not the tracked permission window` |
| `detach()` inside `arm` | `drops the previous listener when armed again` |

An earlier revision of this table listed the timeout as covered when it was not: the test stubbed the `race` effect itself, and redux-saga-test-plan's static `race` provider is shape-blind, so the worker was never entered. The timeout test now drives the real race and stubs only redux-saga's own `delay`.

The eight pre-existing saga tests needed no changes under the `race` — the winner cancels the losing `delay`, so nothing slowed down. The timeout test uses `redux-saga-test-plan`'s static `race` provider rather than fake timers.

`npm run format:check` does not cover these paths (its glob is `src/*`, one level); formatting was verified with an explicit `npx prettier --check` and by `npm run lint`, which enforces `prettier/prettier` at error severity.

## Left out on purpose

- **`closeNewLedgerWindowsAndClearState`** (`use-ledger.ts`) calls `windows.getAll({ windowTypes: ['popup'] })` and removes every popup window, while its own target is created `type: 'normal'`. It therefore never hits its own target — the explicit `windows.remove(windowId)` on the next line does that — and instead closes unrelated approval windows. Real bug, four lines from this fix, different failure mode; filing separately.
- **`create-open-window.ts`**: `if (newWindow.id && !isNewWindow)` has the same shape as WALLET-1391 (and uses truthiness rather than `!= null`), but is not a live bug — its only tracking importer re-checks `window.id == null` and fails the request.
- Moving the ledger clear into `background/handlers/window-removed.ts`. That route is id-correct by construction and would additionally fix the popup-context hole, but it changes semantics and lands in a directory whose branch/function floors have no headroom. Worth its own ticket.
- `locale:extract_pot`. Saga error messages render untranslated by design (`saga-error-banner.tsx` prints `error.message` raw) and a run would rewrite the catalog wholesale.



---

## Review round 2

All four review comments were reproduced before being acted on, and all four were correct.

**The race abandoned a `windows.create` it could not abort.** Verified in isolation: the losing branch cancels the child and a create that resolves afterwards never reaches `exportKeysWindowIdChanged`. That reintroduced the untracked window from slowness alone. The worker is now `spawn`ed detached — `fork` cannot work here, a forked child keeps its parent alive and `takeLeading` stays wedged — so the entry saga bounds only how long it *waits*. A create that lands after the timeout still tracks, and if a retry already tracked a window the straggler closes itself rather than overwriting the id.

**The timeout test proved nothing.** Deleting the bound left it green. It now drives the real race through the watcher with a permanently pending `windows.getCurrent`, stubs only `delayP`, pins the constant as a literal, and asserts the menu item recovers. This also exposed cross-test mock leakage in the file (only an `afterEach` clear); fixed with a top-level `beforeEach`.

**The Ledger listener outlived its flow.** `ledgerStateCleared()` reaches the store from paths that never close the permission window, after which another `useLedger` instance takes over the slice and the stale listener wipes it. The module is now a tracker with `arm`/`detach` so the lifecycle is covered by tests rather than only fixed. The teardown is deliberately *not* the arming effect's cleanup — `windowId` is one of its dependencies and the arm path dispatches `ledgerNewWindowIdChanged`, so that cleanup would remove the listener it had just registered.

**The `console.error` redaction was unpinned.** Now asserted in the shape `register-ledger-permission-window.test.ts` uses.
