### PR TITLE
fix: WALLET-1414 — surface a failed icon load instead of rendering nothing

### DIFF
--- a/src/libs/ui/components/svg-icon/report-icon-load-failure.test.ts
+++ b/src/libs/ui/components/svg-icon/report-icon-load-failure.test.ts
@@ -1,0 +1,82 @@
+import { reportIconLoadFailure } from './report-icon-load-failure';
+
+describe('reportIconLoadFailure', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalTestEnv = process.env.TEST_ENV;
+  let consoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+    if (originalTestEnv === undefined) {
+      delete process.env.TEST_ENV;
+    } else {
+      process.env.TEST_ENV = originalTestEnv;
+    }
+  });
+
+  // The dedupe set is module-level and therefore shared across this file, so
+  // every case below owns a src no other case uses.
+
+  it('reports the failed src and the reason behind it', () => {
+    reportIconLoadFailure(
+      'assets/icons/reported-once.svg',
+      new Error('Not found')
+    );
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError.mock.calls[0][0]).toContain(
+      'assets/icons/reported-once.svg'
+    );
+    expect(consoleError.mock.calls[0][0]).toContain('Not found');
+  });
+
+  it('stays silent on a repeat failure of the same src', () => {
+    reportIconLoadFailure('assets/icons/repeated.svg', new Error('Not found'));
+    reportIconLoadFailure('assets/icons/repeated.svg', new Error('Not found'));
+    reportIconLoadFailure('assets/icons/repeated.svg', new Error('Not found'));
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  });
+
+  it('still reports a different src after one has been reported', () => {
+    reportIconLoadFailure('assets/icons/first.svg', new Error('Not found'));
+    reportIconLoadFailure('assets/icons/second.svg', new Error('Not found'));
+
+    expect(consoleError).toHaveBeenCalledTimes(2);
+    expect(consoleError.mock.calls[1][0]).toContain('assets/icons/second.svg');
+  });
+
+  // e2e-tests/fixtures.ts fails the run on any console line starting with
+  // '[SvgIcon]' — that gate belongs to assertLocalIconSrc, which catches a
+  // non-bundled src reaching this component. A failed fetch is not a policy
+  // violation, so this marker deliberately sits outside that prefix. Pinned
+  // here so a later rename cannot silently re-arm the gate.
+  it('uses a marker the e2e violation gate does not match', () => {
+    reportIconLoadFailure('assets/icons/marker.svg', new Error('Not found'));
+
+    const message: string = consoleError.mock.calls[0][0];
+
+    expect(message.startsWith('[SvgIcon:load]')).toBe(true);
+    expect(message.startsWith('[SvgIcon]')).toBe(false);
+  });
+
+  // Unlike assertLocalIconSrc, which is silent outside observed builds: this
+  // is a runtime failure that otherwise only ever happens on a user's machine.
+  it('stays ungated by build, unlike assertLocalIconSrc', () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.TEST_ENV;
+
+    reportIconLoadFailure('assets/icons/in-prod.svg', new Error('Not found'));
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/libs/ui/components/svg-icon/report-icon-load-failure.ts
+++ b/src/libs/ui/components/svg-icon/report-icon-load-failure.ts
@@ -1,0 +1,36 @@
+/**
+ * SvgIcon is react-inlinesvg: on a failed fetch or parse it renders its
+ * `children` (null unless supplied) and calls `onError`, and logs nothing of
+ * its own — its only console.error calls are cache plumbing. Without this
+ * report an icon that never arrived is indistinguishable from an icon that was
+ * never asked for, in development and in production alike.
+ *
+ * The marker is `[SvgIcon:load]`, deliberately not `[SvgIcon]`:
+ * e2e-tests/fixtures.ts fails the run on any console line starting with the
+ * latter. That gate belongs to assertLocalIconSrc, which catches a non-bundled
+ * src reaching this component — a security invariant. A failed network fetch
+ * is not one, and sharing the prefix would make an unrelated CI failure read
+ * as a security regression.
+ *
+ * Reports in every build, production included — unlike assertLocalIconSrc,
+ * which enforces a development-time invariant and stays silent in shipped
+ * builds. This one describes a runtime failure that otherwise surfaces only on
+ * a user's machine.
+ */
+
+// react-inlinesvg caches successes only (CacheStore.isCached is true for
+// STATUS.LOADED alone), so every mounted instance sharing a broken src
+// refetches and fails again — twenty rows of a list would emit twenty
+// identical lines. The repetition carries no information the first line
+// doesn't, so one report per src is the whole signal.
+const reportedSources = new Set<string>();
+
+export const reportIconLoadFailure = (src: string, error: Error): void => {
+  if (reportedSources.has(src)) {
+    return;
+  }
+
+  reportedSources.add(src);
+
+  console.error(`[SvgIcon:load] failed to inline "${src}": ${error.message}`);
+};

--- a/src/libs/ui/components/svg-icon/svg-icon.test.tsx
+++ b/src/libs/ui/components/svg-icon/svg-icon.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ThemeProvider } from 'styled-components';
+
+import { lightTheme } from '@libs/ui/theme-config';
+
+import { SvgIcon } from './svg-icon';
+
+// react-inlinesvg only reaches its FAILED branch behind canUseDOM(), and this
+// repo's jest environment is 'node' — the real component returns its `loader`
+// and short-circuits before any of the failure handling runs. The stub stands
+// in for exactly the two things the library documents on failure: it calls
+// onError, and it renders the children it was given. This mirrors the
+// documented behaviour of react-inlinesvg 4.5.0 (the version pinned in
+// package.json as "^4.5.0") — a minor bump could change that branch without
+// this suite noticing, since it asserts against the stub, not the library.
+const mockInlineSvg = jest.fn();
+
+jest.mock('react-inlinesvg', () => ({
+  __esModule: true,
+  default: (props: unknown) => mockInlineSvg(props)
+}));
+
+interface StubProps {
+  onError?: (error: Error) => void;
+  children?: React.ReactNode;
+}
+
+describe('SvgIcon', () => {
+  let consoleError: jest.SpyInstance;
+
+  const render = (src: string) =>
+    renderToStaticMarkup(
+      <ThemeProvider theme={lightTheme}>
+        <SvgIcon src={src} />
+      </ThemeProvider>
+    );
+
+  beforeEach(() => {
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockInlineSvg.mockReset();
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  // A bundled path throughout, so assertLocalIconSrc stays quiet and cannot be
+  // mistaken for the assertion under test.
+  it('reports the failure and renders the placeholder when the file fails to load', () => {
+    mockInlineSvg.mockImplementation((props: StubProps) => {
+      props.onError?.(new Error('Not found'));
+      return props.children ?? null;
+    });
+
+    const html = render('assets/icons/failing-in-svg-icon-test.svg');
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError.mock.calls[0][0]).toContain('[SvgIcon:load]');
+    expect(consoleError.mock.calls[0][0]).toContain(
+      'assets/icons/failing-in-svg-icon-test.svg'
+    );
+    expect(html).toContain('data-testid="broken-icon-placeholder"');
+  });
+
+  it('renders the icon and reports nothing when the file loads', () => {
+    mockInlineSvg.mockImplementation(() => <svg data-testid="loaded-icon" />);
+
+    const html = render('assets/icons/loading-in-svg-icon-test.svg');
+
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(html).toContain('data-testid="loaded-icon"');
+    expect(html).not.toContain('data-testid="broken-icon-placeholder"');
+  });
+});

--- a/src/libs/ui/components/svg-icon/svg-icon.tsx
+++ b/src/libs/ui/components/svg-icon/svg-icon.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { Color, getColorFromTheme } from '@libs/ui/utils';
 
 import { assertLocalIconSrc } from './assert-local-icon-src';
+import { reportIconLoadFailure } from './report-icon-load-failure';
 
 type Ref = HTMLDivElement;
 
@@ -75,12 +76,53 @@ const Container = styled('div').withConfig({
   })
 );
 
-const StyledReactSVG = styled(ReactSVG)<SvgIconProps>(
-  ({ size, width, height }) => ({
-    display: 'flex',
-    width: width != null ? width : size,
-    height: height != null ? height : size
-  })
+// Only the three props the callback below actually reads. Typing this with the
+// full SvgIconProps pulls in HTMLAttributes' `onError?: ReactEventHandler`,
+// which intersects with react-inlinesvg's `onError?: (error: Error) => void`
+// and leaves no handler able to satisfy both.
+const StyledReactSVG = styled(ReactSVG)<{
+  size: number;
+  width?: number | string;
+  height?: number | string;
+}>(({ size, width, height }) => ({
+  display: 'flex',
+  width: width != null ? width : size,
+  height: height != null ? height : size
+}));
+
+/**
+ * Stands in for an icon whose file failed to fetch or parse. Written as
+ * literal JSX rather than pointed at an asset path on purpose: it must not
+ * fetch anything and it must not route back through SvgIcon. RemoteIcon's
+ * error-recovery path already ends in an SvgIcon, so an asset-backed fallback
+ * here could fail in turn and loop.
+ *
+ * Container already fixes the width and height, so a failed icon never shifted
+ * the layout — this changes nothing geometrically, it only makes the breakage
+ * visible instead of leaving a hole.
+ *
+ * react-inlinesvg's FAILED branch (`react-inlinesvg/src/index.tsx:46-48`)
+ * returns `children` verbatim — unlike its success branch, it does not
+ * `cloneElement` them with StyledReactSVG's generated class. So this
+ * placeholder never receives that class; its effective parent is Container,
+ * and the `width="100%" height="100%"` below resolve against Container's box.
+ */
+const BrokenIconPlaceholder = () => (
+  <svg
+    viewBox="0 0 24 24"
+    width="100%"
+    height="100%"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    opacity={0.4}
+    aria-hidden="true"
+    focusable="false"
+    data-testid="broken-icon-placeholder"
+  >
+    <rect x="3" y="3" width="18" height="18" rx="4" />
+    <path d="M8 16 16 8" />
+  </svg>
 );
 
 export const SvgIcon = forwardRef<Ref, SvgIconProps>(
@@ -132,7 +174,10 @@ export const SvgIcon = forwardRef<Ref, SvgIconProps>(
           size={size}
           height={height}
           width={width}
-        />
+          onError={error => reportIconLoadFailure(src, error)}
+        >
+          <BrokenIconPlaceholder />
+        </StyledReactSVG>
       </Container>
     );
   }


### PR DESCRIPTION
https://make-software.atlassian.net/browse/WALLET-1414

## Problem

`SvgIcon` renders `react-inlinesvg` with no `onError` and no children. The library
returns `children` — `null` by default — when its status is `FAILED` or `UNSUPPORTED`,
and its own `console.error` calls are cache plumbing only. A failed fetch or parse was
therefore a no-op in both directions: nothing rendered, nothing reported, in every
environment. Every `SvgIcon` in the extension behaved this way, and 98 files render one.

The case that surfaced it: `RemoteIcon` routes its error-recovery path through
`SvgIcon`, so a bundled fallback asset that is missing, misspelled, or moved by a
refactor made the failed remote image and its intended fallback both vanish silently.
`assertLocalIconSrc` cannot catch it either — it fires on remote sources reaching
`SvgIcon`, never on a local-path fetch failure.

## Change

- `report-icon-load-failure.ts` — reports a failed load through `console.error`, once
  per `src`. `react-inlinesvg` caches successes only (`CacheStore.isCached` is true for
  `STATUS.LOADED` alone), so every instance sharing a broken source refetches and fails
  again; a list of twenty rows would otherwise emit twenty identical lines.
- `SvgIcon` passes `onError` to the library and supplies a placeholder as failure
  children — literal JSX, so it performs no fetch and cannot route back through
  `SvgIcon` and loop. `Container` already fixed the element's width and height, so a
  failed icon never shifted the layout; this makes the breakage visible instead of
  leaving a hole.
- The `StyledReactSVG` generic is narrowed to the three props its callback reads.
  Typing it with the full `SvgIconProps` pulls in `HTMLAttributes`' `onError`, whose
  intersection with the library's `ErrorCallback` resolves the parameter to
  `SyntheticEvent` — no handler can satisfy both. `SvgIconProps` itself is unchanged,
  so no call site moves.

## Notes for review

- **The marker is `[SvgIcon:load]`, not `[SvgIcon]`, deliberately.** `e2e-tests/fixtures.ts:49`
  fails the run on any console line starting with `[CSP]` or `[SvgIcon]`. That gate
  belongs to `assertLocalIconSrc`, which catches a non-bundled src reaching this
  inlining component — a security invariant. A failed network fetch is not one, and
  sharing the prefix would make an unrelated CI failure read as a security regression.
  A test pins the distinction so a rename cannot silently re-arm the gate.
- **It reports in production too**, unlike `assertLocalIconSrc`. That guard enforces a
  development-time invariant; this one describes a runtime failure that otherwise
  surfaces only on a user's machine — which is what the ticket reports.
- **Nothing sensitive reaches the log.** `error.message` is only ever a string authored
  by the library itself (`Not found`, `Content type isn't valid: …`, `Missing src`,
  `Could not convert the src to a React element`) — never a response body, never a URL
  beyond `src`. Every call site passing a dynamic `src` already gates on
  `isBundledAssetPath`.
- **The dedupe set is bounded.** `svg-icon` is imported by no background or
  content-script module, so the set lives for one popup document's lifetime and holds
  at most the distinct bundled asset paths that failed in it.
- **No spurious reports.** `react-inlinesvg` filters `AbortError` before reaching
  `handleError`, so unmount and navigation teardown produce nothing; a single failure
  that fires `onError` twice is absorbed by the dedupe.
- The component test stubs `react-inlinesvg`. Under `testEnvironment: 'node'` the real
  component short-circuits on `canUseDOM()` and returns its `loader`, so the failure
  branch is unreachable without a stub. A deliberate-revert check confirmed the test
  fails when `onError` and the children are removed.

`npm run ci-check` green: 80 suites, 620 tests.
