### PR TITLE
test: WALLET-1415 — observe the Safari CSP meta reaching the document

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,3 +1,8 @@
+import fs from 'fs';
+import path from 'path';
+
+import { Browser } from '@src/constants';
+
 import {
   getSafariCspContent,
   hasHttpPrefix,
@@ -190,5 +195,208 @@ describe('getSafariCspContent', () => {
 
   it('no longer reaches the casper-assets bucket', () => {
     expect(getSafariCspContent()).not.toContain('casper-assets');
+  });
+});
+
+/**
+ * The slice of the DOM `setCSPForSafari` touches, and nothing else:
+ * `querySelector`, `createElement`, and `getElementsByTagName('head')[0]
+ * .appendChild`. Hand-built rather than jsdom-backed — jsdom is not a
+ * dependency of this repo, and one function is not worth the tree.
+ *
+ * `querySelector` implements the single `[http-equiv]` selector for real (it
+ * scans head for an element carrying that attribute) instead of returning a
+ * canned value, so the early-out branch is decided by the state of the stub
+ * head rather than by the test. Any other selector throws: reaching one means
+ * the function changed and this stub no longer models what it does.
+ */
+interface StubElement {
+  tagName: string;
+  setAttribute(name: string, value: string): void;
+  getAttribute(name: string): string | null;
+}
+
+const createStubElement = (
+  tagName: string,
+  initialAttributes: Record<string, string> = {}
+): StubElement => {
+  const attributes = new Map(Object.entries(initialAttributes));
+
+  return {
+    tagName,
+    setAttribute(name, value) {
+      attributes.set(name, value);
+    },
+    getAttribute(name) {
+      return attributes.get(name) ?? null;
+    }
+  };
+};
+
+const createStubDocument = (initialHeadChildren: StubElement[] = []) => {
+  const head = {
+    children: [...initialHeadChildren],
+    appendChild(element: StubElement) {
+      head.children.push(element);
+
+      return element;
+    }
+  };
+
+  return {
+    head,
+    createElement: (tagName: string) => createStubElement(tagName),
+    getElementsByTagName: (tagName: string) =>
+      tagName === 'head' ? [head] : [],
+    querySelector: (selector: string) => {
+      if (selector !== '[http-equiv]') {
+        throw new Error(`stub document does not implement "${selector}"`);
+      }
+
+      return (
+        head.children.find(child => child.getAttribute('http-equiv') != null) ??
+        null
+      );
+    }
+  };
+};
+
+// isSafariBuild is frozen at module load from process.env.BROWSER, so the build
+// flavour cannot be flipped per test — each one has to be evaluated under the
+// env it is about. Loaded once per flavour here rather than per test because
+// re-evaluating this module also re-evaluates casper-js-sdk.
+const loadUtilsForBrowser = (browser: Browser): typeof import('./utils') => {
+  const previousBrowser = process.env.BROWSER;
+
+  process.env.BROWSER = browser;
+
+  let loaded: typeof import('./utils') | undefined;
+
+  jest.isolateModules(() => {
+    // A static import is hoisted above the env assignment above, which is the
+    // one thing this must not do.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    loaded = require('./utils');
+  });
+
+  if (previousBrowser === undefined) {
+    delete process.env.BROWSER;
+  } else {
+    process.env.BROWSER = previousBrowser;
+  }
+
+  return loaded as typeof import('./utils');
+};
+
+describe('setCSPForSafari', () => {
+  const safariUtils = loadUtilsForBrowser(Browser.Safari);
+  const globalWithDocument = globalThis as { document?: unknown };
+
+  const runAgainstDocument = (
+    utils: typeof import('./utils'),
+    stubDocument: ReturnType<typeof createStubDocument>
+  ) => {
+    const previousDocument = globalWithDocument.document;
+
+    globalWithDocument.document = stubDocument;
+
+    try {
+      utils.setCSPForSafari();
+    } finally {
+      if (previousDocument === undefined) {
+        delete globalWithDocument.document;
+      } else {
+        globalWithDocument.document = previousDocument;
+      }
+    }
+
+    return stubDocument;
+  };
+
+  it('appends the policy meta to head on a Safari build', () => {
+    const stubDocument = runAgainstDocument(safariUtils, createStubDocument());
+
+    expect(stubDocument.head.children).toHaveLength(1);
+
+    const [meta] = stubDocument.head.children;
+
+    expect(meta.tagName).toBe('meta');
+    expect(meta.getAttribute('http-equiv')).toBe('Content-Security-Policy');
+    // Compared against the shared builder rather than a literal: what the
+    // policy should say is pinned by the getSafariCspContent suite above, and
+    // what this asserts is that the very same string reaches the document.
+    expect(meta.getAttribute('content')).toBe(
+      safariUtils.getSafariCspContent()
+    );
+  });
+
+  it('appends nothing a second time', () => {
+    const stubDocument = createStubDocument();
+
+    runAgainstDocument(safariUtils, stubDocument);
+    runAgainstDocument(safariUtils, stubDocument);
+
+    expect(stubDocument.head.children).toHaveLength(1);
+  });
+
+  // The guard is on `[http-equiv]`, not on `[http-equiv="Content-Security-
+  // Policy"]`, so ANY http-equiv meta in a page template suppresses the only
+  // CSP a Safari build gets, silently and with the suite still green. None of
+  // the five index.html templates carries one today; this test is here so that
+  // the day one does, the consequence is written down rather than discovered.
+  it('appends nothing when the document already carries any http-equiv meta', () => {
+    const unrelatedMeta = createStubElement('meta', {
+      'http-equiv': 'refresh',
+      content: '30'
+    });
+    const stubDocument = runAgainstDocument(
+      safariUtils,
+      createStubDocument([unrelatedMeta])
+    );
+
+    expect(stubDocument.head.children).toEqual([unrelatedMeta]);
+  });
+
+  it.each([Browser.Chrome, Browser.Firefox, Browser.Edge])(
+    'touches nothing on a %s build',
+    browser => {
+      const stubDocument = runAgainstDocument(
+        loadUtilsForBrowser(browser),
+        createStubDocument()
+      );
+
+      expect(stubDocument.head.children).toHaveLength(0);
+    }
+  );
+});
+
+// setCSPForSafari only protects the documents that call it, and the call is a
+// single line inside each app's root component — easy to drop in a refactor and
+// easy to forget in a new app. The entries are enumerated from disk rather than
+// listed here so that a sixth app is covered the day it is added.
+describe('app entrypoints', () => {
+  const appsDir = path.resolve(__dirname, 'apps');
+  const apps = fs
+    .readdirSync(appsDir, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name)
+    .filter(app => fs.existsSync(path.join(appsDir, app, 'index.tsx')));
+
+  it('all five are discovered', () => {
+    // A rename that left the scan above matching nothing would otherwise turn
+    // the assertions below into a silent no-op.
+    expect(apps.length).toBe(5);
+  });
+
+  it.each(apps)('src/apps/%s/index.tsx calls setCSPForSafari', app => {
+    const source = fs.readFileSync(
+      path.join(appsDir, app, 'index.tsx'),
+      'utf8'
+    );
+
+    expect(source).toMatch(
+      /import\s*\{[^}]*\bsetCSPForSafari\b[^}]*\}\s*from\s*'@src\/utils'/
+    );
+    expect(source).toMatch(/^\s*setCSPForSafari\(\);$/m);
   });
 });


### PR DESCRIPTION
[WALLET-1415](https://make-software.atlassian.net/browse/WALLET-1415)

`setCSPForSafari` is the only source of a Content-Security-Policy for Safari builds — `getCSP()` in `webpack.config.js` has no Safari branch, and none of `manifest.v2.json`, `manifest.v3.json`, `manifest.v2.safari.json` declares the key. The `getSafariCspContent` suite added in #1431 pins what the policy *says*, but nothing asserted that the string ever reaches a document. A dropped `appendChild`, or a dropped call in a new app entry, left a Safari page running with no CSP at all and the suite still green.

Tests only; no production code changed.

### `setCSPForSafari`

Four cases against a stub document covering both branches:

- a Safari build appends exactly one `<meta http-equiv="Content-Security-Policy">` whose `content` is `getSafariCspContent()` verbatim — comparing against the shared builder rather than a literal, so this asserts the link (policy → document) that the existing suite could not;
- a second call appends nothing;
- a document that already carries **any** `http-equiv` meta gets no CSP. The guard is `[http-equiv]`, not `[http-equiv="Content-Security-Policy"]`, so an unrelated meta added to one of the five `index.html` templates would disable the only policy Safari gets. None carries one today; this pins the consequence rather than leaving it to be discovered;
- Chrome, Firefox and Edge builds do not touch the document at all.

The stub is hand-built rather than jsdom-backed: `jsdom` / `jest-environment-jsdom` are not dependencies of this repo and one function does not justify the tree. Its `querySelector` implements the `[http-equiv]` selector for real — it scans head for an element carrying the attribute — so the early-out is decided by document state, not by a canned return value. `isSafariBuild` is frozen at module load from `process.env.BROWSER`, so each build flavour is loaded once through `jest.isolateModules`.

### App entrypoints

The call is one line inside each app's root component. A guard enumerates `src/apps/*/index.tsx` from disk (so a sixth app is covered the day it is added), asserts all five are found, and asserts each imports and calls `setCSPForSafari`.

### Verification

Each assertion was checked against a deliberate regression, reverted after: dropping the `appendChild`, dropping the `isSafariBuild` guard, forcing the `http-equiv` guard always-true, widening `content` to `default-src *`, and removing the call (and separately the import) from an app entry — every one turns the suite red.

`npm run ci-check` passes (format, lint, tsc, knip, full jest with coverage thresholds). `npm run semgrep` reports 0 findings across 14 rules.

### Follow-up worth considering, not done here

Tightening the guard to `[http-equiv="Content-Security-Policy"]` would stop an unrelated meta from disabling the policy. That is a behaviour change; the test currently pins today's behaviour.

[WALLET-1415]: https://make-software.atlassian.net/browse/WALLET-1415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ