### PR TITLE
test: WALLET-1417 — await the sign dialog instead of asserting inside a listener

### DIFF
--- a/e2e-tests/popup/signature-request-scenarios/signature-request-scenarios.spec.ts
+++ b/e2e-tests/popup/signature-request-scenarios/signature-request-scenarios.spec.ts
@@ -44,12 +44,13 @@ popup.describe('Popup UI: signature request scenarios', () => {
     ).toBeVisible();
     await popupExpect(signatureRequestPage.getByText('1234')).toBeVisible();
 
-    page.on('dialog', async dialog => {
-      popupExpect(dialog.message()).toContain('Sign successful');
-      await dialog.accept();
-    });
+    const [dialog] = await Promise.all([
+      page.waitForEvent('dialog', { timeout: 15000 }),
+      signatureRequestPage.getByRole('button', { name: 'Sign' }).click()
+    ]);
 
-    await signatureRequestPage.getByRole('button', { name: 'Sign' }).click();
+    popupExpect(dialog.message()).toContain('Sign successful');
+    await dialog.accept();
   });
 
   popup('should signing the delegate deploy', async ({ page, context }) => {
@@ -77,12 +78,13 @@ popup.describe('Popup UI: signature request scenarios', () => {
 
     await popupExpect(signatureRequestPage.getByText('2.5 CSPR')).toBeVisible();
 
-    page.on('dialog', async dialog => {
-      popupExpect(dialog.message()).toContain('Sign successful');
-      await dialog.accept();
-    });
+    const [dialog] = await Promise.all([
+      page.waitForEvent('dialog', { timeout: 15000 }),
+      signatureRequestPage.getByRole('button', { name: 'Sign' }).click()
+    ]);
 
-    await signatureRequestPage.getByRole('button', { name: 'Sign' }).click();
+    popupExpect(dialog.message()).toContain('Sign successful');
+    await dialog.accept();
   });
 
   popup('should signing the undelegate deploy', async ({ page, context }) => {
@@ -112,12 +114,13 @@ popup.describe('Popup UI: signature request scenarios', () => {
 
     await popupExpect(signatureRequestPage.getByText('2.5 CSPR')).toBeVisible();
 
-    page.on('dialog', async dialog => {
-      popupExpect(dialog.message()).toContain('Sign successful');
-      await dialog.accept();
-    });
+    const [dialog] = await Promise.all([
+      page.waitForEvent('dialog', { timeout: 15000 }),
+      signatureRequestPage.getByRole('button', { name: 'Sign' }).click()
+    ]);
 
-    await signatureRequestPage.getByRole('button', { name: 'Sign' }).click();
+    popupExpect(dialog.message()).toContain('Sign successful');
+    await dialog.accept();
   });
 
   popup('should signing the redelegate deploy', async ({ page, context }) => {
@@ -141,12 +144,13 @@ popup.describe('Popup UI: signature request scenarios', () => {
 
     await popupExpect(signatureRequestPage.getByText('2.5 CSPR')).toBeVisible();
 
-    page.on('dialog', async dialog => {
-      popupExpect(dialog.message()).toContain('Sign successful');
-      await dialog.accept();
-    });
+    const [dialog] = await Promise.all([
+      page.waitForEvent('dialog', { timeout: 15000 }),
+      signatureRequestPage.getByRole('button', { name: 'Sign' }).click()
+    ]);
 
-    await signatureRequestPage.getByRole('button', { name: 'Sign' }).click();
+    popupExpect(dialog.message()).toContain('Sign successful');
+    await dialog.accept();
   });
 
   popup('should cancel the signing process', async ({ page, context }) => {
@@ -158,11 +162,13 @@ popup.describe('Popup UI: signature request scenarios', () => {
       page.getByRole('button', { name: 'Transfer' }).first().click()
     ]);
     await signatureRequestPage.waitForLoadState('domcontentloaded');
-    page.on('dialog', async dialog => {
-      popupExpect(dialog.message()).toContain('Sign cancelled');
-      await dialog.accept();
-    });
 
-    await signatureRequestPage.getByRole('button', { name: 'Cancel' }).click();
+    const [dialog] = await Promise.all([
+      page.waitForEvent('dialog', { timeout: 15000 }),
+      signatureRequestPage.getByRole('button', { name: 'Cancel' }).click()
+    ]);
+
+    popupExpect(dialog.message()).toContain('Sign cancelled');
+    await dialog.accept();
   });
 });


### PR DESCRIPTION
Closes [WALLET-1417](https://make-software.atlassian.net/browse/WALLET-1417).

## Problem

The only end-to-end observation that signing produced a signature was a `popupExpect(dialog.message()).toContain(…)` living **inside** a `page.on('dialog', …)` callback. In all five scenarios the listener was registered immediately before the test's terminal `await …click()`, and the test body ended at that click. Nothing awaited the dialog.

If no dialog ever fired, the callback never ran, the assertion never executed, and the test passed. `popupExpect` is `popup.expect` — a hard, non-soft expect — so this was not failures accumulating silently; the assertion simply never happened.

`dialog` appeared nowhere else in `e2e-tests/`, so there was no `waitForEvent('dialog')` and no global dialog handler in the fixtures. The only `waitForEvent` in the spec is `context.waitForEvent('page', …)`, which awaits the approval window opening — a pre-signature fact, not the result.

Net effect: the repository's only executable coverage of the signature-request page could not distinguish "the user signed and the dapp received the signature" from "the user clicked Sign and nothing happened". A delivery regression on the sign path would ship with the e2e suite green.

## Change

Await the event instead of listening for it, in all five scenarios:

```ts
const [dialog] = await Promise.all([
  page.waitForEvent('dialog', { timeout: 15000 }),
  signatureRequestPage.getByRole('button', { name: 'Sign' }).click()
]);

popupExpect(dialog.message()).toContain('Sign successful');
await dialog.accept();
```

Two details worth calling out:

- **The dialog is observed on `page`, not on `signatureRequestPage`.** It is the playground dapp's own `alert()`, raised in the tab that made the request — which is also where the original listener was registered. Awaiting it on the extension's signature-request window would hang until timeout in every test.
- **The wait is armed before the click, not after it.** A bare `await …click()` followed by `await page.waitForEvent('dialog')` can miss a dialog that fires in the gap between the two. `Promise.all` closes that race, and matches the idiom already used in this file for `context.waitForEvent('page', …)`.

## Why it matters now

This is the suite that should have caught regressions in #1439 (`fix: WALLET-1384 — keep the payload of every in-flight signature request`), whose review surfaced the gap. There the moment the response is emitted is also the moment the payload is deleted and the page's `signatureRequest` collapses to `undefined` — a transition the suite was structurally unable to observe.

The spec is otherwise untouched; this is pre-existing and predates #1439.

## Verification

- `format:check`, `lint`, `tsc`, `knip` clean; jest 580 tests / 77 suites pass.
- `tsc -p e2e-tests/tsconfig.json`, `prettier --check`, and `eslint` on the changed file all clean against this branch's head.
- **The e2e suite itself was not run green.** It does not run in my local environment for reasons unrelated to this change: every test in the file dies in `beforeEach` at `fixtures.ts:348`, where `CasperWalletProvider` never appears on the playground page, so `connectAccounts` times out. Reproduced identically on the unmodified spec, and it fails the same way headful, so it is neither caused by this change nor by headless mode. The assertions added here need a working run to demonstrate.

[WALLET-1417]: https://make-software.atlassian.net/browse/WALLET-1417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ