### PR TITLE
fix: WALLET-1418 — reclaim leaked signature-payload slots

### DIFF
--- a/src/background/handlers/sdk-methods.test.ts
+++ b/src/background/handlers/sdk-methods.test.ts
@@ -26,6 +26,7 @@ import { windowRequestOpened } from '@background/redux/windowManagement/actions'
 import { emitSdkEventToActiveTabsWithOrigin } from '@background/utils';
 
 import { sdkMethod } from '@content/sdk-method';
+import { SdkErrorCode } from '@content/sdk-types';
 
 import { encryptAsHexWithCasperPublicKey } from '@libs/crypto';
 
@@ -454,6 +455,12 @@ describe('signRequest', () => {
         { requestId: 'req-1' }
       )
     });
+    // A different condition from a capacity refusal, and it must stay
+    // distinguishable: this one is about the deploy, not about the wallet.
+    const refused = result as {
+      response: { payload: { errorCode?: string } };
+    };
+    expect(refused.response.payload.errorCode).toBeUndefined();
     expect(openWindowMock).not.toHaveBeenCalled();
     expect(dispatch).not.toHaveBeenCalled();
   });
@@ -523,7 +530,8 @@ describe('signRequest', () => {
       response: sdkMethod.signResponse(
         {
           cancelled: true,
-          message: 'Too many pending signature requests'
+          message: 'Too many pending signature requests',
+          errorCode: SdkErrorCode.tooManyPendingRequests
         },
         { requestId: 'req-1' }
       )
@@ -531,6 +539,26 @@ describe('signRequest', () => {
     // Only the payload dispatch — no `windowRequestOpened` descriptor.
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(openWindowMock).not.toHaveBeenCalled();
+  });
+
+  it('a capacity refusal is surfaced in the extension log, identifiers only', async () => {
+    isEqualCIMock.mockReturnValue(false);
+    selectDeploysJsonByIdMock.mockReturnValue({});
+    const { store } = makeStore();
+
+    await handleSdkMethod(
+      sdkMethod.signRequest({ deployJson, signingPublicKeyHex: 'PK-1' }, META),
+      SENDER,
+      store
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.any(String), {
+      requestId: 'req-1',
+      method: sdkMethod.signRequest.type
+    });
+    const logged = JSON.stringify(consoleErrorSpy.mock.calls);
+    expect(logged).not.toContain('PK-1');
+    expect(logged).not.toContain(ORIGIN);
   });
 
   it('a prototype-name requestId reads as absent, not as an inherited member', async () => {
@@ -554,7 +582,8 @@ describe('signRequest', () => {
       response: sdkMethod.signResponse(
         {
           cancelled: true,
-          message: 'Too many pending signature requests'
+          message: 'Too many pending signature requests',
+          errorCode: SdkErrorCode.tooManyPendingRequests
         },
         { requestId: 'constructor' }
       )
@@ -730,13 +759,40 @@ describe('signTypedDataRequest', () => {
           signature: null,
           digest: null,
           publicKey: null,
-          error: 'Too many pending signature requests'
+          error: 'Too many pending signature requests',
+          errorCode: SdkErrorCode.tooManyPendingRequests
         },
         { requestId: 'req-1' }
       )
     });
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(openWindowMock).not.toHaveBeenCalled();
+  });
+
+  it('a capacity refusal is surfaced in the extension log, identifiers only', async () => {
+    selectEip712JsonByIdMock.mockReturnValue({});
+    const { store } = makeStore();
+
+    await handleSdkMethod(
+      sdkMethod.signTypedDataRequest(
+        {
+          typedData: { foo: 'secret' } as any,
+          options: undefined,
+          signingPublicKeyHex: 'PK-1'
+        },
+        META
+      ),
+      SENDER,
+      store
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.any(String), {
+      requestId: 'req-1',
+      method: sdkMethod.signTypedDataRequest.type
+    });
+    const logged = JSON.stringify(consoleErrorSpy.mock.calls);
+    expect(logged).not.toContain('secret');
+    expect(logged).not.toContain(ORIGIN);
   });
 
   it('a prototype-name requestId reads as absent, not as an inherited member', async () => {
@@ -764,7 +820,8 @@ describe('signTypedDataRequest', () => {
           signature: null,
           digest: null,
           publicKey: null,
-          error: 'Too many pending signature requests'
+          error: 'Too many pending signature requests',
+          errorCode: SdkErrorCode.tooManyPendingRequests
         },
         { requestId: 'constructor' }
       )

--- a/src/background/handlers/sdk-methods.test.ts
+++ b/src/background/handlers/sdk-methods.test.ts
@@ -13,6 +13,8 @@ import { MainStore } from '@background/redux/get-main-store';
 import { selectVaultIsLocked } from '@background/redux/session/selectors';
 import {
   selectAccountNamesByOriginDict,
+  selectDeploysJsonById,
+  selectEip712JsonById,
   selectIsAccountConnected,
   selectVaultActiveAccount
 } from '@background/redux/vault/selectors';
@@ -48,7 +50,9 @@ jest.mock('@src/utils', () => ({
 jest.mock('@background/redux/vault/selectors', () => ({
   selectVaultActiveAccount: jest.fn(),
   selectIsAccountConnected: jest.fn(),
-  selectAccountNamesByOriginDict: jest.fn()
+  selectAccountNamesByOriginDict: jest.fn(),
+  selectDeploysJsonById: jest.fn(),
+  selectEip712JsonById: jest.fn()
 }));
 jest.mock('@background/redux/session/selectors', () => ({
   selectVaultIsLocked: jest.fn()
@@ -89,6 +93,12 @@ const selectNamesByOriginMock =
 const selectIsLockedMock = selectVaultIsLocked as jest.MockedFunction<
   typeof selectVaultIsLocked
 >;
+const selectDeploysJsonByIdMock = selectDeploysJsonById as jest.MockedFunction<
+  typeof selectDeploysJsonById
+>;
+const selectEip712JsonByIdMock = selectEip712JsonById as jest.MockedFunction<
+  typeof selectEip712JsonById
+>;
 
 const ORIGIN = 'https://dapp.example';
 const META = { requestId: 'req-1' };
@@ -119,6 +129,10 @@ beforeEach(() => {
     publicKey: 'PK-1'
   } as any);
   selectIsConnectedMock.mockReturnValue(false);
+  // `dispatch` is a spy, so the store never really changes: the default stands
+  // for a payload write that was accepted.
+  selectDeploysJsonByIdMock.mockReturnValue({ [META.requestId]: '{}' });
+  selectEip712JsonByIdMock.mockReturnValue({ [META.requestId]: '{}' });
   consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 });
 
@@ -445,6 +459,89 @@ describe('signRequest', () => {
     expect(result).toEqual({ handled: true, response: undefined });
   });
 
+  it('payload write refused at capacity → cancelled response, no window', async () => {
+    // The map stays empty after the dispatch, so the signature page would have
+    // had nothing to render and the dapp promise would have hung to its own
+    // 30-minute timeout.
+    isEqualCIMock.mockReturnValue(false);
+    selectDeploysJsonByIdMock.mockReturnValue({});
+    const { store, dispatch } = makeStore();
+
+    const result = await handleSdkMethod(
+      sdkMethod.signRequest({ deployJson, signingPublicKeyHex: 'PK-1' }, META),
+      SENDER,
+      store
+    );
+
+    expect(result).toEqual({
+      handled: true,
+      response: sdkMethod.signResponse(
+        {
+          cancelled: true,
+          message: 'Too many pending signature requests'
+        },
+        { requestId: 'req-1' }
+      )
+    });
+    // Only the payload dispatch — no `windowRequestOpened` descriptor.
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(openWindowMock).not.toHaveBeenCalled();
+  });
+
+  it('a prototype-name requestId reads as absent, not as an inherited member', async () => {
+    // A bare `map[requestId]` would answer with the `Object` constructor here
+    // and conclude the refused write had succeeded.
+    isEqualCIMock.mockReturnValue(false);
+    selectDeploysJsonByIdMock.mockReturnValue({});
+    const { store, dispatch } = makeStore();
+
+    const result = await handleSdkMethod(
+      sdkMethod.signRequest(
+        { deployJson, signingPublicKeyHex: 'PK-1' },
+        { requestId: 'constructor' }
+      ),
+      SENDER,
+      store
+    );
+
+    expect(result).toEqual({
+      handled: true,
+      response: sdkMethod.signResponse(
+        {
+          cancelled: true,
+          message: 'Too many pending signature requests'
+        },
+        { requestId: 'constructor' }
+      )
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(openWindowMock).not.toHaveBeenCalled();
+  });
+
+  it('a falsy stored payload counts as present', async () => {
+    // `JSON.parse('0')` is what lands in the map, so presence must be a
+    // null check — a truthiness test would refuse an accepted write.
+    isEqualCIMock.mockReturnValue(false);
+    selectDeploysJsonByIdMock.mockReturnValue({ [META.requestId]: 0 } as any);
+    const { store, dispatch } = makeStore();
+
+    const result = await handleSdkMethod(
+      sdkMethod.signRequest(
+        { deployJson: '0', signingPublicKeyHex: 'PK-1' },
+        META
+      ),
+      SENDER,
+      store
+    );
+
+    expect(result).toEqual({ handled: true, response: undefined });
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(openWindowMock).toHaveBeenCalledWith(
+      store,
+      expect.objectContaining({ windowApp: WindowApp.SignatureRequestDeploy })
+    );
+  });
+
   it('passes the requestId to openWindow so the window can be attached', async () => {
     isEqualCIMock.mockReturnValue(false);
     const { store } = makeStore();
@@ -541,6 +638,99 @@ describe('signTypedDataRequest', () => {
       expect.objectContaining({ windowApp: WindowApp.SignatureRequestEip712 })
     );
     expect(result).toEqual({ handled: true, response: undefined });
+  });
+
+  it('payload write refused at capacity → cancelled response, no window', async () => {
+    selectEip712JsonByIdMock.mockReturnValue({});
+    const { store, dispatch } = makeStore();
+
+    const result = await handleSdkMethod(
+      sdkMethod.signTypedDataRequest(
+        {
+          typedData: { foo: 'bar' } as any,
+          options: undefined,
+          signingPublicKeyHex: 'PK-1'
+        },
+        META
+      ),
+      SENDER,
+      store
+    );
+
+    expect(result).toEqual({
+      handled: true,
+      response: sdkMethod.signTypedDataResponse(
+        {
+          cancelled: true,
+          signature: null,
+          digest: null,
+          publicKey: null,
+          error: 'Too many pending signature requests'
+        },
+        { requestId: 'req-1' }
+      )
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(openWindowMock).not.toHaveBeenCalled();
+  });
+
+  it('a prototype-name requestId reads as absent, not as an inherited member', async () => {
+    selectEip712JsonByIdMock.mockReturnValue({});
+    const { store, dispatch } = makeStore();
+
+    const result = await handleSdkMethod(
+      sdkMethod.signTypedDataRequest(
+        {
+          typedData: { foo: 'bar' } as any,
+          options: undefined,
+          signingPublicKeyHex: 'PK-1'
+        },
+        { requestId: 'constructor' }
+      ),
+      SENDER,
+      store
+    );
+
+    expect(result).toEqual({
+      handled: true,
+      response: sdkMethod.signTypedDataResponse(
+        {
+          cancelled: true,
+          signature: null,
+          digest: null,
+          publicKey: null,
+          error: 'Too many pending signature requests'
+        },
+        { requestId: 'constructor' }
+      )
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(openWindowMock).not.toHaveBeenCalled();
+  });
+
+  it('a falsy stored payload counts as present', async () => {
+    selectEip712JsonByIdMock.mockReturnValue({ [META.requestId]: '' });
+    const { store, dispatch } = makeStore();
+
+    const result = await handleSdkMethod(
+      sdkMethod.signTypedDataRequest(
+        {
+          typedData: { foo: 'bar' } as any,
+          options: undefined,
+          signingPublicKeyHex: 'PK-1'
+        },
+        META
+      ),
+      SENDER,
+      store
+    );
+
+    expect(result).toEqual({ handled: true, response: undefined });
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(openWindowMock).toHaveBeenCalledWith(
+      store,
+      expect.objectContaining({ windowApp: WindowApp.SignatureRequestEip712 })
+    );
   });
 
   it('passes the requestId to openWindow so the window can be attached', async () => {

--- a/src/background/handlers/sdk-methods.test.ts
+++ b/src/background/handlers/sdk-methods.test.ts
@@ -12,12 +12,17 @@ import { openWindow } from '@background/open-window';
 import { MainStore } from '@background/redux/get-main-store';
 import { selectVaultIsLocked } from '@background/redux/session/selectors';
 import {
+  deployPayloadReceived,
+  eip712PayloadReceived
+} from '@background/redux/vault/actions';
+import {
   selectAccountNamesByOriginDict,
   selectDeploysJsonById,
   selectEip712JsonById,
   selectIsAccountConnected,
   selectVaultActiveAccount
 } from '@background/redux/vault/selectors';
+import { windowRequestOpened } from '@background/redux/windowManagement/actions';
 import { emitSdkEventToActiveTabsWithOrigin } from '@background/utils';
 
 import { sdkMethod } from '@content/sdk-method';
@@ -118,6 +123,31 @@ const SENDER = {
   url: 'https://dapp.example/page',
   tab: { id: 9 }
 } as Runtime.MessageSender;
+
+// `reconcileStalePayloadsSaga` may resume at any `await`, and a payload that no
+// descriptor and no window claims is exactly what it purges — so the payload
+// write and `windowRequestOpened` have to land in one synchronous block. The
+// probe is a microtask queued at the write: an `await` in between would let it
+// run before the descriptor.
+function watchGapBeforeDescriptor(dispatch: jest.Mock, payloadType: string) {
+  const seen: { microtaskRanBeforeDescriptor: boolean | null } = {
+    microtaskRanBeforeDescriptor: null
+  };
+  let microtaskRan = false;
+
+  dispatch.mockImplementation((action: { type: string }) => {
+    if (action.type === payloadType) {
+      void Promise.resolve().then(() => {
+        microtaskRan = true;
+      });
+    }
+    if (action.type === windowRequestOpened.type) {
+      seen.microtaskRanBeforeDescriptor = microtaskRan;
+    }
+  });
+
+  return seen;
+}
 
 let consoleErrorSpy: jest.SpyInstance;
 
@@ -459,6 +489,21 @@ describe('signRequest', () => {
     expect(result).toEqual({ handled: true, response: undefined });
   });
 
+  it('dispatches the deploy payload and the descriptor in one synchronous block', async () => {
+    isEqualCIMock.mockReturnValue(false);
+    const { store, dispatch } = makeStore();
+    const seen = watchGapBeforeDescriptor(dispatch, deployPayloadReceived.type);
+
+    await handleSdkMethod(
+      sdkMethod.signRequest({ deployJson, signingPublicKeyHex: 'PK-1' }, META),
+      SENDER,
+      store
+    );
+
+    // `null` would mean no descriptor was dispatched at all.
+    expect(seen.microtaskRanBeforeDescriptor).toBe(false);
+  });
+
   it('payload write refused at capacity → cancelled response, no window', async () => {
     // The map stays empty after the dispatch, so the signature page would have
     // had nothing to render and the dapp promise would have hung to its own
@@ -638,6 +683,26 @@ describe('signTypedDataRequest', () => {
       expect.objectContaining({ windowApp: WindowApp.SignatureRequestEip712 })
     );
     expect(result).toEqual({ handled: true, response: undefined });
+  });
+
+  it('dispatches the eip712 payload and the descriptor in one synchronous block', async () => {
+    const { store, dispatch } = makeStore();
+    const seen = watchGapBeforeDescriptor(dispatch, eip712PayloadReceived.type);
+
+    await handleSdkMethod(
+      sdkMethod.signTypedDataRequest(
+        {
+          typedData: { foo: 'bar' } as any,
+          options: undefined,
+          signingPublicKeyHex: 'PK-1'
+        },
+        META
+      ),
+      SENDER,
+      store
+    );
+
+    expect(seen.microtaskRanBeforeDescriptor).toBe(false);
   });
 
   it('payload write refused at capacity → cancelled response, no window', async () => {

--- a/src/background/handlers/sdk-methods.ts
+++ b/src/background/handlers/sdk-methods.ts
@@ -36,6 +36,7 @@ import { emitSdkEventToActiveTabsWithOrigin } from '@background/utils';
 import { SiteNotConnectedError, WalletLockedError } from '@content/sdk-errors';
 import { sdkEvent } from '@content/sdk-event';
 import { SdkMethod, sdkMethod } from '@content/sdk-method';
+import { SdkErrorCode } from '@content/sdk-types';
 
 import { encryptAsHexWithCasperPublicKey } from '@libs/crypto';
 
@@ -53,6 +54,20 @@ const APPROVAL_REQUEST_TYPES: ReadonlySet<string> = new Set([
   sdkMethod.signTypedDataRequest.type,
   sdkMethod.decryptMessageRequest.type
 ]);
+
+const CAPACITY_REFUSAL_MESSAGE = 'Too many pending signature requests';
+
+// The dapp half of a capacity refusal is `errorCode`; this is the extension
+// half, so a wallet refusing every signature is not invisible on this side
+// either. Identifiers only — never the deploy, the typed data or the origin.
+// Log-only rather than `sagaError`: this path is dapp-triggerable, and a banner
+// mounted over every app surface would be a page's to spam.
+function reportCapacityRefusal(action: SdkMethod) {
+  console.error(
+    'sdk-methods: pending-payload map at capacity, request refused',
+    { requestId: action.meta.requestId, method: action.type }
+  );
+}
 
 export async function handleSdkMethod(
   action: SdkMethod,
@@ -231,12 +246,15 @@ export async function handleSdkMethod(
         action.meta.requestId
       ) == null
     ) {
+      reportCapacityRefusal(action);
+
       return {
         handled: true,
         response: sdkMethod.signResponse(
           {
             cancelled: true,
-            message: 'Too many pending signature requests'
+            message: CAPACITY_REFUSAL_MESSAGE,
+            errorCode: SdkErrorCode.tooManyPendingRequests
           },
           { requestId: action.meta.requestId }
         )
@@ -327,6 +345,8 @@ export async function handleSdkMethod(
         action.meta.requestId
       ) == null
     ) {
+      reportCapacityRefusal(action);
+
       return {
         handled: true,
         response: sdkMethod.signTypedDataResponse(
@@ -335,7 +355,8 @@ export async function handleSdkMethod(
             signature: null,
             digest: null,
             publicKey: null,
-            error: 'Too many pending signature requests'
+            error: CAPACITY_REFUSAL_MESSAGE,
+            errorCode: SdkErrorCode.tooManyPendingRequests
           },
           { requestId: action.meta.requestId }
         )

--- a/src/background/handlers/sdk-methods.ts
+++ b/src/background/handlers/sdk-methods.ts
@@ -20,8 +20,11 @@ import {
   eip712PayloadReceived,
   siteDisconnected
 } from '@background/redux/vault/actions';
+import { getPayload } from '@background/redux/vault/payload-map';
 import {
   selectAccountNamesByOriginDict,
+  selectDeploysJsonById,
+  selectEip712JsonById,
   selectIsAccountConnected,
   selectVaultActiveAccount
 } from '@background/redux/vault/selectors';
@@ -217,6 +220,27 @@ export async function handleSdkMethod(
       })
     );
 
+    // At capacity `storePayload` refuses the INCOMING write. Answering here is
+    // what makes that residual visible: without it the window opens on a
+    // payload the page can never read.
+    if (
+      getPayload(
+        selectDeploysJsonById(store.getState()),
+        action.meta.requestId
+      ) == null
+    ) {
+      return {
+        handled: true,
+        response: sdkMethod.signResponse(
+          {
+            cancelled: true,
+            message: 'Too many pending signature requests'
+          },
+          { requestId: action.meta.requestId }
+        )
+      };
+    }
+
     store.dispatch(
       windowRequestOpened({
         requestId: action.meta.requestId,
@@ -292,6 +316,28 @@ export async function handleSdkMethod(
         json: JSON.stringify({ typedData, options })
       })
     );
+
+    // Same refusal as the deploy branch above, on the other map.
+    if (
+      getPayload(
+        selectEip712JsonById(store.getState()),
+        action.meta.requestId
+      ) == null
+    ) {
+      return {
+        handled: true,
+        response: sdkMethod.signTypedDataResponse(
+          {
+            cancelled: true,
+            signature: null,
+            digest: null,
+            publicKey: null,
+            error: 'Too many pending signature requests'
+          },
+          { requestId: action.meta.requestId }
+        )
+      };
+    }
 
     store.dispatch(
       windowRequestOpened({

--- a/src/background/handlers/sdk-methods.ts
+++ b/src/background/handlers/sdk-methods.ts
@@ -213,6 +213,8 @@ export async function handleSdkMethod(
       };
     }
 
+    // No `await` before `windowRequestOpened` below: `reconcileStalePayloadsSaga`
+    // purges a payload that no descriptor and no window claims.
     store.dispatch(
       deployPayloadReceived({
         id: action.meta.requestId,
@@ -310,6 +312,7 @@ export async function handleSdkMethod(
 
     const { signingPublicKeyHex, typedData, options } = action.payload;
 
+    // Same synchronous block as the deploy branch, for the same reason.
     store.dispatch(
       eip712PayloadReceived({
         id: action.meta.requestId,

--- a/src/background/open-request-windows.test.ts
+++ b/src/background/open-request-windows.test.ts
@@ -1,0 +1,173 @@
+import { windows } from 'webextension-polyfill';
+
+import { collectRequestIdsFromOpenWindows } from './open-request-windows';
+
+jest.mock('webextension-polyfill', () => ({
+  windows: { getAll: jest.fn().mockResolvedValue([]) },
+  runtime: { getURL: jest.fn(() => 'chrome-extension://abcdefghijklmnop/') }
+}));
+
+const mockWindowsGetAll = windows.getAll as jest.Mock;
+
+const approvalWindowUrl = (requestId: string) =>
+  `chrome-extension://abcdefghijklmnop/signature-request.html` +
+  `?requestId=${requestId}&origin=https%3A%2F%2Fdapp.example&tabId=7` +
+  `#/sign-deploy`;
+
+beforeEach(() => {
+  mockWindowsGetAll.mockReset().mockResolvedValue([]);
+  jest.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('collectRequestIdsFromOpenWindows', () => {
+  it('asks for populated windows — without tabs there is no URL to read', async () => {
+    await collectRequestIdsFromOpenWindows();
+
+    expect(mockWindowsGetAll).toHaveBeenCalledWith({ populate: true });
+  });
+
+  it('collects the requestId out of an approval window URL, hash and all', async () => {
+    mockWindowsGetAll.mockResolvedValue([
+      { id: 1, tabs: [{ url: approvalWindowUrl('req-1') }] }
+    ]);
+
+    expect(await collectRequestIdsFromOpenWindows()).toEqual(
+      new Set(['req-1'])
+    );
+  });
+
+  // The Ledger permission window carries the same requestId as the approval
+  // window it was opened from (`src/hooks/use-ledger.ts`).
+  it('unions ids across windows and across tabs, de-duplicating repeats', async () => {
+    mockWindowsGetAll.mockResolvedValue([
+      {
+        id: 1,
+        tabs: [
+          { url: approvalWindowUrl('req-1') },
+          { url: approvalWindowUrl('req-2') }
+        ]
+      },
+      { id: 2, tabs: [{ url: approvalWindowUrl('req-1') }] }
+    ]);
+
+    expect(await collectRequestIdsFromOpenWindows()).toEqual(
+      new Set(['req-1', 'req-2'])
+    );
+  });
+
+  it('falls back to pendingUrl while a tab is still navigating', async () => {
+    mockWindowsGetAll.mockResolvedValue([
+      { id: 1, tabs: [{ pendingUrl: approvalWindowUrl('req-pending') }] }
+    ]);
+
+    expect(await collectRequestIdsFromOpenWindows()).toEqual(
+      new Set(['req-pending'])
+    );
+  });
+
+  it('ignores windows and tabs that carry no usable url', async () => {
+    mockWindowsGetAll.mockResolvedValue([
+      { id: 1 },
+      { id: 2, tabs: [] },
+      { id: 3, tabs: [{}, { url: '' }] },
+      {
+        id: 4,
+        tabs: [{ url: 'chrome-extension://abcdefghijklmnop/popup.html' }]
+      }
+    ]);
+
+    expect(await collectRequestIdsFromOpenWindows()).toEqual(new Set());
+  });
+
+  it('skips an unparseable url and keeps reading the rest', async () => {
+    mockWindowsGetAll.mockResolvedValue([
+      { id: 1, tabs: [{ url: 'not a url' }] },
+      { id: 2, tabs: [{ url: approvalWindowUrl('req-1') }] }
+    ]);
+
+    expect(await collectRequestIdsFromOpenWindows()).toEqual(
+      new Set(['req-1'])
+    );
+  });
+
+  it('ignores an empty requestId param, which keeps no slot alive', async () => {
+    mockWindowsGetAll.mockResolvedValue([
+      {
+        id: 1,
+        tabs: [
+          { url: 'chrome-extension://abcdefghijklmnop/popup.html?requestId=' }
+        ]
+      }
+    ]);
+
+    expect(await collectRequestIdsFromOpenWindows()).toEqual(new Set());
+  });
+
+  // `requestId` is dapp-chosen, so without an origin check any page could put a
+  // `?requestId=` of its choosing in its own URL and pin that slot forever.
+  it('ignores a requestId carried by a page that is not one of ours', async () => {
+    mockWindowsGetAll.mockResolvedValue([
+      {
+        id: 1,
+        tabs: [{ url: 'https://evil.example/?requestId=req-1' }]
+      }
+    ]);
+
+    expect(await collectRequestIdsFromOpenWindows()).toEqual(new Set());
+  });
+
+  it('reads our own pages while ignoring a foreign tab that spoofs the same id', async () => {
+    mockWindowsGetAll.mockResolvedValue([
+      { id: 1, tabs: [{ url: 'https://evil.example/?requestId=spoofed' }] },
+      { id: 2, tabs: [{ url: approvalWindowUrl('req-1') }] }
+    ]);
+
+    expect(await collectRequestIdsFromOpenWindows()).toEqual(
+      new Set(['req-1'])
+    );
+  });
+
+  // `runtime.getURL('')` carries this extension's id, so the prefix test is
+  // per-extension, not merely per-protocol.
+  it('ignores an extension page belonging to a different extension', async () => {
+    mockWindowsGetAll.mockResolvedValue([
+      {
+        id: 1,
+        tabs: [
+          {
+            url: 'chrome-extension://zzzzzzzzzzzzzzzz/signature-request.html?requestId=req-1'
+          }
+        ]
+      }
+    ]);
+
+    expect(await collectRequestIdsFromOpenWindows()).toEqual(new Set());
+  });
+
+  // `null` is "no evidence", not "no window holds a request": the caller must
+  // not purge on it.
+  it('returns null rather than an empty set when the enumeration rejects', async () => {
+    mockWindowsGetAll.mockRejectedValue(new Error('boom'));
+
+    expect(await collectRequestIdsFromOpenWindows()).toBeNull();
+  });
+
+  it('never puts a window URL into the log when the enumeration rejects', async () => {
+    const consoleError = jest.spyOn(console, 'error');
+    mockWindowsGetAll.mockRejectedValue(
+      new Error(
+        'failed for chrome-extension://abcdefghijklmnop/signature-request.html?message=my-secret-message'
+      )
+    );
+
+    await collectRequestIdsFromOpenWindows();
+
+    const logged = JSON.stringify(consoleError.mock.calls);
+    expect(logged).not.toContain('my-secret-message');
+    expect(logged).not.toContain('?');
+  });
+});

--- a/src/background/open-request-windows.test.ts
+++ b/src/background/open-request-windows.test.ts
@@ -96,6 +96,10 @@ describe('collectRequestIdsFromOpenWindows', () => {
 
   // A silently skipped tab purges a live request with nothing pointing at the
   // cause, so the skip is logged — redacted, never the raw url.
+  //
+  // Asserted positively as well as negatively: `new URL`'s TypeError says only
+  // `Invalid URL`, so absence assertions alone would still pass on a line that
+  // names no tab at all and leaves the operator where they were.
   it('logs the skipped url without its query string', async () => {
     const consoleError = jest.spyOn(console, 'error');
     mockWindowsGetAll.mockResolvedValue([
@@ -105,8 +109,12 @@ describe('collectRequestIdsFromOpenWindows', () => {
     expect(await collectRequestIdsFromOpenWindows()).toEqual(new Set());
 
     expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith(
+      'collectRequestIdsFromOpenWindows: could not parse a tab url',
+      'http://[::1/',
+      expect.any(String)
+    );
     const logged = JSON.stringify(consoleError.mock.calls);
-    expect(logged).toContain('could not parse a tab url');
     expect(logged).not.toContain('my-secret-message');
     expect(logged).not.toContain('?');
   });
@@ -235,6 +243,11 @@ describe('collectRequestIdsFromOpenWindows', () => {
     expect(await collectRequestIdsFromOpenWindows()).toBeNull();
   });
 
+  // The argument's TYPE is asserted, not only its content. A plain `Error` has
+  // no enumerable own properties, so `JSON.stringify` renders it `{}` and the
+  // two absence assertions below hold whatever the code does — dropping
+  // `redactUrlQuery` and logging the error object would keep them green while
+  // the console started printing the untruncated message.
   it('never puts a window URL into the log when the enumeration rejects', async () => {
     const consoleError = jest.spyOn(console, 'error');
     mockWindowsGetAll.mockRejectedValue(
@@ -245,6 +258,10 @@ describe('collectRequestIdsFromOpenWindows', () => {
 
     await collectRequestIdsFromOpenWindows();
 
+    expect(consoleError).toHaveBeenCalledWith(
+      'collectRequestIdsFromOpenWindows: could not enumerate windows',
+      expect.any(String)
+    );
     const logged = JSON.stringify(consoleError.mock.calls);
     expect(logged).not.toContain('my-secret-message');
     expect(logged).not.toContain('?');

--- a/src/background/open-request-windows.test.ts
+++ b/src/background/open-request-windows.test.ts
@@ -94,12 +94,31 @@ describe('collectRequestIdsFromOpenWindows', () => {
     );
   });
 
+  // A silently skipped tab purges a live request with nothing pointing at the
+  // cause, so the skip is logged — redacted, never the raw url.
+  it('logs the skipped url without its query string', async () => {
+    const consoleError = jest.spyOn(console, 'error');
+    mockWindowsGetAll.mockResolvedValue([
+      { id: 1, tabs: [{ url: 'http://[::1/?message=my-secret-message' }] }
+    ]);
+
+    expect(await collectRequestIdsFromOpenWindows()).toEqual(new Set());
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    const logged = JSON.stringify(consoleError.mock.calls);
+    expect(logged).toContain('could not parse a tab url');
+    expect(logged).not.toContain('my-secret-message');
+    expect(logged).not.toContain('?');
+  });
+
   it('ignores an empty requestId param, which keeps no slot alive', async () => {
     mockWindowsGetAll.mockResolvedValue([
       {
         id: 1,
         tabs: [
-          { url: 'chrome-extension://abcdefghijklmnop/popup.html?requestId=' }
+          {
+            url: 'chrome-extension://abcdefghijklmnop/signature-request.html?requestId='
+          }
         ]
       }
     ]);
@@ -131,7 +150,67 @@ describe('collectRequestIdsFromOpenWindows', () => {
     );
   });
 
-  // `runtime.getURL('')` carries this extension's id, so the prefix test is
+  // `sdk.bundle.js` is web-accessible on all three targets, and the extension
+  // id is public (`content/index.ts` puts it in the page DOM), so the origin
+  // alone does not make a URL ours to trust.
+  it('ignores a requestId on a web-accessible resource of our own extension', async () => {
+    mockWindowsGetAll.mockResolvedValue([
+      {
+        id: 1,
+        tabs: [
+          {
+            url: 'chrome-extension://abcdefghijklmnop/sdk.bundle.js?requestId=req-1'
+          }
+        ]
+      }
+    ]);
+
+    expect(await collectRequestIdsFromOpenWindows()).toEqual(new Set());
+  });
+
+  // The closed set. `popup.html` carries no `requestId` today, but it is
+  // `use-ledger.ts`'s default `domain`, and a missed Ledger window purges a
+  // payload mid-signature.
+  it.each(['signature-request.html', 'connect-to-app.html', 'popup.html'])(
+    'reads a requestId carried by %s',
+    async page => {
+      mockWindowsGetAll.mockResolvedValue([
+        {
+          id: 1,
+          tabs: [
+            {
+              url: `chrome-extension://abcdefghijklmnop/${page}?requestId=req-1&tabId=7`
+            }
+          ]
+        }
+      ]);
+
+      expect(await collectRequestIdsFromOpenWindows()).toEqual(
+        new Set(['req-1'])
+      );
+    }
+  );
+
+  // Neither is ever opened with a `requestId`, and neither reads one.
+  it.each(['onboarding.html', 'import-account-with-file.html'])(
+    'ignores a requestId carried by %s, which never legitimately has one',
+    async page => {
+      mockWindowsGetAll.mockResolvedValue([
+        {
+          id: 1,
+          tabs: [
+            {
+              url: `chrome-extension://abcdefghijklmnop/${page}?requestId=req-1`
+            }
+          ]
+        }
+      ]);
+
+      expect(await collectRequestIdsFromOpenWindows()).toEqual(new Set());
+    }
+  );
+
+  // `runtime.getURL('')` carries this extension's id, so the origin test is
   // per-extension, not merely per-protocol.
   it('ignores an extension page belonging to a different extension', async () => {
     mockWindowsGetAll.mockResolvedValue([

--- a/src/background/open-request-windows.ts
+++ b/src/background/open-request-windows.ts
@@ -2,15 +2,26 @@ import { Windows, runtime, windows } from 'webextension-polyfill';
 
 import { redactUrlQuery } from '@background/redact-url-query';
 
+// Every page a `?requestId=` can legitimately reach. `popup.html` never carries
+// one today, but it is `use-ledger.ts`'s default `domain` and none of these is
+// web-accessible, so listing it costs nothing and fails toward keeping.
+const REQUEST_BEARING_PATHNAMES = new Set([
+  '/signature-request.html',
+  '/connect-to-app.html',
+  '/popup.html'
+]);
+
 /**
- * Every `requestId` currently displayed by a browser window, or `null` if the
- * enumeration failed. Never collapse `null` into an empty set: the caller
- * deletes signing payloads on this reading, and deleting on no evidence takes
- * the transaction away from an approval window that is on screen.
+ * Every `requestId` currently displayed by a tab at one of this extension's own
+ * `REQUEST_BEARING_PATHNAMES`, or `null` if the enumeration failed. Never
+ * collapse `null` into an empty set: the caller deletes signing payloads on
+ * this reading, and deleting on no evidence takes the transaction away from an
+ * approval window that is on screen.
  *
- * Only this extension's own pages are read. `requestId` is dapp-chosen, so
- * without the origin test any page could pin a slot forever by putting a
- * `?requestId=` of its choosing in its own URL.
+ * A tab counts only when its scheme, its host AND its pathname match.
+ * `requestId` is dapp-chosen and `sdk.bundle.js` is web-accessible under this
+ * extension's own origin, so an origin-only test would let a page hold every
+ * payload slot open with `?requestId=` values of its choosing.
  */
 export async function collectRequestIdsFromOpenWindows(): Promise<Set<string> | null> {
   let allWindows: Windows.Window[];
@@ -27,25 +38,43 @@ export async function collectRequestIdsFromOpenWindows(): Promise<Set<string> | 
   }
 
   const requestIds = new Set<string>();
-  const extensionUrlPrefix = runtime.getURL('');
+  // Compared piecewise rather than by `.origin`, which is the opaque "null" for
+  // non-special schemes and would equate every extension's pages with ours.
+  const extensionUrl = new URL(runtime.getURL(''));
 
   for (const browserWindow of allWindows) {
     for (const tab of browserWindow.tabs ?? []) {
       // `pendingUrl` (Chrome-only) is set while `url` is still empty.
       const url = tab.url || tab.pendingUrl;
 
-      if (!url || !url.startsWith(extensionUrlPrefix)) {
+      if (!url) {
         continue;
       }
 
-      let requestId: string | null;
+      let tabUrl: URL;
 
       try {
-        requestId = new URL(url).searchParams.get('requestId');
-      } catch {
-        // One unparseable tab must not turn the whole reading into no evidence.
+        tabUrl = new URL(url);
+      } catch (error) {
+        // One unparseable tab must not turn the whole reading into no evidence,
+        // but a silent skip purges a live request with nothing pointing here.
+        console.error(
+          'collectRequestIdsFromOpenWindows: could not parse a tab url',
+          redactUrlQuery(error)
+        );
+
         continue;
       }
+
+      if (
+        tabUrl.protocol !== extensionUrl.protocol ||
+        tabUrl.host !== extensionUrl.host ||
+        !REQUEST_BEARING_PATHNAMES.has(tabUrl.pathname)
+      ) {
+        continue;
+      }
+
+      const requestId = tabUrl.searchParams.get('requestId');
 
       if (requestId) {
         requestIds.add(requestId);

--- a/src/background/open-request-windows.ts
+++ b/src/background/open-request-windows.ts
@@ -1,0 +1,66 @@
+import { Windows, runtime, windows } from 'webextension-polyfill';
+
+// Matches open-window.ts: a browser error message is unbounded.
+const MAX_LOGGED_ERROR_LENGTH = 200;
+
+// A `signMessage` approval URL carries the user's plaintext message as a search
+// param, and a windows-API rejection can quote the URL it failed on.
+function redactUrlQuery(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+
+  return message.split('?')[0].slice(0, MAX_LOGGED_ERROR_LENGTH);
+}
+
+/**
+ * Every `requestId` currently displayed by a browser window, or `null` if the
+ * enumeration failed. Never collapse `null` into an empty set: the caller
+ * deletes signing payloads on this reading, and deleting on no evidence takes
+ * the transaction away from an approval window that is on screen.
+ *
+ * Only this extension's own pages are read. `requestId` is dapp-chosen, so
+ * without the origin test any page could pin a slot forever by putting a
+ * `?requestId=` of its choosing in its own URL.
+ */
+export async function collectRequestIdsFromOpenWindows(): Promise<Set<string> | null> {
+  let allWindows: Windows.Window[];
+
+  try {
+    allWindows = await windows.getAll({ populate: true });
+  } catch (error) {
+    console.error(
+      'collectRequestIdsFromOpenWindows: could not enumerate windows',
+      redactUrlQuery(error)
+    );
+
+    return null;
+  }
+
+  const requestIds = new Set<string>();
+  const extensionUrlPrefix = runtime.getURL('');
+
+  for (const browserWindow of allWindows) {
+    for (const tab of browserWindow.tabs ?? []) {
+      // `pendingUrl` (Chrome-only) is set while `url` is still empty.
+      const url = tab.url || tab.pendingUrl;
+
+      if (!url || !url.startsWith(extensionUrlPrefix)) {
+        continue;
+      }
+
+      let requestId: string | null;
+
+      try {
+        requestId = new URL(url).searchParams.get('requestId');
+      } catch {
+        // One unparseable tab must not turn the whole reading into no evidence.
+        continue;
+      }
+
+      if (requestId) {
+        requestIds.add(requestId);
+      }
+    }
+  }
+
+  return requestIds;
+}

--- a/src/background/open-request-windows.ts
+++ b/src/background/open-request-windows.ts
@@ -58,8 +58,15 @@ export async function collectRequestIdsFromOpenWindows(): Promise<Set<string> | 
       } catch (error) {
         // One unparseable tab must not turn the whole reading into no evidence,
         // but a silent skip purges a live request with nothing pointing here.
+        //
+        // The url is logged as well as the error: `new URL`'s TypeError reads
+        // `Invalid URL` and names nothing, so the error alone says a skip
+        // happened without saying which tab it was. Redacted, both of them —
+        // a `signMessage` approval url carries the user's plaintext message as
+        // a search param.
         console.error(
           'collectRequestIdsFromOpenWindows: could not parse a tab url',
+          redactUrlQuery(url),
           redactUrlQuery(error)
         );
 

--- a/src/background/open-request-windows.ts
+++ b/src/background/open-request-windows.ts
@@ -1,15 +1,6 @@
 import { Windows, runtime, windows } from 'webextension-polyfill';
 
-// Matches open-window.ts: a browser error message is unbounded.
-const MAX_LOGGED_ERROR_LENGTH = 200;
-
-// A `signMessage` approval URL carries the user's plaintext message as a search
-// param, and a windows-API rejection can quote the URL it failed on.
-function redactUrlQuery(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error);
-
-  return message.split('?')[0].slice(0, MAX_LOGGED_ERROR_LENGTH);
-}
+import { redactUrlQuery } from '@background/redact-url-query';
 
 /**
  * Every `requestId` currently displayed by a browser window, or `null` if the

--- a/src/background/open-window.ts
+++ b/src/background/open-window.ts
@@ -7,6 +7,7 @@ import {
   cancelRequestsDisplacedBy,
   failRequestOnWindowError
 } from '@background/handlers/cancel-requests';
+import { redactUrlQuery } from '@background/redact-url-query';
 import { MainStore } from '@background/redux/get-main-store';
 import {
   windowIdChanged,
@@ -26,17 +27,6 @@ export interface OpenApprovalWindowProps extends OpenWindowProps {
    * one state no window event can ever cancel.
    */
   requestId: string;
-}
-
-const MAX_LOGGED_ERROR_LENGTH = 200;
-
-// Everything from the first `?` onward is dropped: that is where a window URL
-// carries its search params, and for `signMessage` one of them is the user's
-// plaintext message.
-function redactUrlQuery(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error);
-
-  return message.split('?')[0].slice(0, MAX_LOGGED_ERROR_LENGTH);
 }
 
 // Fire-and-forget by design (the message handler must not block on a browser

--- a/src/background/redact-url-query.test.ts
+++ b/src/background/redact-url-query.test.ts
@@ -1,0 +1,34 @@
+import { redactUrlQuery } from './redact-url-query';
+
+describe('redactUrlQuery', () => {
+  // The reason this function exists: a `signMessage` approval URL carries the
+  // user's plaintext message as a search param, and a windows-API rejection can
+  // quote the URL it failed on.
+  it('drops everything from the first ? onward', () => {
+    expect(
+      redactUrlQuery(
+        new Error(
+          'Cannot create window: signature-request.html?message=SECRET&requestId=r8'
+        )
+      )
+    ).toBe('Cannot create window: signature-request.html');
+  });
+
+  it('keeps a message that carries no query untouched', () => {
+    expect(redactUrlQuery(new Error('no windows API'))).toBe('no windows API');
+  });
+
+  // A rejection value is not always an Error, and reading `.message` off a
+  // string would log `undefined` instead of the cause.
+  it('stringifies a non-Error rejection, still redacting its query', () => {
+    expect(redactUrlQuery('failed on url.html?message=SECRET')).toBe(
+      'failed on url.html'
+    );
+    expect(redactUrlQuery(undefined)).toBe('undefined');
+  });
+
+  // A browser error message is unbounded.
+  it('truncates at 200 characters', () => {
+    expect(redactUrlQuery(new Error('x'.repeat(500)))).toBe('x'.repeat(200));
+  });
+});

--- a/src/background/redact-url-query.ts
+++ b/src/background/redact-url-query.ts
@@ -1,0 +1,11 @@
+const MAX_LOGGED_ERROR_LENGTH = 200;
+
+// Everything from the first `?` onward is dropped: that is where a window URL
+// carries its search params, and for `signMessage` one of them is the user's
+// plaintext message. Kept dependency-free so the window modules can share one
+// copy without dragging the store in behind it.
+export function redactUrlQuery(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+
+  return message.split('?')[0].slice(0, MAX_LOGGED_ERROR_LENGTH);
+}

--- a/src/background/redux/app-events/types.ts
+++ b/src/background/redux/app-events/types.ts
@@ -17,6 +17,7 @@ export type SagaErrorSource =
   | 'unlockVaultSaga'
   | 'timeoutCounterSaga'
   | 'updateVaultCipher'
+  | 'reconcileStalePayloadsSaga'
   | 'createAccountSaga'
   | 'openExportKeysWindowSaga'
   // approval-request lifecycle failures

--- a/src/background/redux/sagas/vault-sagas.test.ts
+++ b/src/background/redux/sagas/vault-sagas.test.ts
@@ -1,7 +1,7 @@
 import * as matchers from 'redux-saga-test-plan/matchers';
 import { combineReducers } from '@reduxjs/toolkit';
 import { expectSaga } from 'redux-saga-test-plan';
-import { storage, tabs } from 'webextension-polyfill';
+import { storage, tabs, windows } from 'webextension-polyfill';
 
 import {
   LOCK_VAULT_TIMEOUT,
@@ -37,8 +37,12 @@ import {
 import { selectTimeoutDurationSetting } from '../settings/selectors';
 import { vaultCipherCreated } from '../vault-cipher/actions';
 import { selectVaultCipherDoesExist } from '../vault-cipher/selectors';
-import { accountRenamed, vaultLoaded } from '../vault/actions';
-import { reducer as vaultReducer } from '../vault/reducer';
+import {
+  accountRenamed,
+  deployPayloadReceived,
+  vaultLoaded
+} from '../vault/actions';
+import { MAX_STORED_PAYLOADS, reducer as vaultReducer } from '../vault/reducer';
 import {
   selectAccountNamesByOriginDict,
   selectVault,
@@ -46,11 +50,15 @@ import {
 } from '../vault/selectors';
 import { VaultState } from '../vault/types';
 import { windowRequestResponded } from '../windowManagement/actions';
+import { reducer as windowManagementReducer } from '../windowManagement/reducer';
+import { selectOpenRequests } from '../windowManagement/selectors';
+import { WindowManagementState } from '../windowManagement/types';
 import { lockVault, startBackground, unlockVault } from './actions';
 import {
   VAULT_REENCRYPT_DEBOUNCE_MS,
   delay,
   lockVaultSaga,
+  reconcileStalePayloadsSaga,
   setDelayForLockoutVaultSaga,
   timeoutCounterSaga,
   unlockVaultSaga,
@@ -65,14 +73,19 @@ jest.mock('webextension-polyfill', () => ({
       remove: jest.fn().mockResolvedValue(undefined)
     }
   },
-  runtime: { sendMessage: jest.fn().mockResolvedValue(undefined) },
-  tabs: { query: jest.fn().mockResolvedValue([]), sendMessage: jest.fn() }
+  runtime: {
+    sendMessage: jest.fn().mockResolvedValue(undefined),
+    getURL: jest.fn(() => 'chrome-extension://abcdefghijklmnop/')
+  },
+  tabs: { query: jest.fn().mockResolvedValue([]), sendMessage: jest.fn() },
+  windows: { getAll: jest.fn().mockResolvedValue([]) }
 }));
 
 const mockStorageGet = storage.local.get as jest.Mock;
 const mockStorageSet = storage.local.set as jest.Mock;
 const mockStorageRemove = storage.local.remove as jest.Mock;
 const mockTabsQuery = tabs.query as jest.Mock;
+const mockWindowsGetAll = windows.getAll as jest.Mock;
 
 const NOW = 1_700_000_000_000;
 const FIVE_SECONDS = 5000;
@@ -103,7 +116,9 @@ beforeEach(() => {
   mockStorageSet.mockReset().mockResolvedValue(undefined);
   mockStorageRemove.mockReset().mockResolvedValue(undefined);
   mockTabsQuery.mockClear();
+  mockWindowsGetAll.mockReset().mockResolvedValue([]);
   jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 });
 
 afterEach(() => {
@@ -532,5 +547,396 @@ describe('updateVaultCipher debounce', () => {
     );
     expect(putTypes).not.toContain(vaultCipherCreated.type);
     expect(putTypes).not.toContain(sagaError.type);
+  });
+});
+
+// WALLET-1418. `MAX_STORED_PAYLOADS` refuses the INCOMING write once
+// `jsonById`/`eip712ById` hold ten entries, and nothing evicts a stored one, so
+// ten payloads whose `windowRequestResponded` never arrived — a clean auto-lock
+// with an approval window open is enough, no worker death needed — permanently
+// refuse every later `sign` on the profile. This saga is the deliberate
+// replacement for the accidental exit `vaultLoaded` used to provide.
+describe('reconcileStalePayloadsSaga', () => {
+  const EMPTY_WINDOW_MANAGEMENT: WindowManagementState = {
+    windowId: null,
+    exportKeysWindowId: null,
+    requests: {}
+  };
+
+  // Hash included, as `createOpenWindow` produces it: `searchParams` must find
+  // `requestId` in front of a fragment.
+  const approvalWindowUrl = (requestId: string) =>
+    `chrome-extension://abcdefghijklmnop/signature-request.html` +
+    `?requestId=${requestId}&origin=https%3A%2F%2Fdapp.example&tabId=7` +
+    `#/sign-deploy`;
+
+  const openRequest = {
+    status: 'open',
+    tabId: 7,
+    origin: 'https://dapp.example',
+    method: 'sign',
+    windowIds: [1]
+  } as const;
+
+  const combinedReducer = () =>
+    combineReducers({
+      vault: vaultReducer,
+      windowManagement: windowManagementReducer
+    }) as never;
+
+  const seedState = (
+    vault: Partial<VaultState>,
+    windowManagement: Partial<WindowManagementState> = {}
+  ) =>
+    ({
+      vault: { ...EMPTY_VAULT, ...vault },
+      windowManagement: { ...EMPTY_WINDOW_MANAGEMENT, ...windowManagement }
+    }) as never;
+
+  const vaultOf = (storeState: unknown) =>
+    (storeState as { vault: VaultState }).vault;
+
+  // The window half of the keep-set. `windowManagement.requests` is not
+  // persisted, so after a service-worker restart the descriptor is gone while
+  // the window is still on screen and still signable.
+  it('keeps a payload whose requestId appears in an open window tab URL, with no descriptor in the store', async () => {
+    mockWindowsGetAll.mockResolvedValue([
+      { id: 1, tabs: [{ url: approvalWindowUrl('live-1') }] }
+    ]);
+
+    const { storeState } = await expectSaga(reconcileStalePayloadsSaga)
+      .withReducer(
+        combinedReducer(),
+        seedState({ jsonById: { 'live-1': '{"deploy":1}' } })
+      )
+      .run();
+
+    expect(vaultOf(storeState).jsonById).toEqual({ 'live-1': '{"deploy":1}' });
+  });
+
+  // The other half. On window reuse `tabs.update` resolves when navigation
+  // starts, so a live window can still report the previous request's URL.
+  it('keeps a payload whose requestId is an open request but appears in no window URL', async () => {
+    mockWindowsGetAll.mockResolvedValue([
+      { id: 1, tabs: [{ url: approvalWindowUrl('previous-request') }] }
+    ]);
+
+    const { storeState } = await expectSaga(reconcileStalePayloadsSaga)
+      .withReducer(
+        combinedReducer(),
+        seedState(
+          { jsonById: { navigating: '{"deploy":2}' } },
+          { requests: { navigating: openRequest } }
+        )
+      )
+      .run();
+
+    expect(vaultOf(storeState).jsonById).toEqual({
+      navigating: '{"deploy":2}'
+    });
+  });
+
+  it('purges a payload in neither the window URLs nor the open requests, from BOTH maps', async () => {
+    mockWindowsGetAll.mockResolvedValue([
+      { id: 1, tabs: [{ url: approvalWindowUrl('live-1') }] }
+    ]);
+
+    const { storeState } = await expectSaga(reconcileStalePayloadsSaga)
+      .withReducer(
+        combinedReducer(),
+        seedState({
+          jsonById: { 'live-1': '{"deploy":1}', orphan: '{"deploy":9}' },
+          eip712ById: { orphan: '{"eip712":9}', 'orphan-2': '{"eip712":8}' }
+        })
+      )
+      .run();
+
+    // `toEqual`, never `toMatchObject`: a subset match tolerates the very key
+    // this test proves is gone.
+    expect(vaultOf(storeState).jsonById).toEqual({ 'live-1': '{"deploy":1}' });
+    expect(vaultOf(storeState).eip712ById).toEqual({});
+  });
+
+  // `windowManagement`'s reducer no-ops the transition unless the request is
+  // 'open', so an orphan spends none of the `MAX_RESPONDED_TOMBSTONES` budget,
+  // while the vault reducer keys off the action and still deletes the payload.
+  it('does not leave a responded tombstone behind for a purged orphan', async () => {
+    mockWindowsGetAll.mockResolvedValue([]);
+
+    const { storeState } = await expectSaga(reconcileStalePayloadsSaga)
+      .withReducer(
+        combinedReducer(),
+        seedState({ jsonById: { orphan: '{"deploy":9}' } })
+      )
+      .run();
+
+    expect(vaultOf(storeState).jsonById).toEqual({});
+    expect(
+      (storeState as { windowManagement: WindowManagementState })
+        .windowManagement.requests
+    ).toEqual({});
+  });
+
+  // Fail closed: a rejected enumeration is no evidence, and purging on no
+  // evidence strands a live request.
+  it('purges nothing when windows.getAll rejects', async () => {
+    mockWindowsGetAll.mockRejectedValue(new Error('no windows API'));
+
+    const { storeState, effects } = await expectSaga(reconcileStalePayloadsSaga)
+      .withReducer(
+        combinedReducer(),
+        seedState({
+          jsonById: { orphan: '{"deploy":9}' },
+          eip712ById: { 'orphan-2': '{"eip712":8}' }
+        })
+      )
+      .run();
+
+    expect(vaultOf(storeState).jsonById).toEqual({ orphan: '{"deploy":9}' });
+    expect(vaultOf(storeState).eip712ById).toEqual({
+      'orphan-2': '{"eip712":8}'
+    });
+    expect(effects.put ?? []).toEqual([]);
+  });
+
+  // A window can be enumerated before its first tab has a URL. That is not an
+  // error and may not abort the run.
+  it('does not throw when windows have tabs without a url, and still keeps what selectOpenRequests covers', async () => {
+    mockWindowsGetAll.mockResolvedValue([
+      { id: 1, tabs: [{}] },
+      { id: 2, tabs: [{ url: '' }] },
+      { id: 3 }
+    ]);
+
+    const { storeState } = await expectSaga(reconcileStalePayloadsSaga)
+      .withReducer(
+        combinedReducer(),
+        seedState(
+          { jsonById: { navigating: '{"deploy":2}', orphan: '{"deploy":9}' } },
+          { requests: { navigating: openRequest } }
+        )
+      )
+      .run();
+
+    expect(vaultOf(storeState).jsonById).toEqual({
+      navigating: '{"deploy":2}'
+    });
+  });
+
+  it('skips a tab whose url cannot be parsed without aborting the run', async () => {
+    mockWindowsGetAll.mockResolvedValue([
+      { id: 1, tabs: [{ url: 'not a url' }] },
+      { id: 2, tabs: [{ url: approvalWindowUrl('live-1') }] }
+    ]);
+
+    const { storeState } = await expectSaga(reconcileStalePayloadsSaga)
+      .withReducer(
+        combinedReducer(),
+        seedState({
+          jsonById: { 'live-1': '{"deploy":1}', orphan: '{"deploy":9}' }
+        })
+      )
+      .run();
+
+    expect(vaultOf(storeState).jsonById).toEqual({ 'live-1': '{"deploy":1}' });
+  });
+
+  // The Ledger permission window carries the same requestId as the approval
+  // window that spawned it (`src/hooks/use-ledger.ts`).
+  it('unions requestIds across every window rather than taking the last one seen', async () => {
+    mockWindowsGetAll.mockResolvedValue([
+      { id: 1, tabs: [{ url: approvalWindowUrl('ledger-request') }] },
+      { id: 2, tabs: [{ url: approvalWindowUrl('other-request') }] }
+    ]);
+
+    const { storeState } = await expectSaga(reconcileStalePayloadsSaga)
+      .withReducer(
+        combinedReducer(),
+        seedState({
+          jsonById: {
+            'ledger-request': '{"deploy":1}',
+            'other-request': '{"deploy":2}'
+          }
+        })
+      )
+      .run();
+
+    expect(vaultOf(storeState).jsonById).toEqual({
+      'ledger-request': '{"deploy":1}',
+      'other-request': '{"deploy":2}'
+    });
+  });
+
+  // The param is dapp-chosen: without the origin check an origin that knows the
+  // ids it leaked could keep them alive from its own tab.
+  it('does not let a non-extension tab carrying the same requestId keep a payload alive', async () => {
+    mockWindowsGetAll.mockResolvedValue([
+      { id: 1, tabs: [{ url: 'https://evil.example/?requestId=orphan' }] }
+    ]);
+
+    const { storeState } = await expectSaga(reconcileStalePayloadsSaga)
+      .withReducer(
+        combinedReducer(),
+        seedState({ jsonById: { orphan: '{"deploy":9}' } })
+      )
+      .run();
+
+    expect(vaultOf(storeState).jsonById).toEqual({});
+  });
+
+  // Enumerating anyway would pull every tab URL in the browser into the
+  // extension process for no gain.
+  it('does not enumerate windows at all when both payload maps are empty', async () => {
+    const { effects } = await expectSaga(reconcileStalePayloadsSaga)
+      .withReducer(combinedReducer(), seedState({}))
+      .run();
+
+    expect(mockWindowsGetAll).not.toHaveBeenCalled();
+    expect(effects.put ?? []).toEqual([]);
+  });
+
+  // An escaping throw would abort the whole saga tree. Driven by an enumeration
+  // that resolves with a non-list, the one way past the oracle's own catch.
+  it('contains an unexpected throw, purges nothing, and reports it', async () => {
+    mockWindowsGetAll.mockResolvedValue(undefined);
+
+    const { storeState, effects } = await expectSaga(reconcileStalePayloadsSaga)
+      .withReducer(
+        combinedReducer(),
+        seedState({ jsonById: { orphan: '{"deploy":9}' } })
+      )
+      .put(
+        sagaError({
+          source: 'reconcileStalePayloadsSaga',
+          message: 'Could not reclaim stored signing payloads'
+        })
+      )
+      .run();
+
+    expect(vaultOf(storeState).jsonById).toEqual({ orphan: '{"deploy":9}' });
+    // The matched `.put()` above is removed from `effects.put`, so what is left
+    // must be empty: no `windowRequestResponded` escaped before the throw.
+    expect(effects.put ?? []).toEqual([]);
+  });
+
+  // The ordering guard: hoisting the two `sagaSelect` calls above the `sagaCall`
+  // leaves every other test in this file green. `fresh` arrives during the round
+  // trip, so a keep-set read before it would purge a request the user is about
+  // to sign. The provider — not a `.dispatch()`, which only flushes against a
+  // matching `take` — is what observes WHEN the read happens.
+  it('computes the keep-set AFTER the window round trip, so a request registered during it survives', async () => {
+    let roundTripDone = false;
+
+    mockWindowsGetAll.mockImplementation(
+      () =>
+        new Promise<unknown[]>(resolve =>
+          setTimeout(() => {
+            roundTripDone = true;
+            resolve([]);
+          }, 120)
+        )
+    );
+
+    // No window is ever reported: the descriptor is the only thing that can
+    // save `fresh`.
+    const { storeState } = await expectSaga(vaultSagas)
+      .withReducer(
+        combinedReducer(),
+        // `fresh` arrived while the vault was locked and lives only in memory.
+        seedState({ jsonById: { fresh: '{"deploy":42}' } })
+      )
+      .provide({
+        select({ selector }: { selector: unknown }, next: () => unknown) {
+          if (selector === selectEncryptionKeyHash) {
+            return null;
+          }
+          if (selector === selectOpenRequests) {
+            return roundTripDone
+              ? [
+                  {
+                    requestId: 'fresh',
+                    status: 'open',
+                    tabId: 7,
+                    origin: 'https://dapp.example',
+                    method: 'sign',
+                    windowIds: [1]
+                  }
+                ]
+              : [];
+          }
+          return next();
+        }
+      } as never)
+      // The cipher contributes the leaked `orphan`; the merge is Task 1's.
+      .dispatch(
+        vaultLoaded({ ...EMPTY_VAULT, jsonById: { orphan: '{"deploy":9}' } })
+      )
+      .silentRun(600);
+
+    expect(vaultOf(storeState).jsonById).toEqual({ fresh: '{"deploy":42}' });
+  });
+
+  // The acceptance test, driven through the root saga so the
+  // `takeLatest(vaultLoaded.type, …)` registration is part of what is asserted.
+  it('reclaims all ten leaked slots on vaultLoaded so the next deploy payload is accepted', async () => {
+    mockWindowsGetAll.mockResolvedValue([]);
+
+    const leaked = Object.fromEntries(
+      Array.from({ length: MAX_STORED_PAYLOADS }, (_, i) => [
+        `leaked-${i}`,
+        `{"deploy":${i}}`
+      ])
+    );
+
+    const { storeState } = await expectSaga(vaultSagas)
+      .withReducer(combinedReducer(), seedState({}))
+      // A null key makes `updateVaultCipher` early-return instead of reaching
+      // a `session` slice this reducer has not got.
+      .provide([[matchers.select.selector(selectEncryptionKeyHash), null]])
+      .dispatch(vaultLoaded({ ...EMPTY_VAULT, jsonById: leaked }))
+      // Without this gap the fresh payload is offered to a map still holding
+      // ten entries and refused — which is the bug, not the fix.
+      .delay(50)
+      .dispatch(
+        deployPayloadReceived({ id: 'fresh-request', json: '{"fresh":true}' })
+      )
+      .silentRun(200);
+
+    expect(vaultOf(storeState).jsonById).toEqual({
+      'fresh-request': '{"fresh":true}'
+    });
+  });
+
+  // Without a re-encryption the cipher still holds the entry and the next
+  // `vaultLoaded` resurrects it; this pins `windowRequestResponded.type` in the
+  // debounce array.
+  it('carries the reclaimed slots into the re-encrypted cipher', async () => {
+    mockWindowsGetAll.mockResolvedValue([
+      { id: 1, tabs: [{ url: approvalWindowUrl('live-1') }] }
+    ]);
+
+    const encryptSpy = jest
+      .spyOn(vaultCryptoModule, 'encryptVault')
+      .mockResolvedValue('cipher-blob');
+
+    await expectSaga(vaultSagas)
+      .withReducer(combinedReducer(), seedState({}))
+      .provide([
+        [matchers.select.selector(selectEncryptionKeyHash), 'key-hash']
+      ])
+      .dispatch(
+        vaultLoaded({
+          ...EMPTY_VAULT,
+          jsonById: { 'live-1': '{"deploy":1}', orphan: '{"deploy":9}' },
+          eip712ById: { 'orphan-2': '{"eip712":8}' }
+        })
+      )
+      .silentRun(VAULT_REENCRYPT_DEBOUNCE_MS + 300);
+
+    expect(encryptSpy).toHaveBeenCalled();
+    const encrypted =
+      encryptSpy.mock.calls[encryptSpy.mock.calls.length - 1][1];
+    expect(encrypted.jsonById).toEqual({ 'live-1': '{"deploy":1}' });
+    expect(encrypted.eip712ById).toEqual({});
   });
 });

--- a/src/background/redux/sagas/vault-sagas.test.ts
+++ b/src/background/redux/sagas/vault-sagas.test.ts
@@ -101,7 +101,8 @@ const EMPTY_VAULT: VaultState = {
   siteNameByOriginDict: {},
   activeAccountName: null,
   jsonById: {},
-  eip712ById: {}
+  eip712ById: {},
+  payloadSeqById: {}
 };
 
 // Instantly resolve the module's own delay helper so tests never wait on a real
@@ -977,7 +978,8 @@ describe('unlockVaultSaga on a cipher written before a payload map existed', () 
       siteNameByOriginDict: { 'https://dapp.example': 'Dapp' },
       activeAccountName: 'Account 1',
       jsonById: ENTRIES.jsonById,
-      eip712ById: ENTRIES.eip712ById
+      eip712ById: ENTRIES.eip712ById,
+      payloadSeqById: { 'req-json': 0, 'req-eip': 1 }
     };
 
     // The key absent, as `JSON.stringify` produced on a build without it.

--- a/src/background/redux/sagas/vault-sagas.test.ts
+++ b/src/background/redux/sagas/vault-sagas.test.ts
@@ -553,11 +553,14 @@ describe('updateVaultCipher debounce', () => {
 });
 
 // WALLET-1418. `MAX_STORED_PAYLOADS` refuses the INCOMING write once
-// `jsonById`/`eip712ById` hold ten entries, and nothing evicts a stored one, so
-// ten payloads whose `windowRequestResponded` never arrived — a clean auto-lock
-// with an approval window open is enough, no worker death needed — permanently
-// refuse every later `sign` on the profile. This saga is the deliberate
-// replacement for the accidental exit `vaultLoaded` used to provide.
+// `jsonById`/`eip712ById` hold ten entries, and the only path that evicts a
+// stored one is `mergePayloadMaps` — which runs inside the reducer, on the same
+// `vaultLoaded` this saga takes, so it has already decided what survives before
+// this saga sees the action and cannot be relied on to reclaim anything for it.
+// So ten payloads whose `windowRequestResponded` never arrived — a clean
+// auto-lock with an approval window open is enough, no worker death needed —
+// permanently refuse every later `sign` on the profile. This saga is the
+// deliberate replacement for the accidental exit `vaultLoaded` used to provide.
 describe('reconcileStalePayloadsSaga', () => {
   const EMPTY_WINDOW_MANAGEMENT: WindowManagementState = {
     windowId: null,

--- a/src/background/redux/sagas/vault-sagas.test.ts
+++ b/src/background/redux/sagas/vault-sagas.test.ts
@@ -18,7 +18,8 @@ import {
 } from '@background/redux/storage-keys';
 
 import * as vaultCryptoModule from '@libs/crypto/vault';
-import { encryptVault } from '@libs/crypto/vault';
+import { FIXED_ENCRYPTION_KEY_HASH } from '@libs/crypto/__fixtures';
+import { decryptVault, encryptVault } from '@libs/crypto/vault';
 
 import { keysUpdated } from '../keys/actions';
 import { lastActivityTimeRefreshed } from '../last-activity-time/actions';
@@ -939,4 +940,112 @@ describe('reconcileStalePayloadsSaga', () => {
     expect(encrypted.jsonById).toEqual({ 'live-1': '{"deploy":1}' });
     expect(encrypted.eip712ById).toEqual({});
   });
+});
+
+// WALLET-1418. `eip712ById` entered `VaultState` after v2.4.2 shipped,
+// `decryptVault` is a bare `JSON.parse` cast and no migration exists, so an old
+// cipher decrypts without the field. A throw in `sanitizePayloadMap` lands in
+// `put(vaultLoaded(vault))`, is swallowed by `unlockVaultSaga`'s own catch, and
+// the vault never unlocks again. Driven through the REAL crypto: a hand-shaped
+// `vaultLoaded` payload cannot show that the round trip produces that shape.
+describe('unlockVaultSaga on a cipher written before a payload map existed', () => {
+  const PAYLOAD_MAPS = ['jsonById', 'eip712ById'] as const;
+
+  const ENTRIES = {
+    jsonById: { 'req-json': '{"deploy":1}' },
+    eip712ById: { 'req-eip': '{"eip712":2}' }
+  };
+
+  const legacyVaultState = (missing: (typeof PAYLOAD_MAPS)[number]) => {
+    const vault: VaultState = {
+      secretPhrase: ['w1', 'w2'],
+      accounts: [
+        {
+          name: 'Account 1',
+          publicKey: '0201aa',
+          secretKey: 'sk-1',
+          hidden: false
+        },
+        {
+          name: 'Account 2',
+          publicKey: '0201bb',
+          secretKey: 'sk-2',
+          hidden: false
+        }
+      ],
+      accountNamesByOriginDict: { 'https://dapp.example': ['Account 1'] },
+      siteNameByOriginDict: { 'https://dapp.example': 'Dapp' },
+      activeAccountName: 'Account 1',
+      jsonById: ENTRIES.jsonById,
+      eip712ById: ENTRIES.eip712ById
+    };
+
+    // The key absent, as `JSON.stringify` produced on a build without it.
+    delete (vault as Partial<VaultState>)[missing];
+
+    return vault;
+  };
+
+  const decryptLegacyCipher = async (
+    missing: (typeof PAYLOAD_MAPS)[number]
+  ) => {
+    const cipher = await encryptVault(
+      FIXED_ENCRYPTION_KEY_HASH,
+      legacyVaultState(missing)
+    );
+
+    return decryptVault(FIXED_ENCRYPTION_KEY_HASH, cipher);
+  };
+
+  it.each(PAYLOAD_MAPS)(
+    'round-trips through the real crypto into an object owning no %s',
+    async missing => {
+      const decrypted = await decryptLegacyCipher(missing);
+
+      expect(Object.prototype.hasOwnProperty.call(decrypted, missing)).toBe(
+        false
+      );
+    }
+  );
+
+  it.each(PAYLOAD_MAPS)(
+    'completes the unlock with %s absent, defaulting it to an empty dict',
+    async missing => {
+      const decrypted = await decryptLegacyCipher(missing);
+      const present = missing === 'jsonById' ? 'eip712ById' : 'jsonById';
+
+      const { storeState, effects } = await expectSaga(
+        unlockVaultSaga,
+        unlockVault({
+          vault: decrypted,
+          newKeyDerivationSaltHash: 'salt-hash',
+          newVaultCipher: 'new-cipher-blob',
+          newEncryptionKeyHash: 'new-key-hash'
+        })
+      )
+        .withReducer(
+          combineReducers({ vault: vaultReducer }) as never,
+          { vault: EMPTY_VAULT } as never
+        )
+        .put(vaultUnlocked())
+        .run();
+
+      const putTypes = (
+        (effects.put ?? []) as Array<{
+          payload: { action: { type: string } };
+        }>
+      ).map(e => e.payload.action.type);
+      expect(putTypes).not.toContain(sagaError.type);
+
+      const vault = (storeState as { vault: VaultState }).vault;
+
+      expect(vault[missing]).toEqual({});
+      expect(vault[present]).toEqual(ENTRIES[present]);
+      expect(vault.accounts.map(account => account.name)).toEqual([
+        'Account 1',
+        'Account 2'
+      ]);
+      expect(vault.activeAccountName).toBe('Account 1');
+    }
+  );
 });

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -8,6 +8,7 @@ import {
   MapTimeoutDurationSettingToValue
 } from '@popup/constants';
 
+import { collectRequestIdsFromOpenWindows } from '@background/open-request-windows';
 import { sagaError } from '@background/redux/app-events/actions';
 import {
   loginRetryLockoutTimeReseted,
@@ -76,6 +77,7 @@ import {
   popupWindowInit,
   windowRequestResponded
 } from '../windowManagement/actions';
+import { selectOpenRequests } from '../windowManagement/selectors';
 import {
   createAccount,
   lockVault,
@@ -95,6 +97,7 @@ export function* vaultSagas() {
     setDelayForLockoutVaultSaga
   );
   yield takeLatest(unlockVault.type, unlockVaultSaga);
+  yield takeLatest(vaultLoaded.type, reconcileStalePayloadsSaga);
   yield takeLatest(
     [
       startBackground.type,
@@ -261,6 +264,93 @@ export function* setDelayForLockoutVaultSaga(
   yield put(loginRetryCountReseted());
   yield put(loginRetryLockoutTimeReseted());
   yield* sagaCall(clearLockoutDeadline);
+}
+
+/**
+ * Reclaim the capped payload slots (`MAX_STORED_PAYLOADS`) that no live request
+ * can answer for. A plain auto-lock is enough to strand one: `lockVaultSaga`
+ * flushes `updateVaultCipher` BEFORE the resets, so an unanswered payload is
+ * persisted, the later `windowRequestResponded` finds an emptied in-memory map,
+ * and `vaultLoaded` restores the entry on the next unlock.
+ *
+ * `windowRequestResponded` is reused rather than a new action added because it
+ * is already in the re-encrypt debounce list above, which is how the deletion
+ * reaches the cipher rather than living in memory until the next restart.
+ */
+export function* reconcileStalePayloadsSaga() {
+  try {
+    // Nothing stored, nothing to reclaim: skip the round trip over every tab
+    // URL. Sound as a pre-await read because it only decides whether to do
+    // nothing at all — never reuse it for the purge decision.
+    const payloadsAtEntry = yield* sagaSelect(selectVault);
+
+    if (
+      Object.keys(payloadsAtEntry.jsonById).length === 0 &&
+      Object.keys(payloadsAtEntry.eip712ById).length === 0
+    ) {
+      return;
+    }
+
+    // `null` is a failed enumeration, not "no window displays a request". Fail
+    // closed: purging on no evidence strands a live request.
+    const liveIdsFromWindows = yield* sagaCall(
+      collectRequestIdsFromOpenWindows
+    );
+
+    if (liveIdsFromWindows == null) {
+      return;
+    }
+
+    // Re-read after the await: a keep-set computed before it is already stale.
+    const openRequests = yield* sagaSelect(selectOpenRequests);
+    const vault = yield* sagaSelect(selectVault);
+
+    // Both halves are needed. After a service-worker restart the descriptors
+    // are gone while the window still shows its `?requestId=`; on window reuse
+    // a live window still reports the previous request's URL mid-navigation.
+    const keep = new Set(liveIdsFromWindows);
+
+    for (const { requestId } of openRequests) {
+      keep.add(requestId);
+    }
+
+    const orphans = new Set<string>();
+
+    for (const requestId of [
+      ...Object.keys(vault.jsonById),
+      ...Object.keys(vault.eip712ById)
+    ]) {
+      if (!keep.has(requestId)) {
+        orphans.add(requestId);
+      }
+    }
+
+    if (orphans.size === 0) {
+      return;
+    }
+
+    // Ids and counts only — no URL, window or tab may be logged: a `signMessage`
+    // approval URL carries the user's plaintext message as a search param.
+    console.warn('reconcileStalePayloadsSaga: reclaiming stale payload slots', {
+      reclaimed: [...orphans],
+      keptCount: keep.size
+    });
+
+    for (const requestId of orphans) {
+      yield put(windowRequestResponded({ requestId }));
+    }
+  } catch (err) {
+    // `root-saga.ts` is a bare `all([...])` with no `onError`, so an escaping
+    // throw aborts every saga — auto-lock and cipher persistence included. The
+    // reported message is fixed: nothing from a window URL may reach the banner.
+    console.error('reconcileStalePayloadsSaga: failed', errorToMessage(err));
+    yield put(
+      sagaError({
+        source: 'reconcileStalePayloadsSaga',
+        message: 'Could not reclaim stored signing payloads'
+      })
+    );
+  }
 }
 
 /**

--- a/src/background/redux/vault/reducer.test.ts
+++ b/src/background/redux/vault/reducer.test.ts
@@ -37,7 +37,8 @@ const initialState: VaultState = {
   siteNameByOriginDict: {},
   activeAccountName: null,
   jsonById: {},
-  eip712ById: {}
+  eip712ById: {},
+  payloadSeqById: {}
 };
 
 describe('vault reducer', () => {
@@ -66,7 +67,8 @@ describe('vault reducer', () => {
       siteNameByOriginDict: { o1: 'Title' },
       activeAccountName: 'a',
       jsonById: { pj: 'payload-json' },
-      eip712ById: { pe: 'payload-eip' }
+      eip712ById: { pe: 'payload-eip' },
+      payloadSeqById: { pj: 0, pe: 1 }
     };
 
     it('takes the cipher payload dicts when the in-memory dicts are empty', () => {
@@ -77,7 +79,8 @@ describe('vault reducer', () => {
         siteNameByOriginDict: { o1: 'Title' },
         activeAccountName: 'a',
         jsonById: { pj: 'payload-json' },
-        eip712ById: { pe: 'payload-eip' }
+        eip712ById: { pe: 'payload-eip' },
+        payloadSeqById: { pj: 0, pe: 1 }
       });
     });
 
@@ -94,7 +97,10 @@ describe('vault reducer', () => {
         siteNameByOriginDict: { o1: 'Title' },
         activeAccountName: 'a',
         jsonById: { pj: 'payload-json', existing: 'keep-json' },
-        eip712ById: { pe: 'payload-eip', existing: 'keep-eip' }
+        eip712ById: { pe: 'payload-eip', existing: 'keep-eip' },
+        // Renumbered into one sequence: the two carried entries keep their
+        // relative age and both sit below the in-memory one.
+        payloadSeqById: { pj: 0, pe: 1, existing: 2 }
       });
     });
 
@@ -222,13 +228,24 @@ describe('vault reducer', () => {
           ])
         );
 
+      const seqOf = (prefix: string, count: number, from = 0) =>
+        Object.fromEntries(
+          Array.from({ length: count }, (_, i) => [`${prefix}-${i}`, from + i])
+        );
+
       const loaded = (
         cipher: Record<string, string>,
-        inMemory: Record<string, string>
+        inMemory: Record<string, string>,
+        cipherSeq: Record<string, number> = {}
       ) =>
         reducer(
           { ...initialState, jsonById: inMemory, eip712ById: inMemory },
-          vaultLoaded({ ...payload, jsonById: cipher, eip712ById: cipher })
+          vaultLoaded({
+            ...payload,
+            jsonById: cipher,
+            eip712ById: cipher,
+            payloadSeqById: cipherSeq
+          })
         );
 
       it.each(['jsonById', 'eip712ById'] as const)(
@@ -312,6 +329,145 @@ describe('vault reducer', () => {
         expect(Object.keys(s.jsonById)).toHaveLength(MAX_STORED_PAYLOADS);
         expect(getPayload(s.jsonById, 'cipher-0')).toBe('cipher-json-0');
         expect(getPayload(s.jsonById, 'shared')).toBe('fresh');
+      });
+
+      // "Newest" is read off `payloadSeqById`. Reading it off the map's own
+      // key order is what these pin against: an object hoists integer-like
+      // keys ahead of every string key, in ascending numeric order, and
+      // `requestId` is dapp-chosen — only `__proto__` is rejected — so `"42"`
+      // is an id the wallet accepts and stores.
+      describe('ranked by payloadSeqById, not by key order', () => {
+        it('evicts by ordinal even when the key order says the opposite', () => {
+          const cipher = { ...mapOf('stale', 9), '42': 'live-json' };
+          const cipherSeq = { ...seqOf('stale', 9), '42': 9 };
+
+          // The hoisting the ranking must not follow: the entry written LAST
+          // enumerates FIRST, where the eviction takes from.
+          expect(Object.keys(cipher)[0]).toBe('42');
+
+          const s = loaded(cipher, mapOf('memory', 1), cipherSeq);
+
+          expect(getPayload(s.jsonById, '42')).toBe('live-json');
+          expect(getPayload(s.jsonById, 'stale-0')).toBeUndefined();
+        });
+
+        // The mirror, so the rule reads as "follow the ordinal" rather than
+        // "spare integer-like keys".
+        it('evicts an integer-like id that really is the oldest', () => {
+          const cipher = { ...mapOf('fresh', 9), '42': 'stale-json' };
+          const cipherSeq = { '42': 0, ...seqOf('fresh', 9, 1) };
+
+          const s = loaded(cipher, mapOf('memory', 1), cipherSeq);
+
+          expect(getPayload(s.jsonById, '42')).toBeUndefined();
+          expect(getPayload(s.jsonById, 'fresh-0')).toBe('fresh-json-0');
+        });
+
+        // An entry with no ordinal was written before the field existed, so it
+        // predates everything stamped.
+        it('treats an unstamped entry as older than every stamped one', () => {
+          const cipher = { legacy: 'legacy-json', ...mapOf('stamped', 9) };
+
+          const s = loaded(cipher, mapOf('memory', 1), seqOf('stamped', 9));
+
+          expect(getPayload(s.jsonById, 'legacy')).toBeUndefined();
+          expect(getPayload(s.jsonById, 'stamped-0')).toBe('stamped-json-0');
+        });
+
+        // A cipher written before the field existed carries no ordinals at
+        // all, so the merge falls back to the map's own order — what it did
+        // before this ranking, rather than treating every entry as unrankable.
+        it('falls back to cipher order when the cipher predates the field', () => {
+          const legacy: VaultState = {
+            ...payload,
+            jsonById: mapOf('cipher', MAX_STORED_PAYLOADS),
+            eip712ById: {}
+          };
+          delete (legacy as Partial<VaultState>).payloadSeqById;
+
+          const s = reducer(
+            { ...initialState, jsonById: mapOf('memory', 3) },
+            vaultLoaded(legacy)
+          );
+
+          expect(Object.keys(s.jsonById)).toHaveLength(MAX_STORED_PAYLOADS);
+          expect(getPayload(s.jsonById, 'cipher-0')).toBeUndefined();
+          expect(getPayload(s.jsonById, 'cipher-9')).toBe('cipher-json-9');
+        });
+
+        // The two sides' ordinals came from different counters — the cipher's
+        // from before the lock, memory's restarted at 0 by `vaultReseted` —
+        // so they are renumbered into one sequence rather than left to be
+        // compared across epochs at the next unlock.
+        it('renumbers the survivors into one sequence, carried entries first', () => {
+          const s = loaded(
+            mapOf('cipher', 6),
+            mapOf('memory', 6),
+            seqOf('cipher', 6)
+          );
+
+          expect(s.payloadSeqById).toEqual({
+            'cipher-2': 0,
+            'cipher-3': 1,
+            'cipher-4': 2,
+            'cipher-5': 3,
+            'memory-0': 4,
+            'memory-1': 5,
+            'memory-2': 6,
+            'memory-3': 7,
+            'memory-4': 8,
+            'memory-5': 9
+          });
+        });
+
+        it('leaves no ordinal behind for an evicted entry', () => {
+          const s = loaded(
+            mapOf('cipher', MAX_STORED_PAYLOADS),
+            mapOf('memory', 3),
+            seqOf('cipher', MAX_STORED_PAYLOADS)
+          );
+
+          expect(Object.keys(s.payloadSeqById).sort()).toEqual(
+            Object.keys(s.jsonById).sort()
+          );
+        });
+
+        // The whole cycle, with no hand-written ordinal anywhere: every one of
+        // them is the reducer's own. A dapp that numbers its requests fills the
+        // map before a lock, the live request is the newest, and the unlock
+        // must not hand its slot to nine leaks.
+        it('keeps the live numerically-keyed request across a lock', () => {
+          let preLock = initialState;
+
+          for (let i = 0; i < MAX_STORED_PAYLOADS - 1; i++) {
+            preLock = reducer(
+              preLock,
+              deployPayloadReceived({ id: `leak-${i}`, json: `leak-json-${i}` })
+            );
+          }
+
+          // The request the user is about to confirm, keyed as a dapp may.
+          preLock = reducer(
+            preLock,
+            deployPayloadReceived({ id: '42', json: 'live-json' })
+          );
+
+          // `lockVaultSaga` flushes the cipher BEFORE the reset, so `preLock`
+          // is what the cipher holds while the in-memory map is emptied.
+          const locked = reducer(preLock, vaultReseted());
+          // `signRequest` has no lock gate: one lands while locked.
+          const whileLocked = reducer(
+            locked,
+            deployPayloadReceived({ id: 'locked-0', json: 'locked-json-0' })
+          );
+
+          const s = reducer(whileLocked, vaultLoaded(preLock));
+
+          expect(getPayload(s.jsonById, '42')).toBe('live-json');
+          expect(getPayload(s.jsonById, 'leak-0')).toBeUndefined();
+          expect(getPayload(s.jsonById, 'locked-0')).toBe('locked-json-0');
+          expect(Object.keys(s.jsonById)).toHaveLength(MAX_STORED_PAYLOADS);
+        });
       });
     });
   });
@@ -613,7 +769,8 @@ describe('vault reducer', () => {
       siteNameByOriginDict: { o1: 'Title' },
       activeAccountName: 'a',
       jsonById: { j: 'x' },
-      eip712ById: { e: 'y' }
+      eip712ById: { e: 'y' },
+      payloadSeqById: { j: 0, e: 1 }
     };
     expect(reducer(seeded, deploysReseted())).toEqual(initialState);
   });
@@ -652,6 +809,45 @@ describe('vault reducer', () => {
       expect(s.eip712ById).toEqual({
         first: 'eip-first',
         second: 'eip-second'
+      });
+    });
+
+    // The write order the merge on unlock ranks on. It has to be stored: a
+    // plain object hoists integer-like keys ahead of every string key, so the
+    // maps themselves cannot answer which entry came last.
+    describe('payloadSeqById', () => {
+      it('stamps one ascending ordinal per stored request, across both maps', () => {
+        const s = [
+          deployPayloadReceived({ id: 'first', json: 'json-first' }),
+          eip712PayloadReceived({ id: 'second', json: 'eip-second' }),
+          deployPayloadReceived({ id: 'third', json: 'json-third' })
+        ].reduce(reducer, initialState);
+
+        expect(s.payloadSeqById).toEqual({ first: 0, second: 1, third: 2 });
+      });
+
+      // A rewrite is the same request refreshed, and it is the REQUEST's age
+      // the merge ranks on — re-stamping would let a page promote its own
+      // entry past a live one simply by re-sending it.
+      it('keeps the original ordinal when the same id is stored again', () => {
+        const s = [
+          deployPayloadReceived({ id: 'first', json: 'json-first' }),
+          deployPayloadReceived({ id: 'second', json: 'json-second' }),
+          deployPayloadReceived({ id: 'first', json: 'refreshed' })
+        ].reduce(reducer, initialState);
+
+        expect(s.payloadSeqById).toEqual({ first: 0, second: 1 });
+        expect(getPayload(s.jsonById, 'first')).toBe('refreshed');
+      });
+
+      it('stamps no ordinal for a refused __proto__ write', () => {
+        const s = reducer(
+          initialState,
+          deployPayloadReceived({ id: '__proto__', json: 'poison' })
+        );
+
+        expect(Object.keys(s.payloadSeqById)).toEqual([]);
+        expect(Object.getPrototypeOf(s.payloadSeqById)).toBe(Object.prototype);
       });
     });
 
@@ -737,6 +933,17 @@ describe('vault reducer', () => {
         expect(Object.keys(s[map])).toHaveLength(MAX_STORED_PAYLOADS);
       });
 
+      it.each([
+        ['jsonById', deployPayloadReceived] as const,
+        ['eip712ById', eip712PayloadReceived] as const
+      ])('stamps no ordinal for a %s write it refused', (map, action) => {
+        const full = atCapacity(map);
+
+        const s = reducer(full, action({ id: 'incoming', json: 'refused' }));
+
+        expect(s.payloadSeqById.incoming).toBeUndefined();
+      });
+
       // A burst answering one request must hand the freed slot to the next
       // write, or the refusal above would be permanent rather than a ceiling.
       it('accepts a new payload once an answered request frees a slot', () => {
@@ -767,6 +974,22 @@ describe('vault reducer', () => {
         windowRequestResponded({ requestId: 'answered' })
       );
       expect(s.jsonById).toEqual({ other: 'kept' });
+    });
+
+    // An ordinal outliving its payload is a leaked slot of the same kind this
+    // case exists to reclaim, in a map nothing else enumerates.
+    it('drops the ordinal along with the payload it dates', () => {
+      const seeded = [
+        deployPayloadReceived({ id: 'answered', json: 'gone' }),
+        deployPayloadReceived({ id: 'other', json: 'kept' })
+      ].reduce(reducer, initialState);
+
+      const s = reducer(
+        seeded,
+        windowRequestResponded({ requestId: 'answered' })
+      );
+
+      expect(s.payloadSeqById).toEqual({ other: 1 });
     });
 
     it('drops the answered request from eip712ById and leaves the rest', () => {

--- a/src/background/redux/vault/reducer.test.ts
+++ b/src/background/redux/vault/reducer.test.ts
@@ -207,6 +207,113 @@ describe('vault reducer', () => {
       expect(Object.keys(s.jsonById)).toEqual([]);
       expect(Object.keys(s.eip712ById)).toEqual([]);
     });
+
+    // The merge is the one writer to these maps no `storePayload` guard covers:
+    // each side is capped at `MAX_STORED_PAYLOADS`, so their union can be twice
+    // that. Bounded here rather than left to `reconcileStalePayloadsSaga`, which
+    // returns without reclaiming on an empty entry read, on a failed window
+    // enumeration and in its catch, and is a `takeLatest` with no retry.
+    describe('over MAX_STORED_PAYLOADS', () => {
+      const mapOf = (prefix: string, count: number) =>
+        Object.fromEntries(
+          Array.from({ length: count }, (_, i) => [
+            `${prefix}-${i}`,
+            `${prefix}-json-${i}`
+          ])
+        );
+
+      const loaded = (
+        cipher: Record<string, string>,
+        inMemory: Record<string, string>
+      ) =>
+        reducer(
+          { ...initialState, jsonById: inMemory, eip712ById: inMemory },
+          vaultLoaded({ ...payload, jsonById: cipher, eip712ById: cipher })
+        );
+
+      it.each(['jsonById', 'eip712ById'] as const)(
+        'caps the merged %s at MAX_STORED_PAYLOADS',
+        map => {
+          const s = loaded(
+            mapOf('cipher', MAX_STORED_PAYLOADS),
+            mapOf('memory', MAX_STORED_PAYLOADS)
+          );
+
+          expect(Object.keys(s[map])).toHaveLength(MAX_STORED_PAYLOADS);
+        }
+      );
+
+      // An in-memory entry arrived in THIS worker session — `signRequest` has
+      // no lock gate, so one lands even while locked — and cannot be a payload
+      // stranded by an earlier session. A cipher entry can.
+      it('keeps every in-memory entry and takes the drop from the cipher', () => {
+        const inMemory = mapOf('memory', 4);
+
+        const s = loaded(mapOf('cipher', MAX_STORED_PAYLOADS), inMemory);
+
+        expect(Object.keys(s.jsonById)).toHaveLength(MAX_STORED_PAYLOADS);
+        Object.entries(inMemory).forEach(([id, json]) => {
+          expect(getPayload(s.jsonById, id)).toBe(json);
+        });
+      });
+
+      // Cipher order is insertion order across sessions, and a rewrite keeps
+      // its original position, so the oldest key is the entry that has survived
+      // the most locks unanswered — a leak. The newest is the one written just
+      // before this lock, the only one an approval window can still be on.
+      it('drops the oldest cipher entries and keeps the newest', () => {
+        const s = loaded(
+          mapOf('cipher', MAX_STORED_PAYLOADS),
+          mapOf('memory', 3)
+        );
+
+        expect(getPayload(s.jsonById, 'cipher-0')).toBeUndefined();
+        expect(getPayload(s.jsonById, 'cipher-2')).toBeUndefined();
+        expect(getPayload(s.jsonById, 'cipher-3')).toBe('cipher-json-3');
+        expect(getPayload(s.jsonById, 'cipher-9')).toBe('cipher-json-9');
+      });
+
+      // Survivors stay ahead of the in-memory entries, so the next lock
+      // persists them in the same order and "oldest" keeps its meaning.
+      it('leaves the surviving cipher entries before the in-memory ones', () => {
+        const s = loaded(mapOf('cipher', 6), mapOf('memory', 6));
+
+        expect(Object.keys(s.jsonById)).toEqual([
+          'cipher-2',
+          'cipher-3',
+          'cipher-4',
+          'cipher-5',
+          'memory-0',
+          'memory-1',
+          'memory-2',
+          'memory-3',
+          'memory-4',
+          'memory-5'
+        ]);
+      });
+
+      it('leaves a union that fits under the ceiling untouched', () => {
+        const cipher = mapOf('cipher', 5);
+        const inMemory = mapOf('memory', 5);
+
+        const s = loaded(cipher, inMemory);
+
+        expect(s.jsonById).toEqual({ ...cipher, ...inMemory });
+        expect(s.eip712ById).toEqual({ ...cipher, ...inMemory });
+      });
+
+      // An id on both sides is one entry: counting it twice would evict a
+      // cipher entry to free a slot that was never spent.
+      it('spends one slot on an id held by both sides', () => {
+        const cipher = { ...mapOf('cipher', 9), shared: 'stale' };
+
+        const s = loaded(cipher, { shared: 'fresh' });
+
+        expect(Object.keys(s.jsonById)).toHaveLength(MAX_STORED_PAYLOADS);
+        expect(getPayload(s.jsonById, 'cipher-0')).toBe('cipher-json-0');
+        expect(getPayload(s.jsonById, 'shared')).toBe('fresh');
+      });
+    });
   });
 
   // 3
@@ -587,10 +694,12 @@ describe('vault reducer', () => {
       expect(getPayload(s.jsonById, '__proto__')).toBeUndefined();
     });
 
-    // The ceiling must never cost an ALREADY STORED request its payload: the
-    // oldest entry is the long-lived one — a request being confirmed on a
-    // Ledger while a page pushes a burst of its own — and dropping it would
-    // reproduce, behind a threshold, exactly the failure this reducer fixes.
+    // On this path the ceiling must never cost an ALREADY STORED request its
+    // payload: within a session the oldest entry is the long-lived one — a
+    // request being confirmed on a Ledger while a page pushes a burst of its
+    // own — and dropping it would reproduce, behind a threshold, exactly the
+    // failure this reducer fixes. Across a lock the age reads the other way,
+    // which is why the merge above evicts the opposite end.
     describe('at MAX_STORED_PAYLOADS', () => {
       const atCapacity = (map: 'jsonById' | 'eip712ById'): VaultState => ({
         ...initialState,

--- a/src/background/redux/vault/reducer.test.ts
+++ b/src/background/redux/vault/reducer.test.ts
@@ -233,6 +233,20 @@ describe('vault reducer', () => {
           Array.from({ length: count }, (_, i) => [`${prefix}-${i}`, from + i])
         );
 
+      // Every merge below can evict, and eviction warns. Spied rather than
+      // silenced: the warning is the only signal that tells a support log
+      // "the unlock merge took it" apart from every other reason a pending
+      // transaction vanished, so it is asserted here rather than left to print.
+      let warn: jest.SpyInstance;
+
+      beforeEach(() => {
+        warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      });
+
+      afterEach(() => {
+        warn.mockRestore();
+      });
+
       const loaded = (
         cipher: Record<string, string>,
         inMemory: Record<string, string>,
@@ -329,8 +343,10 @@ describe('vault reducer', () => {
       });
 
       // The slots come out of the in-memory side oldest first: those writes
-      // arrived while the vault was locked, none is approved, and their dapp
-      // can still be told.
+      // arrived while the vault was locked and none is approved, so they are
+      // the cheapest to lose. Not free — nothing here answers the dapp, and
+      // the window for an evicted id renders with no payload until the user
+      // closes it. The warning below is the only trace it leaves.
       it('takes the drop from the oldest in-memory entries, not the newest', () => {
         const cipher = { ...mapOf('stale', 9), live: 'live-json' };
         const cipherSeq = { ...seqOf('stale', 9), live: 9 };
@@ -347,6 +363,30 @@ describe('vault reducer', () => {
         ).toBe(`memory-json-${MAX_STORED_PAYLOADS - 1}`);
       });
 
+      // The reserve is two, and both directions cost something: at one the
+      // second pre-lock request is never restored, at three the extra slot is
+      // paid out of live locked-session writes. The fixture above cannot see
+      // either, because it carries a single live cipher entry.
+      it('reserves exactly two cipher slots, no more and no fewer', () => {
+        const cipher = {
+          ...mapOf('stale', 8),
+          'live-a': 'live-a-json',
+          'live-b': 'live-b-json'
+        };
+        const cipherSeq = { ...seqOf('stale', 8), 'live-a': 8, 'live-b': 9 };
+
+        const s = loaded(
+          cipher,
+          mapOf('memory', MAX_STORED_PAYLOADS),
+          cipherSeq
+        );
+
+        expect(getPayload(s.jsonById, 'live-a')).toBe('live-a-json');
+        expect(getPayload(s.jsonById, 'live-b')).toBe('live-b-json');
+        expect(getPayload(s.jsonById, 'stale-7')).toBeUndefined();
+        expect(Object.keys(s.jsonById)).toHaveLength(MAX_STORED_PAYLOADS);
+      });
+
       it('leaves a union that fits under the ceiling untouched', () => {
         const cipher = mapOf('cipher', 5);
         const inMemory = mapOf('memory', 5);
@@ -355,6 +395,102 @@ describe('vault reducer', () => {
 
         expect(s.jsonById).toEqual({ ...cipher, ...inMemory });
         expect(s.eip712ById).toEqual({ ...cipher, ...inMemory });
+      });
+
+      // The case above has `carried === MAX - live` exactly, where both clamps
+      // in the slot arithmetic are no-ops. Here the cipher asks for less than
+      // the reserve while the union still fits: dropping either clamp makes
+      // this merge discard entries that had room, on the two sides in turn.
+      it('drops nothing when the cipher asks for less than the reserve', () => {
+        const cipher = mapOf('cipher', 3);
+        const inMemory = mapOf('memory', 6);
+
+        const s = loaded(cipher, inMemory);
+
+        expect(s.jsonById).toEqual({ ...cipher, ...inMemory });
+      });
+
+      // The shape the ticket describes: locked with nothing pending, a page
+      // fires a full map at the locked wallet, unlock. The reserve must not be
+      // paid when the cipher is asking for nothing.
+      it('keeps every locked-session payload when the cipher is empty', () => {
+        const inMemory = mapOf('memory', MAX_STORED_PAYLOADS);
+
+        const s = loaded({}, inMemory);
+
+        expect(s.jsonById).toEqual(inMemory);
+        expect(warn).not.toHaveBeenCalled();
+      });
+
+      // `payloadSeqById` decides which locked-session write is destroyed, and
+      // the map's own key order is not a stand-in for it: `orderOldestFirst`
+      // ranks an unstamped integer-like id NEWEST, so falling back to key order
+      // here would spare '42' — which is in fact the oldest entry in the map.
+      it('picks the evicted in-memory entry by ordinal, not by key order', () => {
+        let inMemory = reducer(
+          initialState,
+          deployPayloadReceived({ id: '42', json: 'oldest-json' })
+        );
+
+        for (let i = 0; i < MAX_STORED_PAYLOADS - 1; i++) {
+          inMemory = reducer(
+            inMemory,
+            deployPayloadReceived({ id: `uuid-${i}`, json: `uuid-json-${i}` })
+          );
+        }
+
+        // Fixture integrity: '42' really is the oldest, by the reducer's own
+        // ordinal, and really is hoisted to the front of the map.
+        expect(inMemory.payloadSeqById['42']).toBe(0);
+        expect(Object.keys(inMemory.jsonById)[0]).toBe('42');
+
+        const s = reducer(
+          inMemory,
+          vaultLoaded({
+            ...payload,
+            jsonById: mapOf('cipher', 2),
+            eip712ById: {},
+            payloadSeqById: seqOf('cipher', 2)
+          })
+        );
+
+        expect(getPayload(s.jsonById, '42')).toBeUndefined();
+        expect(getPayload(s.jsonById, 'uuid-0')).toBeUndefined();
+        expect(getPayload(s.jsonById, 'uuid-1')).toBe('uuid-json-1');
+      });
+
+      it('warns with the evicted locked-session ids and the kept count', () => {
+        const cipher = { ...mapOf('stale', 9), live: 'live-json' };
+        const cipherSeq = { ...seqOf('stale', 9), live: 9 };
+
+        loaded(cipher, mapOf('memory', MAX_STORED_PAYLOADS), cipherSeq);
+
+        expect(warn).toHaveBeenCalledWith(
+          'mergePayloadMaps: evicted locked-session payloads',
+          {
+            evicted: ['memory-0', 'memory-1'],
+            keptCount: MAX_STORED_PAYLOADS
+          }
+        );
+      });
+
+      // The other half, and the one the reserve can take a live request out
+      // of: a carried entry outside the newest `CIPHER_RESERVED_SLOTS` is
+      // dropped whether it is a leak or not, so it says so too.
+      it('warns with the evicted carried ids and the kept count', () => {
+        loaded(
+          mapOf('cipher', MAX_STORED_PAYLOADS),
+          mapOf('memory', 3),
+          seqOf('cipher', MAX_STORED_PAYLOADS)
+        );
+
+        expect(warn).toHaveBeenCalledWith(
+          'mergePayloadMaps: evicted carried payloads',
+          {
+            evicted: ['cipher-0', 'cipher-1', 'cipher-2'],
+            keptCount: MAX_STORED_PAYLOADS
+          }
+        );
       });
 
       // An id on both sides is one entry: counting it twice would evict a

--- a/src/background/redux/vault/reducer.test.ts
+++ b/src/background/redux/vault/reducer.test.ts
@@ -309,6 +309,44 @@ describe('vault reducer', () => {
         ]);
       });
 
+      // `room` reaches 0 once the in-memory map is at the ceiling, and before
+      // this the whole cipher side went with it — the live pre-lock request
+      // included — on count alone. A page puts it there on demand:
+      // `signRequest` has no lock gate, so ten requests fired at a locked
+      // wallet fill the map.
+      it('keeps the newest cipher entries when the in-memory map is at the ceiling', () => {
+        const cipher = { ...mapOf('stale', 9), live: 'live-json' };
+        const cipherSeq = { ...seqOf('stale', 9), live: 9 };
+
+        const s = loaded(
+          cipher,
+          mapOf('memory', MAX_STORED_PAYLOADS),
+          cipherSeq
+        );
+
+        expect(Object.keys(s.jsonById)).toHaveLength(MAX_STORED_PAYLOADS);
+        expect(getPayload(s.jsonById, 'live')).toBe('live-json');
+      });
+
+      // The slots come out of the in-memory side oldest first: those writes
+      // arrived while the vault was locked, none is approved, and their dapp
+      // can still be told.
+      it('takes the drop from the oldest in-memory entries, not the newest', () => {
+        const cipher = { ...mapOf('stale', 9), live: 'live-json' };
+        const cipherSeq = { ...seqOf('stale', 9), live: 9 };
+
+        const s = loaded(
+          cipher,
+          mapOf('memory', MAX_STORED_PAYLOADS),
+          cipherSeq
+        );
+
+        expect(getPayload(s.jsonById, 'memory-0')).toBeUndefined();
+        expect(
+          getPayload(s.jsonById, `memory-${MAX_STORED_PAYLOADS - 1}`)
+        ).toBe(`memory-json-${MAX_STORED_PAYLOADS - 1}`);
+      });
+
       it('leaves a union that fits under the ceiling untouched', () => {
         const cipher = mapOf('cipher', 5);
         const inMemory = mapOf('memory', 5);
@@ -393,6 +431,50 @@ describe('vault reducer', () => {
           expect(Object.keys(s.jsonById)).toHaveLength(MAX_STORED_PAYLOADS);
           expect(getPayload(s.jsonById, 'cipher-0')).toBeUndefined();
           expect(getPayload(s.jsonById, 'cipher-9')).toBe('cipher-json-9');
+        });
+
+        // The fallback order lies about exactly one class of id. An
+        // integer-like key is hoisted to the front of the map whenever it was
+        // written, so reading it as the oldest evicts the entry a legacy
+        // cipher is least able to spare.
+        it('does not evict an integer-like id from a cipher that predates the field', () => {
+          const legacy: VaultState = {
+            ...payload,
+            jsonById: { ...mapOf('leak', 9), '42': 'live-json' },
+            eip712ById: {}
+          };
+          delete (legacy as Partial<VaultState>).payloadSeqById;
+
+          // The hoisting: written LAST, enumerates FIRST.
+          expect(Object.keys(legacy.jsonById)[0]).toBe('42');
+
+          const s = reducer(
+            { ...initialState, jsonById: mapOf('memory', 3) },
+            vaultLoaded(legacy)
+          );
+
+          expect(getPayload(s.jsonById, '42')).toBe('live-json');
+          expect(getPayload(s.jsonById, 'leak-0')).toBeUndefined();
+        });
+
+        // An ordinary key's position IS its age, so the fallback still reads
+        // it — the rule is "distrust the hoisted key", not "spare every
+        // unstamped one".
+        it('still evicts the oldest ordinary id from a cipher that predates the field', () => {
+          const legacy: VaultState = {
+            ...payload,
+            jsonById: mapOf('leak', MAX_STORED_PAYLOADS),
+            eip712ById: {}
+          };
+          delete (legacy as Partial<VaultState>).payloadSeqById;
+
+          const s = reducer(
+            { ...initialState, jsonById: mapOf('memory', 3) },
+            vaultLoaded(legacy)
+          );
+
+          expect(getPayload(s.jsonById, 'leak-0')).toBeUndefined();
+          expect(getPayload(s.jsonById, 'leak-9')).toBe('leak-json-9');
         });
 
         // The two sides' ordinals came from different counters — the cipher's

--- a/src/background/redux/vault/reducer.test.ts
+++ b/src/background/redux/vault/reducer.test.ts
@@ -69,7 +69,7 @@ describe('vault reducer', () => {
       eip712ById: { pe: 'payload-eip' }
     };
 
-    it('replaces state and takes payload dicts when existing dicts are empty', () => {
+    it('takes the cipher payload dicts when the in-memory dicts are empty', () => {
       expect(reducer(initialState, vaultLoaded(payload))).toEqual({
         secretPhrase: ['w1', 'w2'],
         accounts: [acc('a')],
@@ -81,7 +81,7 @@ describe('vault reducer', () => {
       });
     });
 
-    it('keeps existing non-empty jsonById / eip712ById', () => {
+    it('merges the cipher dicts into the in-memory ones', () => {
       const state: VaultState = {
         ...initialState,
         jsonById: { existing: 'keep-json' },
@@ -93,9 +93,101 @@ describe('vault reducer', () => {
         accountNamesByOriginDict: { o1: ['a'] },
         siteNameByOriginDict: { o1: 'Title' },
         activeAccountName: 'a',
-        jsonById: { existing: 'keep-json' },
-        eip712ById: { existing: 'keep-eip' }
+        jsonById: { pj: 'payload-json', existing: 'keep-json' },
+        eip712ById: { pe: 'payload-eip', existing: 'keep-eip' }
       });
+    });
+
+    // `updateVaultCipher` early-returns while locked, so memory holds the
+    // later write.
+    it('lets the in-memory value win on an id present in both dicts', () => {
+      const state: VaultState = {
+        ...initialState,
+        jsonById: { pj: 'fresh-json' },
+        eip712ById: { pe: 'fresh-eip' }
+      };
+
+      const s = reducer(state, vaultLoaded(payload));
+
+      expect(s.jsonById).toEqual({ pj: 'fresh-json' });
+      expect(s.eip712ById).toEqual({ pe: 'fresh-eip' });
+    });
+
+    // Asserted on what the reducer owns: at es2017 the merge is emitted as
+    // `Object.assign`, where a string `__proto__` vanishes silently and an
+    // object one replaces the map's prototype.
+    it.each([
+      ['a string', '"poison"'],
+      ['an object, as the deploy path dispatches', '{ "poisoned": true }']
+    ])(
+      'drops a __proto__ key carrying %s from the loaded dicts',
+      (_l, json) => {
+        // Object-literal `__proto__` is prototype syntax, not a key;
+        // `JSON.parse` is what creates the own property.
+        const poisoned: VaultState = {
+          ...payload,
+          jsonById: JSON.parse(
+            `{ "__proto__": ${json}, "pj": "payload-json" }`
+          ),
+          eip712ById: JSON.parse(
+            `{ "__proto__": ${json}, "pe": "payload-eip" }`
+          )
+        };
+
+        const s = reducer(initialState, vaultLoaded(poisoned));
+
+        expect(Object.keys(s.jsonById)).toEqual(['pj']);
+        expect(Object.keys(s.eip712ById)).toEqual(['pe']);
+        expect(Object.getPrototypeOf(s.jsonById)).toBe(Object.prototype);
+        expect(Object.getPrototypeOf(s.eip712ById)).toBe(Object.prototype);
+        expect(getPayload(s.jsonById, '__proto__')).toBeUndefined();
+        expect(getPayload(s.eip712ById, '__proto__')).toBeUndefined();
+      }
+    );
+
+    // The sanitizer must not overreach: a request keyed `constructor` still has
+    // a payload to sign.
+    it.each(['toString', 'constructor', 'valueOf', 'hasOwnProperty'])(
+      'keeps a cipher payload stored under the inherited name %s',
+      key => {
+        const state: VaultState = {
+          ...initialState,
+          jsonById: { inMemory: 'keep-json' },
+          eip712ById: { inMemory: 'keep-eip' }
+        };
+
+        const s = reducer(
+          state,
+          vaultLoaded({
+            ...payload,
+            jsonById: { [key]: 'from-cipher' },
+            eip712ById: { [key]: 'from-cipher' }
+          })
+        );
+
+        expect(Object.prototype.hasOwnProperty.call(s.jsonById, key)).toBe(
+          true
+        );
+        expect(Object.prototype.hasOwnProperty.call(s.eip712ById, key)).toBe(
+          true
+        );
+        expect(getPayload(s.jsonById, key)).toBe('from-cipher');
+        expect(getPayload(s.eip712ById, key)).toBe('from-cipher');
+        expect(getPayload(s.jsonById, 'inMemory')).toBe('keep-json');
+        expect(getPayload(s.eip712ById, 'inMemory')).toBe('keep-eip');
+      }
+    );
+
+    // `Object.keys`, not a bare lookup: an inherited name would answer the
+    // latter.
+    it('returns dicts owning nothing when cipher and memory are both empty', () => {
+      const s = reducer(
+        initialState,
+        vaultLoaded({ ...payload, jsonById: {}, eip712ById: {} })
+      );
+
+      expect(Object.keys(s.jsonById)).toEqual([]);
+      expect(Object.keys(s.eip712ById)).toEqual([]);
     });
   });
 

--- a/src/background/redux/vault/reducer.test.ts
+++ b/src/background/redux/vault/reducer.test.ts
@@ -178,6 +178,24 @@ describe('vault reducer', () => {
       }
     );
 
+    // A cipher written before the field entered `VaultState` decrypts without
+    // it — `decryptVault` is a bare cast and there is no migration — and a
+    // throw here escapes into `unlockVaultSaga`'s catch, so the vault never
+    // unlocks again.
+    it.each(['jsonById', 'eip712ById'] as const)(
+      'loads a cipher written before %s existed as an empty dict instead of throwing',
+      field => {
+        const legacy: VaultState = { ...payload };
+        delete (legacy as Partial<VaultState>)[field];
+        const other = field === 'jsonById' ? 'eip712ById' : 'jsonById';
+
+        const s = reducer(initialState, vaultLoaded(legacy));
+
+        expect(s[field]).toEqual({});
+        expect(s[other]).toEqual(payload[other]);
+      }
+    );
+
     // `Object.keys`, not a bare lookup: an inherited name would answer the
     // latter.
     it('returns dicts owning nothing when cipher and memory are both empty', () => {

--- a/src/background/redux/vault/reducer.ts
+++ b/src/background/redux/vault/reducer.ts
@@ -25,9 +25,10 @@ type State = VaultState;
  * nothing; the debounced re-encrypt early-returns because the vault is locked;
  * and `vaultLoaded` restores the entry on the next unlock. No service-worker
  * death is involved — it reproduces on Firefox and Safari too, where the
- * background page is persistent. Nothing else deletes a key, so a leaked payload
- * lives in `storage.local` for good — while riding along in every popup-state
- * broadcast, since `selectPopupState` sends `vault` whole.
+ * background page is persistent. Nothing else in this reducer deletes a key, so
+ * a leaked payload sits in `storage.local` — riding along in every popup-state
+ * broadcast, since `selectPopupState` sends `vault` whole — until
+ * `reconcileStalePayloadsSaga` reclaims its slot on the next unlock.
  *
  * Ten is far above real concurrency (one approval window means 1-2 in-flight
  * requests) and far below anything that costs memory. See `storePayload` for
@@ -97,12 +98,13 @@ function storePayload(
   return { ...payloads, [requestId]: json };
 }
 
-// `storePayload`'s key guard, re-stated on the merge path: `vaultLoaded` is
-// forwarded into the store with no `isTrustedUiSender` gate. Not reachable from
-// a page today — `content/index.ts` admits only `SDK_REQUEST_TYPES`.
-function sanitizePayloadMap(payloads: PayloadMap): PayloadMap {
+// `storePayload`'s key guard on the merge path — `vaultLoaded` is forwarded
+// with no `isTrustedUiSender` gate. Widened past `VaultState` because a cipher
+// written before a map existed decrypts without it, and throwing here would
+// leave the vault permanently locked.
+function sanitizePayloadMap(payloads: PayloadMap | undefined): PayloadMap {
   return Object.fromEntries(
-    Object.entries(payloads).filter(([requestId]) =>
+    Object.entries(payloads ?? {}).filter(([requestId]) =>
       isStorableRequestId(requestId)
     )
   );

--- a/src/background/redux/vault/reducer.ts
+++ b/src/background/redux/vault/reducer.ts
@@ -28,7 +28,8 @@ type State = VaultState;
  * background page is persistent. Nothing else in this reducer deletes a key, so
  * a leaked payload sits in `storage.local` — riding along in every popup-state
  * broadcast, since `selectPopupState` sends `vault` whole — until
- * `reconcileStalePayloadsSaga` reclaims its slot on the next unlock.
+ * `reconcileStalePayloadsSaga` reclaims its slot, or `mergePayloadMaps` drops
+ * it as the oldest entry over the ceiling.
  *
  * Ten is far above real concurrency (one approval window means 1-2 in-flight
  * requests) and far below anything that costs memory. See `storePayload` for
@@ -78,7 +79,8 @@ type PayloadMap = State['jsonById'];
 // the deletion. Either way `vaultLoaded` restores the entry on unlock, so enough
 // of them fill the map and refuse every later payload.
 //
-// Reclaimed by `reconcileStalePayloadsSaga` (sagas/vault-sagas.ts).
+// Reclaimed by `reconcileStalePayloadsSaga` (sagas/vault-sagas.ts), and by
+// `mergePayloadMaps` when the merge on unlock is over the ceiling.
 function storePayload(
   payloads: PayloadMap,
   requestId: string,
@@ -110,6 +112,33 @@ function sanitizePayloadMap(payloads: PayloadMap | undefined): PayloadMap {
   );
 }
 
+// The one writer to these maps `storePayload` does not cover: the union of two
+// capped maps is twice the cap, so it bounds itself instead of waiting for
+// `reconcileStalePayloadsSaga`, which returns without reclaiming on an empty
+// entry read, on a failed `windows.getAll` and in its catch, with no retry.
+//
+// In-memory entries win and all survive: each arrived in THIS worker session
+// (`signRequest` has no lock gate, so one lands while locked too), so none can
+// be a payload stranded before the last restart. The cipher fills the rest
+// NEWEST first — the reverse of `storePayload`, because age means the opposite
+// across a lock: not the request waited on longest, but the entry that survived
+// the most unlocks unanswered. A live pre-lock request is the newest of them.
+function mergePayloadMaps(
+  cipher: PayloadMap | undefined,
+  inMemory: PayloadMap
+): PayloadMap {
+  const entries = [
+    ...Object.entries(sanitizePayloadMap(cipher)).filter(
+      ([requestId]) => getPayload(inMemory, requestId) == null
+    ),
+    ...Object.entries(inMemory)
+  ];
+
+  return Object.fromEntries(
+    entries.slice(Math.max(entries.length - MAX_STORED_PAYLOADS, 0))
+  );
+}
+
 const initialState: State = {
   secretPhrase: null,
   accounts: [],
@@ -125,11 +154,6 @@ const slice = createSlice({
   initialState,
   reducers: {
     vaultReseted: () => initialState,
-    // The maps merge, in-memory winning: `updateVaultCipher` early-returns while
-    // locked, so a payload written then exists only in memory. Not via
-    // `storePayload` — it refuses at `MAX_STORED_PAYLOADS` and would drop them.
-    // The union may sit over the ceiling until `reconcileStalePayloadsSaga`
-    // runs, and a signature request arriving in that window is refused.
     vaultLoaded: (
       state,
       {
@@ -149,8 +173,8 @@ const slice = createSlice({
       accounts,
       activeAccountName,
       secretPhrase,
-      jsonById: { ...sanitizePayloadMap(jsonById), ...state.jsonById },
-      eip712ById: { ...sanitizePayloadMap(eip712ById), ...state.eip712ById }
+      jsonById: mergePayloadMaps(jsonById, state.jsonById),
+      eip712ById: mergePayloadMaps(eip712ById, state.eip712ById)
     }),
     secretPhraseCreated: (
       state,

--- a/src/background/redux/vault/reducer.ts
+++ b/src/background/redux/vault/reducer.ts
@@ -38,6 +38,7 @@ type State = VaultState;
 export const MAX_STORED_PAYLOADS = 10;
 
 type PayloadMap = State['jsonById'];
+type PayloadSeqMap = State['payloadSeqById'];
 
 // `__proto__` is refused outright, for the reason `isStorableRequestId` was
 // written: the map is built by assignment, and assigning `__proto__` runs the
@@ -100,6 +101,77 @@ function storePayload(
   return { ...payloads, [requestId]: json };
 }
 
+// The ordinal is stamped once per request. A rewrite of an id already stored is
+// the same request refreshed, and it is the request's age the merge ranks on —
+// re-stamping it would make a page able to promote its own entry by re-sending.
+// A refused write (`__proto__`, or the ceiling) gets none, so the sequence only
+// ever names ids a map actually holds and cannot leak a slot of its own.
+function stampPayloadSeq(
+  seqById: PayloadSeqMap,
+  requestId: string,
+  stored: boolean
+): PayloadSeqMap {
+  if (!stored || payloadSeqOf(seqById, requestId) != null) {
+    return seqById;
+  }
+
+  // Read without a type check, unlike `payloadSeqOf`: this map is never the
+  // cipher's. `vaultLoaded` renumbers whatever it decrypts, so everything that
+  // reaches here is an ordinal this reducer wrote. Guarding it anyway would add
+  // a branch nothing can enter.
+  const stamped = Object.values(seqById);
+
+  return {
+    ...seqById,
+    [requestId]: stamped.length === 0 ? 0 : Math.max(...stamped) + 1
+  };
+}
+
+// Own properties only, for the reason `getPayload` exists: `requestId` is
+// dapp-chosen, so a bare index answers `toString` with a function. The type
+// check is not decoration either — this map arrives from the cipher as an
+// unchecked cast.
+function payloadSeqOf(
+  seqById: PayloadSeqMap | undefined,
+  requestId: string
+): number | undefined {
+  const seq =
+    seqById != null && Object.prototype.hasOwnProperty.call(seqById, requestId)
+      ? seqById[requestId]
+      : undefined;
+
+  return typeof seq === 'number' ? seq : undefined;
+}
+
+// Oldest first, by stored ordinal rather than by enumeration order — see the
+// note on `payloadSeqById` for why the two are not the same thing.
+//
+// An id carrying no ordinal comes from a cipher written before the field
+// existed, so it predates everything stamped and sorts first. Those keep their
+// enumeration order among themselves, which is exactly the ranking this
+// replaced, so a legacy cipher merges the way it did before.
+function orderOldestFirst(
+  requestIds: string[],
+  seqById: PayloadSeqMap | undefined
+): string[] {
+  const ranked: [string, number][] = [];
+  const unranked: string[] = [];
+
+  for (const requestId of requestIds) {
+    const seq = payloadSeqOf(seqById, requestId);
+
+    if (seq == null) {
+      unranked.push(requestId);
+    } else {
+      ranked.push([requestId, seq]);
+    }
+  }
+
+  ranked.sort(([, a], [, b]) => a - b);
+
+  return [...unranked, ...ranked.map(([requestId]) => requestId)];
+}
+
 // `storePayload`'s key guard on the merge path — `vaultLoaded` is forwarded
 // with no `isTrustedUiSender` gate. Widened past `VaultState` because a cipher
 // written before a map existed decrypts without it, and throwing here would
@@ -123,19 +195,74 @@ function sanitizePayloadMap(payloads: PayloadMap | undefined): PayloadMap {
 // NEWEST first — the reverse of `storePayload`, because age means the opposite
 // across a lock: not the request waited on longest, but the entry that survived
 // the most unlocks unanswered. A live pre-lock request is the newest of them.
+//
+// "Newest" is read off `payloadSeqById`, never off the map's own key order: an
+// object hoists integer-like keys ahead of every string key, and `requestId` is
+// dapp-chosen, so ranking on enumeration order evicted a live request keyed
+// `"42"` ahead of ten leaked UUID-keyed ones — the exact inversion of the rule
+// this comment states.
 function mergePayloadMaps(
   cipher: PayloadMap | undefined,
+  cipherSeq: PayloadSeqMap | undefined,
   inMemory: PayloadMap
 ): PayloadMap {
-  const entries = [
-    ...Object.entries(sanitizePayloadMap(cipher)).filter(
-      ([requestId]) => getPayload(inMemory, requestId) == null
+  const carried = sanitizePayloadMap(cipher);
+  const carriedIds = orderOldestFirst(
+    Object.keys(carried).filter(
+      requestId => getPayload(inMemory, requestId) == null
     ),
+    cipherSeq
+  );
+
+  // Never taken out of the in-memory side: an id held by both spends one slot,
+  // so `carriedIds` is already what the cipher is asking to add.
+  const room = Math.max(MAX_STORED_PAYLOADS - Object.keys(inMemory).length, 0);
+
+  return Object.fromEntries([
+    ...carriedIds
+      .slice(Math.max(carriedIds.length - room, 0))
+      .map((requestId): [string, string] => [requestId, carried[requestId]]),
     ...Object.entries(inMemory)
-  ];
+  ]);
+}
+
+// The merged map holds ordinals minted by two different counters — the
+// cipher's, from before the lock, and this session's, which restarted at 0 when
+// `vaultReseted` cleared the maps. Left side by side they would rank a pre-lock
+// entry above everything written since, and the error would compound at every
+// later lock. Renumbered into one sequence instead: carried entries keep their
+// relative age and all sit below the in-memory ones, which are newer by
+// construction — each arrived in THIS worker session.
+//
+// Built from the merged maps, so an evicted payload takes its ordinal with it
+// and this map cannot outgrow the slots it describes.
+function renumberPayloadSeq(
+  merged: Pick<State, 'jsonById' | 'eip712ById'>,
+  cipherSeq: PayloadSeqMap | undefined,
+  inMemory: Pick<State, 'jsonById' | 'eip712ById' | 'payloadSeqById'>
+): PayloadSeqMap {
+  const fromCipher: string[] = [];
+  const fromMemory: string[] = [];
+
+  for (const requestId of new Set([
+    ...Object.keys(merged.jsonById),
+    ...Object.keys(merged.eip712ById)
+  ])) {
+    if (
+      getPayload(inMemory.jsonById, requestId) == null &&
+      getPayload(inMemory.eip712ById, requestId) == null
+    ) {
+      fromCipher.push(requestId);
+    } else {
+      fromMemory.push(requestId);
+    }
+  }
 
   return Object.fromEntries(
-    entries.slice(Math.max(entries.length - MAX_STORED_PAYLOADS, 0))
+    [
+      ...orderOldestFirst(fromCipher, cipherSeq),
+      ...orderOldestFirst(fromMemory, inMemory.payloadSeqById)
+    ].map((requestId, index): [string, number] => [requestId, index])
   );
 }
 
@@ -146,7 +273,8 @@ const initialState: State = {
   siteNameByOriginDict: {},
   activeAccountName: null,
   jsonById: {},
-  eip712ById: {}
+  eip712ById: {},
+  payloadSeqById: {}
 };
 
 const slice = createSlice({
@@ -164,18 +292,30 @@ const slice = createSlice({
           activeAccountName,
           secretPhrase,
           jsonById,
-          eip712ById
+          eip712ById,
+          payloadSeqById
         }
       }: PayloadAction<VaultState>
-    ) => ({
-      accountNamesByOriginDict,
-      siteNameByOriginDict,
-      accounts,
-      activeAccountName,
-      secretPhrase,
-      jsonById: mergePayloadMaps(jsonById, state.jsonById),
-      eip712ById: mergePayloadMaps(eip712ById, state.eip712ById)
-    }),
+    ) => {
+      const merged = {
+        jsonById: mergePayloadMaps(jsonById, payloadSeqById, state.jsonById),
+        eip712ById: mergePayloadMaps(
+          eip712ById,
+          payloadSeqById,
+          state.eip712ById
+        )
+      };
+
+      return {
+        accountNamesByOriginDict,
+        siteNameByOriginDict,
+        accounts,
+        activeAccountName,
+        secretPhrase,
+        ...merged,
+        payloadSeqById: renumberPayloadSeq(merged, payloadSeqById, state)
+      };
+    },
     secretPhraseCreated: (
       state,
       action: PayloadAction<SecretPhrase>
@@ -412,17 +552,41 @@ const slice = createSlice({
     deployPayloadReceived: (
       state,
       { payload }: PayloadAction<{ id: string; json: string }>
-    ): State => ({
-      ...state,
-      jsonById: storePayload(state.jsonById, payload.id, payload.json)
-    }),
+    ): State => {
+      const jsonById = storePayload(state.jsonById, payload.id, payload.json);
+
+      return {
+        ...state,
+        jsonById,
+        // Identity is how a refusal is told from a write: `storePayload`
+        // returns the map it was given when it declines one.
+        payloadSeqById: stampPayloadSeq(
+          state.payloadSeqById,
+          payload.id,
+          jsonById !== state.jsonById
+        )
+      };
+    },
     eip712PayloadReceived: (
       state,
       { payload }: PayloadAction<{ id: string; json: string }>
-    ): State => ({
-      ...state,
-      eip712ById: storePayload(state.eip712ById, payload.id, payload.json)
-    }),
+    ): State => {
+      const eip712ById = storePayload(
+        state.eip712ById,
+        payload.id,
+        payload.json
+      );
+
+      return {
+        ...state,
+        eip712ById,
+        payloadSeqById: stampPayloadSeq(
+          state.payloadSeqById,
+          payload.id,
+          eip712ById !== state.eip712ById
+        )
+      };
+    },
     hideAccountFromListChanged: (
       state,
       { payload: { accountName } }: PayloadAction<{ accountName: string }>
@@ -487,11 +651,16 @@ const slice = createSlice({
 
         const jsonById = { ...state.jsonById };
         const eip712ById = { ...state.eip712ById };
+        // Dropped with the payload it dates. An ordinal outliving its entry
+        // would be a leaked slot of the same kind this reducer exists to
+        // reclaim, only in a map nothing enumerates.
+        const payloadSeqById = { ...state.payloadSeqById };
 
         delete jsonById[requestId];
         delete eip712ById[requestId];
+        delete payloadSeqById[requestId];
 
-        return { ...state, jsonById, eip712ById };
+        return { ...state, jsonById, eip712ById, payloadSeqById };
       }
     );
   }

--- a/src/background/redux/vault/reducer.ts
+++ b/src/background/redux/vault/reducer.ts
@@ -37,6 +37,24 @@ type State = VaultState;
  */
 export const MAX_STORED_PAYLOADS = 10;
 
+/**
+ * Slots `mergePayloadMaps` holds back for the cipher side, whatever the
+ * in-memory map is holding.
+ *
+ * Without it the cipher's share is whatever the in-memory map leaves over, and
+ * that reaches zero on demand: `handleSdkMethod` has no lock gate on either
+ * sign branch, so a page that fires `MAX_STORED_PAYLOADS` requests at a locked
+ * wallet fills the map by itself and the whole cipher side is discarded on the
+ * next unlock — including the request the user was already mid-approval on
+ * when the lock hit, which is the one entry `storePayload` names as the one
+ * that must never be lost.
+ *
+ * Two, because that is the concurrency `MAX_STORED_PAYLOADS` documents for a
+ * single approval window: the deploy itself, plus the Ledger permission window
+ * that can accompany it.
+ */
+const CIPHER_RESERVED_SLOTS = 2;
+
 type PayloadMap = State['jsonById'];
 type PayloadSeqMap = State['payloadSeqById'];
 
@@ -143,25 +161,48 @@ function payloadSeqOf(
   return typeof seq === 'number' ? seq : undefined;
 }
 
+// An array index in the spec's sense: the keys an object enumerates FIRST, in
+// ascending numeric order, ahead of every string key. `requestId` is
+// dapp-chosen and only `__proto__` is refused, so `"42"` is an id the wallet
+// accepts and stores.
+function isHoistedKey(requestId: string): boolean {
+  const index = Number(requestId);
+
+  return (
+    Number.isInteger(index) &&
+    index >= 0 &&
+    index < 2 ** 32 - 1 &&
+    String(index) === requestId
+  );
+}
+
 // Oldest first, by stored ordinal rather than by enumeration order — see the
 // note on `payloadSeqById` for why the two are not the same thing.
 //
 // An id carrying no ordinal comes from a cipher written before the field
-// existed, so it predates everything stamped and sorts first. Those keep their
-// enumeration order among themselves, which is exactly the ranking this
-// replaced, so a legacy cipher merges the way it did before.
+// existed, so it predates everything stamped and sorts first. Among themselves
+// those keep their enumeration order, which is exactly the ranking this
+// replaced — with one exception, because that order lies about one class of
+// id. A hoisted key sits at the front of the map whenever it was written, so
+// its position carries no age at all, while an ordinary key's does. Its true
+// position is unrecoverable, so it is ranked NEWEST rather than oldest: the two
+// mistakes do not cost the same. Keeping a leak spends a slot
+// `reconcileStalePayloadsSaga` reclaims on this same unlock; evicting a live
+// request loses the payload the user is about to approve, which is the
+// WALLET-1418 symptom itself.
 function orderOldestFirst(
   requestIds: string[],
   seqById: PayloadSeqMap | undefined
 ): string[] {
   const ranked: [string, number][] = [];
   const unranked: string[] = [];
+  const unrankedHoisted: string[] = [];
 
   for (const requestId of requestIds) {
     const seq = payloadSeqOf(seqById, requestId);
 
     if (seq == null) {
-      unranked.push(requestId);
+      (isHoistedKey(requestId) ? unrankedHoisted : unranked).push(requestId);
     } else {
       ranked.push([requestId, seq]);
     }
@@ -169,7 +210,13 @@ function orderOldestFirst(
 
   ranked.sort(([, a], [, b]) => a - b);
 
-  return [...unranked, ...ranked.map(([requestId]) => requestId)];
+  // Still ahead of everything stamped: an unstamped entry predates the field,
+  // and the hoisting question only orders the unstamped set against itself.
+  return [
+    ...unranked,
+    ...unrankedHoisted,
+    ...ranked.map(([requestId]) => requestId)
+  ];
 }
 
 // `storePayload`'s key guard on the merge path — `vaultLoaded` is forwarded
@@ -204,25 +251,52 @@ function sanitizePayloadMap(payloads: PayloadMap | undefined): PayloadMap {
 function mergePayloadMaps(
   cipher: PayloadMap | undefined,
   cipherSeq: PayloadSeqMap | undefined,
-  inMemory: PayloadMap
+  inMemory: PayloadMap,
+  inMemorySeq: PayloadSeqMap | undefined
 ): PayloadMap {
   const carried = sanitizePayloadMap(cipher);
+
+  // Never taken out of the in-memory side: an id held by both spends one slot,
+  // so `carriedIds` is already what the cipher is asking to add.
   const carriedIds = orderOldestFirst(
     Object.keys(carried).filter(
       requestId => getPayload(inMemory, requestId) == null
     ),
     cipherSeq
   );
+  const liveIds = orderOldestFirst(Object.keys(inMemory), inMemorySeq);
 
-  // Never taken out of the in-memory side: an id held by both spends one slot,
-  // so `carriedIds` is already what the cipher is asking to add.
-  const room = Math.max(MAX_STORED_PAYLOADS - Object.keys(inMemory).length, 0);
+  // The room left over after the in-memory side — but never less than the
+  // reserve, so the cipher cannot be displaced wholesale.
+  const cipherSlots = Math.min(
+    carriedIds.length,
+    Math.max(MAX_STORED_PAYLOADS - liveIds.length, CIPHER_RESERVED_SLOTS)
+  );
+  const keptCarried = carriedIds.slice(carriedIds.length - cipherSlots);
+  const keptLive = liveIds.slice(
+    Math.max(liveIds.length - (MAX_STORED_PAYLOADS - cipherSlots), 0)
+  );
+
+  // Logged the way the sibling reclaim does (`reconcileStalePayloadsSaga`),
+  // ids and counts only and never payloads: this is the one eviction a user
+  // can reach on demand, and without a line here a vanished pending
+  // transaction looks the same as every other cause.
+  if (keptLive.length < liveIds.length) {
+    console.warn('mergePayloadMaps: evicted locked-session payloads', {
+      evicted: liveIds.slice(0, liveIds.length - keptLive.length),
+      keptCount: keptCarried.length + keptLive.length
+    });
+  }
 
   return Object.fromEntries([
-    ...carriedIds
-      .slice(Math.max(carriedIds.length - room, 0))
-      .map((requestId): [string, string] => [requestId, carried[requestId]]),
-    ...Object.entries(inMemory)
+    ...keptCarried.map((requestId): [string, string] => [
+      requestId,
+      carried[requestId]
+    ]),
+    ...keptLive.map((requestId): [string, string] => [
+      requestId,
+      inMemory[requestId]
+    ])
   ]);
 }
 
@@ -298,11 +372,17 @@ const slice = createSlice({
       }: PayloadAction<VaultState>
     ) => {
       const merged = {
-        jsonById: mergePayloadMaps(jsonById, payloadSeqById, state.jsonById),
+        jsonById: mergePayloadMaps(
+          jsonById,
+          payloadSeqById,
+          state.jsonById,
+          state.payloadSeqById
+        ),
         eip712ById: mergePayloadMaps(
           eip712ById,
           payloadSeqById,
-          state.eip712ById
+          state.eip712ById,
+          state.payloadSeqById
         )
       };
 

--- a/src/background/redux/vault/reducer.ts
+++ b/src/background/redux/vault/reducer.ts
@@ -73,7 +73,12 @@ type PayloadSeqMap = State['payloadSeqById'];
 // boundary for every approval type — but the two guards answer to different
 // owners, and this map is the one at risk.
 //
-// At capacity the INCOMING write is refused; nothing already stored is evicted.
+// At capacity the INCOMING write is refused; nothing already stored is evicted
+// HERE. That is a property of this function, not of the map: `mergePayloadMaps`
+// does evict stored entries, from both sides, and it is the only path that
+// does. See the note there — the trade runs the opposite way across a lock,
+// because "oldest" ranges over a different population once entries have
+// outlived their request lifecycle.
 //
 // The obvious alternative — make room by dropping the oldest entry — puts the
 // loss on the request that has waited longest, which is exactly the one this
@@ -277,13 +282,25 @@ function mergePayloadMaps(
     Math.max(liveIds.length - (MAX_STORED_PAYLOADS - cipherSlots), 0)
   );
 
-  // Logged the way the sibling reclaim does (`reconcileStalePayloadsSaga`),
-  // ids and counts only and never payloads: this is the one eviction a user
-  // can reach on demand, and without a line here a vanished pending
-  // transaction looks the same as every other cause.
+  // Both sides log, the way the sibling reclaim does
+  // (`reconcileStalePayloadsSaga`): ids and counts only, never payloads.
+  // Separate lines because the two losses are not the same event. A dropped
+  // locked-session write is the eviction a page can reach on demand; a dropped
+  // carried entry is usually a leak this merge is here to reclaim, but it is
+  // NOT always one — the reserve is a count, not a liveness test, so a live
+  // pre-lock request outside the newest `CIPHER_RESERVED_SLOTS` goes the same
+  // way. Without a line for each, a vanished pending transaction looks the
+  // same as every other cause, and the two are diagnosed differently.
   if (keptLive.length < liveIds.length) {
     console.warn('mergePayloadMaps: evicted locked-session payloads', {
       evicted: liveIds.slice(0, liveIds.length - keptLive.length),
+      keptCount: keptCarried.length + keptLive.length
+    });
+  }
+
+  if (keptCarried.length < carriedIds.length) {
+    console.warn('mergePayloadMaps: evicted carried payloads', {
+      evicted: carriedIds.slice(0, carriedIds.length - keptCarried.length),
       keptCount: keptCarried.length + keptLive.length
     });
   }

--- a/src/background/redux/vault/reducer.ts
+++ b/src/background/redux/vault/reducer.ts
@@ -17,14 +17,17 @@ type State = VaultState;
  * Ceiling on `jsonById` / `eip712ById`.
  *
  * Both maps are cleared per request by the `windowRequestResponded` case in
- * `extraReducers` below — but a deletion can be MISSED. An MV3 service-worker
- * restart wipes `windowManagement.requests` (in-memory only) while these maps
- * come back from the encrypted cipher through `vaultLoaded`, so the response
- * for a pre-restart id can never arrive. Nothing else deletes a key:
- * `deploysReseted` is a full-slice reset dispatched on lock, and `lockVaultSaga`
- * flushes `updateVaultCipher` BEFORE it, so a leaked payload is re-loaded on the
- * next unlock and lives in `storage.local` for good — while riding along in
- * every popup-state broadcast, since `selectPopupState` sends `vault` whole.
+ * `extraReducers` below — but a deletion can be MISSED, and a clean auto-lock
+ * with an approval window open is enough on its own. `lockVaultSaga` runs
+ * `updateVaultCipher()` BEFORE `vaultReseted()`/`deploysReseted()`, so the
+ * unanswered payload is persisted into the cipher; the `windowRequestResponded`
+ * that arrives afterwards finds an already-emptied in-memory map and deletes
+ * nothing; the debounced re-encrypt early-returns because the vault is locked;
+ * and `vaultLoaded` restores the entry on the next unlock. No service-worker
+ * death is involved — it reproduces on Firefox and Safari too, where the
+ * background page is persistent. Nothing else deletes a key, so a leaked payload
+ * lives in `storage.local` for good — while riding along in every popup-state
+ * broadcast, since `selectPopupState` sends `vault` whole.
  *
  * Ten is far above real concurrency (one approval window means 1-2 in-flight
  * requests) and far below anything that costs memory. See `storePayload` for
@@ -63,22 +66,18 @@ type PayloadMap = State['jsonById'];
 // A rewrite of an id already present is always applied — it cannot grow the map.
 //
 // Residual, accepted: a payload leaks whenever its deletion never reaches the
-// cipher. Two routes, not one — the request is never answered at all (auto-lock
-// while an approval window is open, then the MV3 worker dies with no
-// `windows.onRemoved` handler alive to cancel it), or it IS answered and the
-// worker dies inside the 500ms re-encrypt debounce that would have persisted
-// the deletion. Either way the entry outlives lock/unlock, because
-// `lockVaultSaga` flushes the cipher before `deploysReseted` and `vaultLoaded`
-// restores from it, so enough of them fill the map and refuse every later
-// payload.
+// cipher. Two routes, not one — the request is never answered at all, which a
+// clean auto-lock with an approval window open causes on its own (`lockVaultSaga`
+// runs `updateVaultCipher()` BEFORE `vaultReseted()`/`deploysReseted()`, so the
+// entry is persisted; the later `windowRequestResponded` finds an already-emptied
+// in-memory map and deletes nothing; the debounced re-encrypt early-returns while
+// the vault is locked — no worker death anywhere, and it reproduces on Firefox
+// and Safari too, where the background page is persistent), or it IS answered and
+// the worker dies inside the 500ms re-encrypt debounce that would have persisted
+// the deletion. Either way `vaultLoaded` restores the entry on unlock, so enough
+// of them fill the map and refuse every later payload.
 //
-// That state has an exit, and it is worth writing down because nothing in the
-// UI points at it: `vaultLoaded` keeps the IN-MEMORY map whenever it is
-// non-empty and discards the cipher's. `signRequest` has no lock gate, so one
-// request arriving while the vault is locked writes the only entry there is —
-// lock, let a dapp send one request, unlock, and the accumulated entries are
-// gone. Reclaiming the slots without that sequence means reconciling the map
-// against the windows actually open, which is a separate change.
+// Reclaimed by `reconcileStalePayloadsSaga` (sagas/vault-sagas.ts).
 function storePayload(
   payloads: PayloadMap,
   requestId: string,
@@ -98,6 +97,17 @@ function storePayload(
   return { ...payloads, [requestId]: json };
 }
 
+// `storePayload`'s key guard, re-stated on the merge path: `vaultLoaded` is
+// forwarded into the store with no `isTrustedUiSender` gate. Not reachable from
+// a page today — `content/index.ts` admits only `SDK_REQUEST_TYPES`.
+function sanitizePayloadMap(payloads: PayloadMap): PayloadMap {
+  return Object.fromEntries(
+    Object.entries(payloads).filter(([requestId]) =>
+      isStorableRequestId(requestId)
+    )
+  );
+}
+
 const initialState: State = {
   secretPhrase: null,
   accounts: [],
@@ -113,6 +123,11 @@ const slice = createSlice({
   initialState,
   reducers: {
     vaultReseted: () => initialState,
+    // The maps merge, in-memory winning: `updateVaultCipher` early-returns while
+    // locked, so a payload written then exists only in memory. Not via
+    // `storePayload` — it refuses at `MAX_STORED_PAYLOADS` and would drop them.
+    // The union may sit over the ceiling until `reconcileStalePayloadsSaga`
+    // runs, and a signature request arriving in that window is refused.
     vaultLoaded: (
       state,
       {
@@ -132,12 +147,8 @@ const slice = createSlice({
       accounts,
       activeAccountName,
       secretPhrase,
-      jsonById:
-        Object.keys(state.jsonById).length === 0 ? jsonById : state.jsonById,
-      eip712ById:
-        Object.keys(state.eip712ById).length === 0
-          ? eip712ById
-          : state.eip712ById
+      jsonById: { ...sanitizePayloadMap(jsonById), ...state.jsonById },
+      eip712ById: { ...sanitizePayloadMap(eip712ById), ...state.eip712ById }
     }),
     secretPhraseCreated: (
       state,

--- a/src/background/redux/vault/types.ts
+++ b/src/background/redux/vault/types.ts
@@ -11,4 +11,18 @@ export type VaultState = {
   activeAccountName: string | null;
   jsonById: Record<string, string>;
   eip712ById: Record<string, string>;
+  // Write order for the two maps above, as an ordinal per `requestId`. It is
+  // stored rather than read back off the maps because a plain object does not
+  // enumerate in insertion order: integer-like keys are hoisted ahead of every
+  // string key, in ascending numeric order, and `requestId` is dapp-chosen, so
+  // `"42"` is an id the wallet accepts. `JSON.parse` rebuilds the cipher the
+  // same way, so the hoisting survives the round trip too. One counter covers
+  // both maps — a request belongs to exactly one of them, and
+  // `windowRequestResponded` deletes from both by the same id.
+  //
+  // Declared required for the same reason the two maps above are, and widened
+  // at the one boundary where it can be absent: a cipher written before this
+  // field existed decrypts without it (`decryptVault` is a bare cast, there is
+  // no migration). See `mergePayloadMaps`.
+  payloadSeqById: Record<string, number>;
 };

--- a/src/content/sdk-method.ts
+++ b/src/content/sdk-method.ts
@@ -44,7 +44,8 @@ export const sdkMethod = {
     signingPublicKeyHex: string;
   }>('CasperWalletProvider:Sign'),
   signResponse: createSdkAction<
-    | { cancelled: true; message?: string }
+    // `errorCode`: see `SdkErrorCode` — refused without showing a window.
+    | { cancelled: true; message?: string; errorCode?: string }
     | { cancelled: false; signatureHex: string }
   >('CasperWalletProvider:Sign:Response'),
   signError: createSdkAction<Error>('CasperWalletProvider:Sign:Error'),

--- a/src/content/sdk-types.ts
+++ b/src/content/sdk-types.ts
@@ -44,12 +44,18 @@ interface EIP712HashArtifacts {
   structHash?: string;
 }
 
+/** Refusals the wallet generates itself, with no approval window ever shown. */
+export enum SdkErrorCode {
+  tooManyPendingRequests = 'TOO_MANY_PENDING_REQUESTS'
+}
+
 export interface SignTypedDataResult {
   cancelled: boolean;
   signature: string | null;
   digest: string | null;
   publicKey: string | null;
   error: string | null;
+  /** When set, `cancelled: true` is a wallet refusal, not a user rejection. */
   errorCode?: string;
   hashArtifacts?: EIP712HashArtifacts;
 }

--- a/src/content/sdk.test.ts
+++ b/src/content/sdk.test.ts
@@ -1,5 +1,9 @@
-import type { CasperWalletProvider as CasperWalletProviderFactory } from './sdk';
+import type {
+  CasperWalletProvider as CasperWalletProviderFactory,
+  SignatureResponse
+} from './sdk';
 import { SDK_HANDSHAKE_TYPE } from './sdk-channel';
+import { SdkErrorCode, SignTypedDataResult } from './sdk-types';
 
 // The project's jest config runs with `testEnvironment: 'node'` (no
 // `jest-environment-jsdom` dependency is installed), so `window`/`document`
@@ -240,5 +244,36 @@ describe('CasperWalletProvider pre-handshake queueing', () => {
     );
 
     expect(port.postMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Compile-level: a dapp must be able to branch on the marker WITHOUT a cast —
+// TS consumers are the audience most likely to handle the refusal properly, and
+// ts-jest type-checks this file, so dropping `errorCode` from either public
+// result type fails here rather than silently shipping a JS-only guarantee.
+describe('a wallet-generated refusal is readable from the public types', () => {
+  it('exposes `errorCode` on both signature result types after narrowing', () => {
+    const deployRefusal: SignatureResponse = {
+      cancelled: true,
+      message: 'Too many pending signature requests',
+      errorCode: SdkErrorCode.tooManyPendingRequests
+    };
+    const typedDataRefusal: SignTypedDataResult = {
+      cancelled: true,
+      signature: null,
+      digest: null,
+      publicKey: null,
+      error: 'Too many pending signature requests',
+      errorCode: SdkErrorCode.tooManyPendingRequests
+    };
+
+    const codes = deployRefusal.cancelled
+      ? [deployRefusal.errorCode, typedDataRefusal.errorCode]
+      : [];
+
+    expect(codes).toEqual([
+      SdkErrorCode.tooManyPendingRequests,
+      SdkErrorCode.tooManyPendingRequests
+    ]);
   });
 });

--- a/src/content/sdk.ts
+++ b/src/content/sdk.ts
@@ -36,6 +36,7 @@ export type SignatureResponse =
   | {
       cancelled: true; // if sign was cancelled
       message?: string;
+      errorCode?: string; // set → refused by the wallet, see `SdkErrorCode`
     }
   | {
       cancelled: false; // if sign was successfull
@@ -205,6 +206,7 @@ export const CasperWalletProvider = (options?: CasperWalletProviderOptions) => {
      * @param deployJson - stringified json of a deploy (use `DeployUtil.deployToJson` from `casper-js-sdk` and `JSON.stringify`)
      * @param signingPublicKeyHex - public key hash (in hex format)
      * @returns a payload response when user responded to transaction request, it will contain `signature` if approved, or `cancelled === true` flag when rejected.
+     * `cancelled: true` carrying an `errorCode` (`SdkErrorCode`) is a wallet-side refusal: no window was shown and the user rejected nothing.
      */
     sign: (
       deployJson: string,

--- a/src/fixtures/initial-state-for-popup-tests.ts
+++ b/src/fixtures/initial-state-for-popup-tests.ts
@@ -71,7 +71,8 @@ export const initialStateForPopupTests: RootState = {
     siteNameByOriginDict: {},
     activeAccountName: 'Account 1',
     jsonById: {},
-    eip712ById: {}
+    eip712ById: {},
+    payloadSeqById: {}
   },
   windowManagement: {
     windowId: null,


### PR DESCRIPTION
[WALLET-1418](https://make-software.atlassian.net/browse/WALLET-1418)

> Follow-up to [WALLET-1384](https://make-software.atlassian.net/browse/WALLET-1384) (#1439, merged). The ceiling this fixes was introduced there, and the defect was raised during that PR's review and deferred by agreement. Base is `develop`.

## The bug

`MAX_STORED_PAYLOADS = 10` refuses the **incoming** write at capacity and evicts nothing — deliberately, so a page cannot displace the request a user is confirming. The consequence is that **nothing reclaimed the slot of a request that was never answered**. The only path that removed an entry was `windowRequestResponded`; the only other clear is the full-slice `deploysReseted`.

After ten leaks on one profile — counted independently per map — every later dapp signature request is refused at the reducer, and the refusal is invisible to its caller: `sdk-methods` dispatched, never re-read state, and called `openWindow` unconditionally. A full approval window opened with `transactionJson === undefined`, the query stayed disabled, and the page rendered a loading skeleton indefinitely while the dapp was told nothing and hung to the SDK's own 30-minute timeout.

### A leak needs no service-worker death

The ticket, and the comments that shipped with #1439, frame the residual as an MV3-restart edge case. It is not — and the branch corrects those comments. Single live worker, **all three targets**:

1. Dapp signs → `jsonById = { r1: … }`.
2. Auto-lock → `lockVaultSaga` runs `updateVaultCipher()` **before** `vaultReseted()`/`deploysReseted()`. `r1` is in the cipher; the in-memory map is `{}`.
3. User closes the approval window → `windows.onRemoved` → `windowRequestResponded(r1)`.
4. The vault reducer finds no payload for `r1` — the map is already empty — and returns the same state object. Nothing is deleted.
5. The debounced `updateVaultCipher` early-returns: `encryptionKeyHash == null`, the vault is locked.
6. Unlock → `vaultLoaded` restores `r1` from the cipher. Permanent.

Firefox and Safari included: `keep-alive.ts` is gated on `isChromeBuild` and both MV2 manifests declare `"background": { "persistent": true }`, so a restart is not available there as an excuse either.

## The fix

Three changes, one per commit, meant to land together.

### 1 · `vaultLoaded` merges instead of replacing

It took the cipher's maps only when the in-memory map was empty and discarded them wholesale otherwise. One request arriving while the vault is locked — `signRequest` has no lock gate — was enough to destroy the payload of everything in flight when the lock fired. That is the WALLET-1384 data loss reached through a different door.

In-memory wins on conflict: `updateVaultCipher` early-returns while locked, so a payload written during a lock exists **only** in memory.

The cipher's keys are filtered through `isStorableRequestId`. `vaultLoaded` is in `FORWARDED_ACTION_TYPES` and its forwarding branch has no `isTrustedUiSender` gate, unlike `windowRequestWindowAttached` — and until now the cipher branch bypassed `storePayload`, so the dapp-controlled-key guard never ran on this path. Replace could only swap the map; merge can grow it.

The merge deliberately does **not** go through `storePayload`: at capacity it refuses the incoming write, so the merge would silently drop entries. The map can therefore sit above the ceiling between this reducer and the reclaim below; during that window a new request is refused, which is the pre-existing at-capacity behaviour and no worse.

### 2 · Reclaim slots no open window can read

On `vaultLoaded`, a saga reconciles both maps against the request ids that can still be read — the `requestId` query params of actually-open extension windows, **unioned with** `selectOpenRequests` — and drops the rest.

**Both halves are load-bearing.**

`windowManagement` is not persisted, so after a service-worker restart the descriptors are gone while the approval window is still on screen and still signable: `LockedRouter` matches `path='*'` **without navigating**, so the window keeps `?requestId=…&origin=…&tabId=…#/sign-deploy` across the lock, and on unlock the sign page re-reads `requestId` from `location.search` and re-derives the payload. Keying the purge on `requests` alone would delete the payload of the request the user is about to confirm — the P0 this design exists to avoid.

Conversely, on window reuse `create-open-window` resolves `tabs.update` when navigation _starts_, so a live window can still report the previous request's URL; there the descriptor is what saves it.

- **Fail closed.** If the enumeration rejects, nothing is purged. Purging on no evidence strands a live request, which is worse than the leak.
- **Reads happen after the round trip**, in one synchronous stretch. `unlockVaultSaga` emits `unlockedEvent` shortly after `vaultLoaded`, dapps retry pending signs on it, and `signRequest` has no lock gate — a keep-set computed before the enumeration is stale by the time it lands. This is pinned by a test, and the pin is mutation-verified: hoisting the reads above the `await` fails exactly that test.
- **No new action creator.** `windowRequestResponded` already deletes the payload keyed off the _action_, already no-ops in `windowManagement` for an id that is not `'open'` (so no tombstone, no `MAX_RESPONDED_TOMBSTONES` slot), and is already in the `updateVaultCipher` debounce list — which is how the reclaim reaches the cipher. A new action would have needed that entry added by hand plus a parity-test exclusion.
- **Only the extension's own pages may carry a `requestId`.** Without that filter a dapp that knows its own leaked ids could hold tabs open at `https://…/?requestId=<id>` and block the reclaim indefinitely, defeating the ticket.
- **No URL, `Window` or `Tab` reaches a log.** A `signMessage` approval URL embeds the user's plaintext message as a query param.
- The enumeration is skipped entirely when both maps are empty — the common unlock — so a no-op unlock does not pull every tab URL in the browser into the extension process.

### 3 · A refused write answers the dapp

`sdk-methods` re-reads the map after dispatching and returns the method-correct SDK response **before** `windowRequestOpened`/`openWindow`, so no descriptor and no window exist for a request that cannot render. With the reclaim in place this should be unreachable; the point is that the residual is visible rather than silent.

Read through `getPayload`, never a bare index: `requestId` is dapp-controlled and `'constructor'` clears both entry guards, so an inherited `Object.prototype` member would make the guard conclude the write succeeded. The presence test is `== null`, not truthiness — the deploy path stores a parsed object in a map declared `Record<string, string>`, and a payload of `0` is a legitimate stored value. **Both properties are pinned, and both pins are mutation-verified**: a bare index kills the two prototype-name tests, a truthiness check kills the two falsy-payload tests.

The eip712 branch answers with `signTypedDataResponse`, not `signResponse`. Response routing is by `requestId` alone, so a `Sign:Response` _would_ resolve the promise — with a value that violates `SignTypedDataResult`, whose `signature`, `digest`, `publicKey` and `error` are all required. `buildCancelResponse` settles the same fork the same way.

#### Why the refusal carries a reason where a user cancel does not

The deploy branch returns `{ cancelled: true, message: … }`, the same shape its immediate sibling (`isDeployAlreadySigningWithThisAccount`) already uses. `SignTypedDataResult` has no `message` field, so the eip712 branch puts the reason in `error`, its only free-text slot — the two branches mirror each other rather than diverging.

That does mean a `cancelled: true` now arrives with a non-null `error`, where every other producer pairs it with `error: null`. Deliberate: those others are user cancels, which have no reason to report, and a dapp benefits from telling "the user declined" apart from "the wallet refused and the user never saw it". `errorCode` was the machine-readable alternative, but it is declared in `SignTypedDataResult` and used nowhere in the codebase — no producer, no consumer — so putting the first value in it would invent a convention for a single call site.

### 4 · Survive a cipher written before a payload map existed

Found by review of the three commits above, and the reason they are not on their own.

`sanitizePayloadMap` called `Object.entries` on whatever the cipher held. `eip712ById` entered `VaultState` on 2026-06-17, so every vault created before v2.5.0 decrypts without it — `decryptVault` is a bare `JSON.parse(...) as VaultState` and nothing migrates. The throw lands inside the `vaultLoaded` put, re-enters `unlockVaultSaga` and is swallowed by its catch: `vaultUnlocked()` never runs, the wallet stays locked behind a TypeError banner, and every retry repeats it. Recovery would have meant resetting the vault.

The guard lives inside the helper rather than at the call sites: the cipher reaches this reducer as an unchecked cast, so the compiler can never demand it at a new call site, and both merge paths funnel through here. Applied to `jsonById` too — the same argument covers the next field added.

**This also repairs a latent break that predates the branch.** On `develop` today a legacy cipher leaves `eip712ById` as `undefined`, and both `getPayload` and `storePayload` throw on it. It now lands as `{}`.

The same commit carries two smaller review findings: the payload dispatch and `windowRequestOpened` must stay in one synchronous block — otherwise the reclaim can resume between them, see a payload with no descriptor and no window, and purge a request that is about to open one — now pinned by two tests that queue a microtask at the payload dispatch and assert it has not run by the descriptor; and `redactUrlQuery` had grown a second copy, so it is extracted into a module that imports nothing. It is the redaction that keeps a plaintext `signMessage` out of the logs, which is the last thing that should be allowed to drift.

## Tests

Every new test was confirmed red against the code it pins, and the load-bearing ones were additionally mutation-checked.

- `vaultLoaded`: an entry from each side survives the merge; in-memory wins on a shared id; `__proto__` from the cipher is dropped with both a string and an object value, asserted on what the reducer owns; the four other inherited names survive as own properties.
- Reclaim: a payload whose id appears in an open window's tab URL survives; one covered only by `selectOpenRequests` survives; one covered by neither is purged from both maps; a rejected enumeration purges nothing; a non-extension tab carrying the same `requestId` does **not** keep a payload alive; a tab with no url, an unparseable url and an empty `requestId` are each skipped without aborting; the keep-set is computed after the round trip; the deletion reaches the cipher.
- Acceptance test for the ticket: ten leaked entries, no open windows, no open requests → after `vaultLoaded` both maps are empty and a fresh `deployPayloadReceived` is accepted. Red before the reclaim, green after.
- SDK boundary: at capacity the response is returned and neither `windowRequestOpened` nor `openWindow` is reached, per map; plus the two invariant pins above.

## Verification

- `npm run ci-check` — green (format, lint, tsc, knip, 82 suites / 688 tests). `redux/vault/reducer.ts` stays at 100% across all four metrics; handlers and sagas both above their floors.
- `npm run dependency:circular` — 140 cycles, unchanged from the base.
- `npm run lint` — 167 warnings, 0 errors, unchanged from the base.

## Known gaps, stated rather than hidden

- The reclaim runs at `vaultLoaded`, i.e. at unlock. A request that is still legitimately `'open'` keeps its slot by design, so the terminal paths that never mark `'responded'` can still hold one within a single unlocked session — bounded and non-permanent, and a different bug. Follow-up ticket.
- Three browser behaviours are asserted from source, not from a build: whether Chrome really stops the worker while an approval window sits on the unlock screen; whether Safari populates `tab.url` for its own `safari-web-extension://` pages under `"tabs"` alone; and whether Firefox's `windows.getAll` omits only the URL _hash_ (`requestId` is a search param, so it should be unaffected). Every one of them fails safe: with no window evidence the design degrades to `selectOpenRequests`, which is exact on the two MV2 targets because their background page is persistent and the descriptors are never lost.


[WALLET-1418]: https://make-software.atlassian.net/browse/WALLET-1418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WALLET-1384]: https://make-software.atlassian.net/browse/WALLET-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ