### PR TITLE
chore: bump js-yaml to 3.15.1 and 4.3.1 for CVE-2026-59870

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1384,9 +1384,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15146,9 +15146,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
     "brace-expansion@2": "^2.1.2",
     "fast-uri": "^3.1.5",
     "adm-zip": "^0.6.0",
-    "js-yaml@4": "^4.3.0",
+    "js-yaml@3": "^3.15.1",
+    "js-yaml@4": "^4.3.1",
     "shell-quote": "^1.9.0",
     "linkify-it": "^5.0.2"
   },


### PR DESCRIPTION
Closes the two remaining open Dependabot alerts (#389, #390), both GHSA-5p4m-2wfm-xmqj — quadratic CPU consumption in `!!omap` resolution.

The advisory affects 3.x and 4.x alike and the fix was not backported into the lines we were on, so the patched releases sit on new patch versions: 3.15.1 and 4.3.1.

Both copies are dev-only transitives and are pinned through the existing `overrides` block:

- `js-yaml@4` `^4.3.0` → `^4.3.1` — the hoisted copy, pulled in by `@eslint/eslintrc`, `i18next-parser` and `markdownlint-cli`.
- `js-yaml@3` `^3.15.1` — new entry for the nested copy under `@istanbuljs/load-nyc-config`. Its `^3.13.1` range would have resolved there on its own, but the pin makes it deterministic and matches the `brace-expansion@1`/`@2` style already used here.

`npm audit` no longer reports js-yaml. The other high-severity advisories it lists are pre-existing, dev-only and already auto-dismissed.