### PR TITLE
fix(background): bind what the delivery layer swallows, redact what it stringifies

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -43,6 +43,9 @@ module.exports = {
     'src/background/redux/**/reducer.ts',
     'src/background/handlers/**/*.ts',
     'src/background/redux/sagas/**/*.ts',
+    // The rest of `src/content/` is out of scope, but this module carries the
+    // dapp-facing redaction and is pure, so it is held to the `global` 100 gate.
+    'src/content/unknown-message-errors.ts',
     '!**/*.d.ts',
     '!**/*.test.ts',
     // Types-only modules — no executable statements/branches to cover.

--- a/src/background/handlers/deliver-via-origin.ts
+++ b/src/background/handlers/deliver-via-origin.ts
@@ -6,7 +6,9 @@ import { SdkMethod } from '@content/sdk-method';
 // SUCCESSFULLY delivered to (0 when there is no recoverable origin, or when the
 // broadcast matched no active same-origin tab). Wrapping the emit isolates a
 // `tabs.query`-level rejection so the caller's error-surface dispatch still runs
-// and the handler never rejects back to the signature page.
+// and the handler never rejects back to the signature page. That rejection is
+// logged rather than discarded: it and "no active same-origin tab" both return
+// 0, and the caller picks its banner copy from that 0.
 export async function deliverViaOrigin(
   origin: string | null,
   action: SdkMethod
@@ -14,7 +16,14 @@ export async function deliverViaOrigin(
   if (!origin) return 0;
   try {
     return await emitSdkEventToActiveTabsWithOrigin(origin, action);
-  } catch {
+  } catch (error) {
+    // Identifiers only — `action` carries `signatureHex` / `encryptedMessage`
+    // (see the SECURITY note in `sdk-response-to-tab.ts`).
+    console.error(
+      'deliverViaOrigin: same-origin fallback failed',
+      { origin, type: action.type },
+      error
+    );
     return 0;
   }
 }

--- a/src/background/handlers/sdk-response-to-tab.test.ts
+++ b/src/background/handlers/sdk-response-to-tab.test.ts
@@ -9,6 +9,7 @@ import {
 import { emitSdkEventToActiveTabsWithOrigin } from '@background/utils';
 
 import { sdkMethod } from '@content/sdk-method';
+import { unknownSdkMessageError } from '@content/unknown-message-errors';
 
 import { handleSdkResponseToTab } from './sdk-response-to-tab';
 
@@ -120,6 +121,17 @@ function makeMessage(tabId: number = TAB_ID): SdkResponseToTabMessage {
     ),
     tabId
   };
+}
+
+// What a rejecting `tabs.sendMessage` actually hands back: `webextension-polyfill`
+// relays the content-script listener's `Error.message` verbatim into this
+// promise (`sendPromisedResult` → `__mozWebExtensionPolyfillReject__` →
+// `new Error(reply.message)`), and that text is the one part of the logs below
+// this file does not control. Built by the real constructor rather than pinned
+// as a literal, so reverting the content-script redaction fails the no-payload
+// assertions here too, not only the content-script's own test.
+function deliveryRejection(): Error {
+  return unknownSdkMessageError(makeMessage().action);
 }
 
 function makeCancelMessage(tabId: number = TAB_ID): SdkResponseToTabMessage {
@@ -410,7 +422,7 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
 
   it('valid tabId, delivery rejects, origin present, fallback delivers (1) → optimistic responded + "delivered" sagaError', async () => {
     const { store, dispatch } = makeStore(undefined);
-    sendMessageMock.mockRejectedValue(new Error('no listener / tab gone'));
+    sendMessageMock.mockRejectedValue(deliveryRejection());
     emitToOriginMock.mockResolvedValue(1);
 
     const result = await handleSdkResponseToTab(
@@ -428,12 +440,15 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
       {
         requestId: REQUEST_ID,
         tabId: TAB_ID,
-        type: expect.any(String),
+        type: sdkMethod.signResponse.type,
         delivered: 1
       },
       expect.any(Error)
     );
     expect(outerConsoleError).not.toHaveBeenCalled();
+    // SECURITY: the Error argument included — this is the branch that fires
+    // whenever another same-origin tab is open, i.e. the common outcome.
+    expect(loggedText(outerConsoleWarn)).not.toContain('deadbeef');
     expect(sendMessageMock).toHaveBeenCalledWith(TAB_ID, makeMessage().action);
 
     // Fallback broadcast to the same-origin active tab.
@@ -460,7 +475,7 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
 
   it('valid tabId, delivery rejects, origin present, fallback delivers ZERO → optimistic responded + "not delivered" sagaError', async () => {
     const { store, dispatch } = makeStore(undefined);
-    sendMessageMock.mockRejectedValue(new Error('no listener / tab gone'));
+    sendMessageMock.mockRejectedValue(deliveryRejection());
     emitToOriginMock.mockResolvedValue(0);
 
     const result = await handleSdkResponseToTab(
@@ -476,7 +491,7 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
       {
         requestId: REQUEST_ID,
         tabId: TAB_ID,
-        type: expect.any(String),
+        type: sdkMethod.signResponse.type,
         delivered: 0
       },
       expect.any(Error)
@@ -496,7 +511,7 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
 
   it('valid tabId, delivery rejects, sender has NO origin → "not delivered" sagaError but no fallback', async () => {
     const { store, dispatch } = makeStore(undefined);
-    sendMessageMock.mockRejectedValue(new Error('no listener / tab gone'));
+    sendMessageMock.mockRejectedValue(deliveryRejection());
 
     const result = await handleSdkResponseToTab(
       makeMessage(),
@@ -510,7 +525,7 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
       {
         requestId: REQUEST_ID,
         tabId: TAB_ID,
-        type: expect.any(String),
+        type: sdkMethod.signResponse.type,
         delivered: 0
       },
       expect.any(Error)
@@ -527,7 +542,7 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
 
   it('never puts the response payload in the delivery-failure log', async () => {
     const { store } = makeStore(undefined);
-    sendMessageMock.mockRejectedValue(new Error('no listener / tab gone'));
+    sendMessageMock.mockRejectedValue(deliveryRejection());
 
     await handleSdkResponseToTab(makeMessage(), UI_SENDER, store);
 
@@ -538,14 +553,14 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
     expect(outerConsoleError.mock.calls[0][1]).toEqual({
       requestId: REQUEST_ID,
       tabId: TAB_ID,
-      type: expect.any(String),
+      type: sdkMethod.signResponse.type,
       delivered: 0
     });
   });
 
   it('fallback emit THROWS (valid tab path) → handler still resolves, "not delivered" sagaError, does not reject', async () => {
     const { store, dispatch } = makeStore(undefined);
-    sendMessageMock.mockRejectedValue(new Error('no listener / tab gone'));
+    sendMessageMock.mockRejectedValue(deliveryRejection());
     emitToOriginMock.mockRejectedValue(new Error('tabs.query blew up'));
 
     const result = await handleSdkResponseToTab(
@@ -560,7 +575,7 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
     // open": both return 0, and the caller picks banner copy from that 0.
     expect(outerConsoleError).toHaveBeenCalledWith(
       'deliverViaOrigin: same-origin fallback failed',
-      { origin: DAPP_ORIGIN, type: expect.any(String) },
+      { origin: DAPP_ORIGIN, type: sdkMethod.signResponse.type },
       expect.any(Error)
     );
     expect(loggedText(outerConsoleError)).not.toContain('deadbeef');
@@ -585,7 +600,7 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
     expect(emitToOriginMock).toHaveBeenCalledTimes(1);
     expect(outerConsoleError).toHaveBeenCalledWith(
       'deliverViaOrigin: same-origin fallback failed',
-      { origin: DAPP_ORIGIN, type: expect.any(String) },
+      { origin: DAPP_ORIGIN, type: sdkMethod.signResponse.type },
       expect.any(Error)
     );
     expect(loggedText(outerConsoleError)).not.toContain('deadbeef');

--- a/src/background/handlers/sdk-response-to-tab.test.ts
+++ b/src/background/handlers/sdk-response-to-tab.test.ts
@@ -133,6 +133,17 @@ function makeCancelMessage(tabId: number = TAB_ID): SdkResponseToTabMessage {
   };
 }
 
+// Everything a spy actually wrote, as text. `JSON.stringify` alone cannot see an
+// Error's `message` (non-enumerable), and the third log argument IS an Error —
+// so stringifying the raw call list would vet nothing about the channel these
+// logs newly opened.
+function loggedText(spy: jest.SpyInstance) {
+  return spy.mock.calls
+    .flat()
+    .map(arg => (arg instanceof Error ? arg.message : JSON.stringify(arg)))
+    .join(' ');
+}
+
 // Find the single `sagaError` dispatch (source === 'sdk-response-to-tab').
 function findSagaError(dispatch: jest.Mock) {
   return dispatch.mock.calls.find(
@@ -144,6 +155,7 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
   // The delivery paths below log their cause. The nested `describe` installs its
   // own spies on top of this one and restores them first, so both coexist.
   let outerConsoleError: jest.SpyInstance;
+  let outerConsoleWarn: jest.SpyInstance;
 
   beforeEach(() => {
     sendMessageMock.mockReset();
@@ -154,10 +166,12 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
     outerConsoleError = jest
       .spyOn(console, 'error')
       .mockImplementation(() => {});
+    outerConsoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
     outerConsoleError.mockRestore();
+    outerConsoleWarn.mockRestore();
   });
 
   it('fresh request (no prior status) → delivers to the tab AND marks responded', async () => {
@@ -407,11 +421,19 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
 
     // Direct delivery was attempted (and rejected).
     expect(sendMessageMock).toHaveBeenCalledTimes(1);
-    expect(outerConsoleError).toHaveBeenCalledWith(
-      'sdk-response-to-tab: delivery to tab failed',
-      { requestId: REQUEST_ID, tabId: TAB_ID, type: expect.any(String) },
+    // Recovered elsewhere → warn, and the log says so. Before, this was byte
+    // identical to the case where the signature was destroyed.
+    expect(outerConsoleWarn).toHaveBeenCalledWith(
+      'sdk-response-to-tab: delivery to tab failed; recovered via same-origin fallback',
+      {
+        requestId: REQUEST_ID,
+        tabId: TAB_ID,
+        type: expect.any(String),
+        delivered: 1
+      },
       expect.any(Error)
     );
+    expect(outerConsoleError).not.toHaveBeenCalled();
     expect(sendMessageMock).toHaveBeenCalledWith(TAB_ID, makeMessage().action);
 
     // Fallback broadcast to the same-origin active tab.
@@ -450,8 +472,13 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
     expect(sendMessageMock).toHaveBeenCalledTimes(1);
     expect(emitToOriginMock).toHaveBeenCalledTimes(1);
     expect(outerConsoleError).toHaveBeenCalledWith(
-      'sdk-response-to-tab: delivery to tab failed',
-      { requestId: REQUEST_ID, tabId: TAB_ID, type: expect.any(String) },
+      'sdk-response-to-tab: delivery to tab failed; response not delivered',
+      {
+        requestId: REQUEST_ID,
+        tabId: TAB_ID,
+        type: expect.any(String),
+        delivered: 0
+      },
       expect.any(Error)
     );
 
@@ -479,8 +506,13 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
 
     expect(sendMessageMock).toHaveBeenCalledTimes(1);
     expect(outerConsoleError).toHaveBeenCalledWith(
-      'sdk-response-to-tab: delivery to tab failed',
-      { requestId: REQUEST_ID, tabId: TAB_ID, type: expect.any(String) },
+      'sdk-response-to-tab: delivery to tab failed; response not delivered',
+      {
+        requestId: REQUEST_ID,
+        tabId: TAB_ID,
+        type: expect.any(String),
+        delivered: 0
+      },
       expect.any(Error)
     );
     // No origin recoverable → no fallback broadcast.
@@ -499,14 +531,15 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
 
     await handleSdkResponseToTab(makeMessage(), UI_SENDER, store);
 
-    // This log is the newest place that could leak the signed payload.
-    expect(JSON.stringify(outerConsoleError.mock.calls)).not.toContain(
-      'deadbeef'
-    );
+    // This log is the newest place that could leak the signed payload, and the
+    // check has to see inside the Error argument too — that is the part whose
+    // text this code does not control.
+    expect(loggedText(outerConsoleError)).not.toContain('deadbeef');
     expect(outerConsoleError.mock.calls[0][1]).toEqual({
       requestId: REQUEST_ID,
       tabId: TAB_ID,
-      type: expect.any(String)
+      type: expect.any(String),
+      delivered: 0
     });
   });
 
@@ -530,9 +563,7 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
       { origin: DAPP_ORIGIN, type: expect.any(String) },
       expect.any(Error)
     );
-    expect(JSON.stringify(outerConsoleError.mock.calls)).not.toContain(
-      'deadbeef'
-    );
+    expect(loggedText(outerConsoleError)).not.toContain('deadbeef');
     const sagaError = findSagaError(dispatch);
     expect(sagaError).toBeDefined();
     expect(sagaError.payload.message).toContain(NOT_DELIVERED_MSG);
@@ -557,9 +588,7 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
       { origin: DAPP_ORIGIN, type: expect.any(String) },
       expect.any(Error)
     );
-    expect(JSON.stringify(outerConsoleError.mock.calls)).not.toContain(
-      'deadbeef'
-    );
+    expect(loggedText(outerConsoleError)).not.toContain('deadbeef');
     // Nothing delivered → NOT marked responded.
     expect(dispatch).not.toHaveBeenCalledWith(
       expect.objectContaining({ payload: { requestId: REQUEST_ID } })

--- a/src/background/handlers/sdk-response-to-tab.test.ts
+++ b/src/background/handlers/sdk-response-to-tab.test.ts
@@ -141,12 +141,23 @@ function findSagaError(dispatch: jest.Mock) {
 }
 
 describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
+  // The delivery paths below log their cause. The nested `describe` installs its
+  // own spies on top of this one and restores them first, so both coexist.
+  let outerConsoleError: jest.SpyInstance;
+
   beforeEach(() => {
     sendMessageMock.mockReset();
     sendMessageMock.mockResolvedValue(undefined);
     emitToOriginMock.mockReset();
     // Default: fallback delivers to one tab. Individual tests override with 0.
     emitToOriginMock.mockResolvedValue(1);
+    outerConsoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    outerConsoleError.mockRestore();
   });
 
   it('fresh request (no prior status) → delivers to the tab AND marks responded', async () => {
@@ -396,6 +407,11 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
 
     // Direct delivery was attempted (and rejected).
     expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(outerConsoleError).toHaveBeenCalledWith(
+      'sdk-response-to-tab: delivery to tab failed',
+      { requestId: REQUEST_ID, tabId: TAB_ID, type: expect.any(String) },
+      expect.any(Error)
+    );
     expect(sendMessageMock).toHaveBeenCalledWith(TAB_ID, makeMessage().action);
 
     // Fallback broadcast to the same-origin active tab.
@@ -433,6 +449,11 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
 
     expect(sendMessageMock).toHaveBeenCalledTimes(1);
     expect(emitToOriginMock).toHaveBeenCalledTimes(1);
+    expect(outerConsoleError).toHaveBeenCalledWith(
+      'sdk-response-to-tab: delivery to tab failed',
+      { requestId: REQUEST_ID, tabId: TAB_ID, type: expect.any(String) },
+      expect.any(Error)
+    );
 
     // The optimistic mark is load-bearing: still dispatched before the await.
     expect(dispatch).toHaveBeenCalledWith(
@@ -457,6 +478,11 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
     );
 
     expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    expect(outerConsoleError).toHaveBeenCalledWith(
+      'sdk-response-to-tab: delivery to tab failed',
+      { requestId: REQUEST_ID, tabId: TAB_ID, type: expect.any(String) },
+      expect.any(Error)
+    );
     // No origin recoverable → no fallback broadcast.
     expect(emitToOriginMock).not.toHaveBeenCalled();
 
@@ -465,6 +491,23 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
     expect(sagaError.payload.message).toContain(NOT_DELIVERED_MSG);
 
     expect(result.handled).toBe(true);
+  });
+
+  it('never puts the response payload in the delivery-failure log', async () => {
+    const { store } = makeStore(undefined);
+    sendMessageMock.mockRejectedValue(new Error('no listener / tab gone'));
+
+    await handleSdkResponseToTab(makeMessage(), UI_SENDER, store);
+
+    // This log is the newest place that could leak the signed payload.
+    expect(JSON.stringify(outerConsoleError.mock.calls)).not.toContain(
+      'deadbeef'
+    );
+    expect(outerConsoleError.mock.calls[0][1]).toEqual({
+      requestId: REQUEST_ID,
+      tabId: TAB_ID,
+      type: expect.any(String)
+    });
   });
 
   it('fallback emit THROWS (valid tab path) → handler still resolves, "not delivered" sagaError, does not reject', async () => {
@@ -480,6 +523,16 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
 
     // The emit rejection is swallowed → the error-surface dispatch still runs.
     expect(emitToOriginMock).toHaveBeenCalledTimes(1);
+    // ...but it is no longer indistinguishable from "no same-origin tab was
+    // open": both return 0, and the caller picks banner copy from that 0.
+    expect(outerConsoleError).toHaveBeenCalledWith(
+      'deliverViaOrigin: same-origin fallback failed',
+      { origin: DAPP_ORIGIN, type: expect.any(String) },
+      expect.any(Error)
+    );
+    expect(JSON.stringify(outerConsoleError.mock.calls)).not.toContain(
+      'deadbeef'
+    );
     const sagaError = findSagaError(dispatch);
     expect(sagaError).toBeDefined();
     expect(sagaError.payload.message).toContain(NOT_DELIVERED_MSG);
@@ -499,6 +552,14 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
     );
 
     expect(emitToOriginMock).toHaveBeenCalledTimes(1);
+    expect(outerConsoleError).toHaveBeenCalledWith(
+      'deliverViaOrigin: same-origin fallback failed',
+      { origin: DAPP_ORIGIN, type: expect.any(String) },
+      expect.any(Error)
+    );
+    expect(JSON.stringify(outerConsoleError.mock.calls)).not.toContain(
+      'deadbeef'
+    );
     // Nothing delivered → NOT marked responded.
     expect(dispatch).not.toHaveBeenCalledWith(
       expect.objectContaining({ payload: { requestId: REQUEST_ID } })

--- a/src/background/handlers/sdk-response-to-tab.ts
+++ b/src/background/handlers/sdk-response-to-tab.ts
@@ -193,20 +193,35 @@ export async function handleSdkResponseToTab(
   try {
     await tabs.sendMessage(tabId, action);
   } catch (error) {
-    // `Could not establish connection`, `Extension context invalidated`, a
-    // `DataCloneError` and a Safari-specific rejection all end up here and were
-    // otherwise indistinguishable. Identifiers only (see the SECURITY note
-    // above), and logged before the fallback so cause precedes consequence.
-    console.error(
-      'sdk-response-to-tab: delivery to tab failed',
-      { requestId, tabId, type: action?.type },
-      error
-    );
     // Tab gone / no listener → try the same-origin fallback (if we can recover
     // the origin) and surface the non-fatal error, choosing the message based
     // on whether the fallback actually delivered. The optimistic mark above
     // already deduped any retry (delivery failure is terminal by design).
     const delivered = await deliverViaOrigin(origin, action);
+
+    // Cause AND outcome, because both were indistinguishable before: `Could not
+    // establish connection`, a `DataCloneError` and a Safari-specific rejection
+    // collapsed into one line, and so did "recovered via another same-origin
+    // tab" and "the signature the user produced is gone". The outcome otherwise
+    // lives only in the dispatched banner, which no support reader gets.
+    // Severity splits on it, the way the duplicate classifier above splits
+    // benign from lost. Identifiers only (see the SECURITY note above).
+    const identifiers = { requestId, tabId, type: action?.type, delivered };
+
+    if (delivered > 0) {
+      console.warn(
+        'sdk-response-to-tab: delivery to tab failed; recovered via same-origin fallback',
+        identifiers,
+        error
+      );
+    } else {
+      console.error(
+        'sdk-response-to-tab: delivery to tab failed; response not delivered',
+        identifiers,
+        error
+      );
+    }
+
     store.dispatch(deliveryFailedError(tabId, delivered > 0));
   }
 

--- a/src/background/handlers/sdk-response-to-tab.ts
+++ b/src/background/handlers/sdk-response-to-tab.ts
@@ -192,7 +192,16 @@ export async function handleSdkResponseToTab(
 
   try {
     await tabs.sendMessage(tabId, action);
-  } catch {
+  } catch (error) {
+    // `Could not establish connection`, `Extension context invalidated`, a
+    // `DataCloneError` and a Safari-specific rejection all end up here and were
+    // otherwise indistinguishable. Identifiers only (see the SECURITY note
+    // above), and logged before the fallback so cause precedes consequence.
+    console.error(
+      'sdk-response-to-tab: delivery to tab failed',
+      { requestId, tabId, type: action?.type },
+      error
+    );
     // Tab gone / no listener → try the same-origin fallback (if we can recover
     // the origin) and surface the non-fatal error, choosing the message based
     // on whether the fallback actually delivered. The optimistic mark above

--- a/src/background/handlers/unknown-message-errors.test.ts
+++ b/src/background/handlers/unknown-message-errors.test.ts
@@ -1,0 +1,53 @@
+import { sdkMethod } from '@content/sdk-method';
+
+import {
+  unknownMessageError,
+  unknownReduxActionError,
+  unknownSdkMessageError
+} from './unknown-message-errors';
+
+// A payload marker that must never reach a message: these are handed to
+// `sendError`, which returns them across the boundary — to `dispatchToMainStore`
+// for the redux branch, into the dapp's own SDK for the sdk branch.
+const SECRET = 'deadbeef';
+
+const REQUEST_ID = 'req-1';
+
+describe('background unknown-message errors', () => {
+  it('names the sdk method and its requestId, and drops the payload', () => {
+    const action = sdkMethod.signResponse(
+      { signatureHex: SECRET, cancelled: false },
+      { requestId: REQUEST_ID }
+    );
+
+    const { message } = unknownSdkMessageError(action);
+
+    expect(message).toContain(sdkMethod.signResponse.type);
+    expect(message).toContain(REQUEST_ID);
+    expect(message).not.toContain(SECRET);
+  });
+
+  it('names the redux action type and drops the payload', () => {
+    const { message } = unknownReduxActionError({
+      type: 'vault/secretPhraseCreated',
+      payload: { secretPhrase: SECRET }
+    } as { type: string });
+
+    expect(message).toContain('vault/secretPhraseCreated');
+    expect(message).not.toContain(SECRET);
+  });
+
+  it('reports what `type` was, not the message', () => {
+    expect(
+      unknownMessageError({ type: 42, payload: SECRET } as never).message
+    ).toBe('Background: Unknown message: type is number');
+    expect(unknownMessageError({}).message).toBe(
+      'Background: Unknown message: type is undefined'
+    );
+    // A nullish message reaches this branch too — `runtime.onMessage` hands the
+    // listener whatever the sender posted.
+    expect(unknownMessageError(undefined).message).toBe(
+      'Background: Unknown message: type is undefined'
+    );
+  });
+});

--- a/src/background/handlers/unknown-message-errors.ts
+++ b/src/background/handlers/unknown-message-errors.ts
@@ -1,0 +1,34 @@
+import { SdkMethod } from '@content/sdk-method';
+
+// SECURITY: identifiers only — an SDK action's payload can carry signature
+// material, and these messages cross the boundary via `sendError`: to
+// `dispatchToMainStore` for the redux branch, into the dapp's own SDK for the
+// sdk branch. Constructed here rather than inline in `index.ts` so a test can
+// hold the redaction in place — that entry point is imported by no test and sits
+// outside `collectCoverageFrom`, the same reasoning that moved the
+// `windows.onRemoved` body into `window-removed.ts`.
+
+// `requestId` stays: it is the correlation key every other log at this layer
+// uses, and this error rejects the originating dapp's own promise, so the value
+// is already known to the receiver. `isSDKMethod` guarantees both fields are
+// strings.
+export function unknownSdkMessageError(action: SdkMethod): Error {
+  return Error(
+    `Background: Unknown sdk message: ${action.type} (requestId ${action.meta.requestId})`
+  );
+}
+
+// The signal for a missing entry in the forwarding allow-list.
+export function unknownReduxActionError(action: { type: string }): Error {
+  return Error(`Background: Unknown redux action: ${action.type}`);
+}
+
+// Every message reaching this branch lacks a string `type` by definition, so
+// `typeof action` would always say 'object'. Report what `type` actually was —
+// equally non-revealing, and it distinguishes a missing field from a non-string
+// one.
+export function unknownMessageError(
+  action: { type?: unknown } | undefined
+): Error {
+  return Error(`Background: Unknown message: type is ${typeof action?.type}`);
+}

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -220,9 +220,9 @@ runtime.onMessage.addListener(
           if (result.handled) {
             return respond(result);
           }
-          throw Error(
-            'Background: Unknown sdk message: ' + JSON.stringify(action)
-          );
+          // Type only: this message is returned to the dapp's SDK, and an SDK
+          // action's payload can carry signature material.
+          throw Error('Background: Unknown sdk message: ' + action.type);
         }
 
         // Must stay AFTER the isSDKMethod branch: a page-crafted message with
@@ -288,9 +288,7 @@ runtime.onMessage.addListener(
             return respond(legacyResult);
           }
 
-          throw Error(
-            'Background: Unknown redux action: ' + JSON.stringify(action)
-          );
+          throw Error('Background: Unknown redux action: ' + typedAction.type);
         }
 
         // this is added for not spamming with errors from bringweb3
@@ -298,7 +296,9 @@ runtime.onMessage.addListener(
           return;
         }
 
-        throw Error('Background: Unknown message: ' + JSON.stringify(action));
+        // No string `type` by definition on this branch, so `typeof` is all
+        // that can be reported without echoing the message back.
+        throw Error('Background: Unknown message: typeof ' + typeof action);
       } catch (error) {
         return sendError(error);
       }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -27,6 +27,11 @@ import {
 import { handleReduxAction } from '@background/handlers/redux-actions';
 import { handleSdkMethod } from '@background/handlers/sdk-methods';
 import { handleSdkResponseToTab } from '@background/handlers/sdk-response-to-tab';
+import {
+  unknownMessageError,
+  unknownReduxActionError,
+  unknownSdkMessageError
+} from '@background/handlers/unknown-message-errors';
 import { handleWindowRemoved } from '@background/handlers/window-removed';
 import { initKeepAlive } from '@background/keep-alive';
 import {
@@ -222,14 +227,7 @@ runtime.onMessage.addListener(
           if (result.handled) {
             return respond(result);
           }
-          // Identifiers only — an SDK action's payload can carry signature
-          // material. `requestId` stays: it is the correlation key every other
-          // log at this layer uses, and this error rejects the originating
-          // dapp's own promise, so the value is already known to the receiver.
-          // `isSDKMethod` guarantees both fields are strings.
-          throw Error(
-            `Background: Unknown sdk message: ${action.type} (requestId ${action.meta.requestId})`
-          );
+          throw unknownSdkMessageError(action);
         }
 
         // Must stay AFTER the isSDKMethod branch: a page-crafted message with
@@ -295,7 +293,7 @@ runtime.onMessage.addListener(
             return respond(legacyResult);
           }
 
-          throw Error('Background: Unknown redux action: ' + typedAction.type);
+          throw unknownReduxActionError(typedAction);
         }
 
         // this is added for not spamming with errors from bringweb3
@@ -303,13 +301,7 @@ runtime.onMessage.addListener(
           return;
         }
 
-        // Every message reaching this branch lacks a string `type` by
-        // definition, so `typeof action` would always say 'object'. Report what
-        // `type` actually was — equally non-revealing, and it distinguishes a
-        // missing field from a non-string one.
-        throw Error(
-          'Background: Unknown message: type is ' + typeof action?.type
-        );
+        throw unknownMessageError(action);
       } catch (error) {
         return sendError(error);
       }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -220,9 +220,14 @@ runtime.onMessage.addListener(
           if (result.handled) {
             return respond(result);
           }
-          // Type only: this message is returned to the dapp's SDK, and an SDK
-          // action's payload can carry signature material.
-          throw Error('Background: Unknown sdk message: ' + action.type);
+          // Identifiers only — an SDK action's payload can carry signature
+          // material. `requestId` stays: it is the correlation key every other
+          // log at this layer uses, and this error rejects the originating
+          // dapp's own promise, so the value is already known to the receiver.
+          // `isSDKMethod` guarantees both fields are strings.
+          throw Error(
+            `Background: Unknown sdk message: ${action.type} (requestId ${action.meta.requestId})`
+          );
         }
 
         // Must stay AFTER the isSDKMethod branch: a page-crafted message with
@@ -296,9 +301,13 @@ runtime.onMessage.addListener(
           return;
         }
 
-        // No string `type` by definition on this branch, so `typeof` is all
-        // that can be reported without echoing the message back.
-        throw Error('Background: Unknown message: typeof ' + typeof action);
+        // Every message reaching this branch lacks a string `type` by
+        // definition, so `typeof action` would always say 'object'. Report what
+        // `type` actually was — equally non-revealing, and it distinguishes a
+        // missing field from a non-string one.
+        throw Error(
+          'Background: Unknown message: type is ' + typeof action?.type
+        );
       } catch (error) {
         return sendError(error);
       }

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -6,6 +6,10 @@ import { SDK_HANDSHAKE_TYPE } from './sdk-channel';
 import { SdkEvent, sdkEvent } from './sdk-event';
 import { CasperWalletEventType } from './sdk-event-type';
 import { isSDKMethod, sdkMethod } from './sdk-method';
+import {
+  unknownSdkEventError,
+  unknownSdkMessageError
+} from './unknown-message-errors';
 
 // The private port handed to the page-world SDK during the handshake. Both the
 // direct `runtime.sendMessage` response and the delayed `runtime.onMessage`
@@ -70,13 +74,7 @@ async function handleSdkMessage(message: unknown) {
         return;
 
       default:
-        // Type only, for the same reason the no-port branch above logs type +
-        // requestId: this runs in the content script, whose console is the dapp
-        // page's console, and these envelopes carry signatureHex /
-        // encryptedMessage.
-        throw Error(
-          'Content: handleOnMessage unknown sdk message: ' + message.type
-        );
+        throw unknownSdkMessageError(message);
     }
   } else {
     emitSdkEvent(message as SdkEvent);
@@ -116,7 +114,7 @@ function emitSdkEvent(message: SdkEvent) {
       break;
 
     default:
-      throw Error('Content: emit sdk event unknown action: ' + message.type);
+      throw unknownSdkEventError(message);
   }
 
   const event = new CustomEvent(eventType, {

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -70,9 +70,12 @@ async function handleSdkMessage(message: unknown) {
         return;
 
       default:
+        // Type only, for the same reason the no-port branch above logs type +
+        // requestId: this runs in the content script, whose console is the dapp
+        // page's console, and these envelopes carry signatureHex /
+        // encryptedMessage.
         throw Error(
-          'Content: handleOnMessage unknown sdk message: ' +
-            JSON.stringify(message)
+          'Content: handleOnMessage unknown sdk message: ' + message.type
         );
     }
   } else {
@@ -113,9 +116,7 @@ function emitSdkEvent(message: SdkEvent) {
       break;
 
     default:
-      throw Error(
-        'Content: emit sdk event unknown action: ' + JSON.stringify(message)
-      );
+      throw Error('Content: emit sdk event unknown action: ' + message.type);
   }
 
   const event = new CustomEvent(eventType, {

--- a/src/content/unknown-message-errors.test.ts
+++ b/src/content/unknown-message-errors.test.ts
@@ -1,0 +1,37 @@
+import { SdkEvent } from './sdk-event';
+import { SdkMethod } from './sdk-method';
+import {
+  unknownSdkEventError,
+  unknownSdkMessageError
+} from './unknown-message-errors';
+
+// A payload marker that must never reach a message: the content script's console
+// and its thrown errors are visible to the dapp page.
+const SECRET = 'deadbeef';
+
+describe('content unknown-message errors', () => {
+  it('names the sdk message type and drops its payload', () => {
+    const message = {
+      type: 'CasperWalletProvider:Sign:Response',
+      payload: { signatureHex: SECRET, cancelled: false },
+      meta: { requestId: 'req-1' }
+    } as unknown as SdkMethod;
+
+    const { message: text } = unknownSdkMessageError(message);
+
+    expect(text).toContain('CasperWalletProvider:Sign:Response');
+    expect(text).not.toContain(SECRET);
+  });
+
+  it('names the sdk event type and drops its payload', () => {
+    const event = {
+      type: 'unlockedEvent',
+      payload: { activePublicKey: SECRET }
+    } as unknown as SdkEvent;
+
+    const { message: text } = unknownSdkEventError(event);
+
+    expect(text).toContain('unlockedEvent');
+    expect(text).not.toContain(SECRET);
+  });
+});

--- a/src/content/unknown-message-errors.ts
+++ b/src/content/unknown-message-errors.ts
@@ -1,0 +1,19 @@
+import { SdkEvent } from './sdk-event';
+import { SdkMethod } from './sdk-method';
+
+// SECURITY: type only, never the envelope — these carry signatureHex /
+// encryptedMessage, and a content script's console is the DAPP PAGE's console.
+// The constructions live here rather than inline in `index.ts` because that
+// module is imported by no test that reaches its `default` branches, so nothing
+// would hold the redaction in place. The background's delivery-failure log
+// re-uses `unknownSdkMessageError` as its rejection fixture: the polyfill relays
+// a listener's `Error.message` verbatim to the sender, so this text lands in a
+// background log too, and that test fails if the redaction here regresses.
+
+export function unknownSdkMessageError(message: SdkMethod): Error {
+  return Error(`Content: handleOnMessage unknown sdk message: ${message.type}`);
+}
+
+export function unknownSdkEventError(message: SdkEvent): Error {
+  return Error(`Content: emit sdk event unknown action: ${message.type}`);
+}


### PR DESCRIPTION
Closes [WALLET-1393](https://make-software.atlassian.net/browse/WALLET-1393).

No failure at the background delivery layer is invisible in the log any more, and no error path stringifies a whole action.

## 1. `deliverViaOrigin` binds its rejection

`deliver-via-origin.ts` returned a silent `0` for both "the `tabs.query` broadcast blew up" and "no active same-origin tab was open". PR #1427 added a consumer that picks the banner copy from that `0`, so the ambiguity became load-bearing. The rejection is now logged with `origin` + `action.type`; the return value is unchanged.

This fallback has three production consumers — `sdk-response-to-tab.ts` (×2) and `cancel-requests.ts` (×2) — so all four delivery paths gain the diagnostic.

## 2. The primary delivery catch binds too — and says what came of it

The `catch` around `tabs.sendMessage` dispatched a `sagaError` but never logged the cause, collapsing `Could not establish connection`, `Extension context invalidated`, `DataCloneError` and Safari-specific rejections into one indistinguishable outcome.

Binding the cause alone would have left a second ambiguity in place: a signature recovered through another same-origin tab logged identically to one that was destroyed, because the outcome lived only in the dispatched banner, which no support reader sees. The log therefore carries `delivered` alongside `requestId` / `tabId` / `type`, and splits severity on it — `warn` when the fallback recovered, `error` when the response was lost. That is the same warn/error split this file already applies to benign versus lost duplicate responses sixty lines above.

## 3. Error paths no longer serialize a whole action

Three sites in `background/index.ts` threw `Error('… ' + JSON.stringify(action))`. These messages are handed to `sendError(error)`, which returns them across the boundary — to `dispatchToMainStore` for the redux branch and into the dapp's SDK for the sdk branch — and an action payload can carry `signatureHex` / `encryptedMessage`. Not reachable today for a signature-bearing action per the parity test, so this is defense in depth.

Each site reports identifiers only. `meta.requestId` is deliberately kept on the SDK one: it is the correlation key every other log at this layer uses, it costs nothing in exposure (the error rejects the originating dapp's own promise, so the receiver already knows the value), and `isSDKMethod` guarantees it is a string. `Unknown redux action: <TYPE>` stays the signal for a missing entry in the forwarding allow-list and reads better than the stringified blob did.

## 4. The same sweep in the content-script relay

`handleSdkMessage` already applies this rule ten lines above the offender — its no-port branch logs `type` + `requestId` only, with a SECURITY comment noting these envelopes carry signatureHex / encryptedMessage — and then its `default` branch threw with the whole envelope stringified, as did `emitSdkEvent`'s.

This one matters more than the background half it mirrors: a content script's console is the *dapp page's* console, while the background's is the service worker's. Same reachability (the `default` fires when a new response type is added and not listed in the switch), so likewise defense in depth. `detail: JSON.stringify(message.payload)` is untouched — that is the page-event delivery mechanism, not an error path.

## Tests

Assertions added to the five existing cases that already drive these branches (`fallback emit THROWS` ×2, `delivery rejects` ×3), plus one new case pinning that the delivery-failure log carries identifiers and no signature material.

The payload guard needed care to be worth anything: `JSON.stringify` cannot see an Error's `message` (non-enumerable), so asserting on `JSON.stringify(mock.calls)` vetted nothing about the Error argument — the one part of the log whose text this code does not control. It now goes through a serializer that unwraps Errors, verified against two deliberate mutations: the action passed as an extra log argument, and the action embedded in `new Error(JSON.stringify(action))`. The naive version caught only the first.

`deliver-via-origin.ts` reaches 100% coverage — the new `catch` body was its only uncovered branch. Both `unknown-message-errors.ts` modules added in the review round are at 100%. `handlers/` sits at 96.9% statements / 90.3% branches against its 95/85 floor. Full `ci-check` green: 88 suites, 817 tests.

## Review round

Two comments, both about what holds this change in place rather than about the change itself. Addressed in 3988fc79.

**The five redacted throw sites had nothing testing them.** Nothing in `src/` imports `background/index.ts`, `src/content/` has no `index.test.ts` (`sdk-channel.test.ts`'s `require('./index')` only inspects the listeners `init()` registers), and neither file is inside `collectCoverageFrom` — so any of the five could go back to `JSON.stringify(action)` with a green `ci-check`. The constructions move into two modules, one per side, each taking the **whole envelope** and extracting `type` itself, so the redaction has a single tested seam instead of a convention every call site has to keep:

- `src/background/handlers/unknown-message-errors.ts` — in coverage scope already, via `handlers/**/*.ts`
- `src/content/unknown-message-errors.ts` — added to `collectCoverageFrom` as one explicit entry rather than widening to `src/content/**`, which would fail the `global` 100 gate; this module is pure and meets it

Same reasoning as `windows.onRemoved` → `window-removed.ts`: the body lives in a handler so it can be tested.

**The §2 guard fed itself a benign fixture.** It rejected with `new Error('no listener / tab gone')`, but `webextension-polyfill@0.12.0` serialises a rejecting listener's `Error.message` into `__mozWebExtensionPolyfillReject__` and rebuilds it as `new Error(reply.message)` on the sender side (`browser-polyfill.js:1105-1148`), and `handleSdkMessage` is `async` — so its throw takes exactly that path, and the §4 redaction is the only thing keeping payload text out of the §2 log. Nothing connected the two files. The fixture is now built by the real content-script constructor instead of a literal, which couples them:

```ts
function deliveryRejection(): Error {
  return unknownSdkMessageError(makeMessage().action);
}
```

**Two more gaps in the same assertions.** The warn branch — the one that fires whenever another same-origin tab is open, i.e. the common outcome — had no no-payload check at all; and `type` was matched as `expect.any(String)` at all six new sites, pinning nothing to `action.type`.

Each fix verified by mutation: reverting the content-script redaction fails 4 tests (3 of them in the background suite), leaking the action into the warn log fails 1, a literal `type` fails 6, reverting either background message fails 2.

## Deliberately not included

- `sdk-response-to-tab.ts:22-30` (`recoverDappOrigin`) keeps its unbound `catch`. It guards `new URL()` on an extension page URL that `isTrustedUiSender` has already validated, and its `null` return is not swallowed — it leads to the "no same-origin fallback available" `sagaError`, which is surfaced. The failure has a visible consequence, so binding it would add noise, not information.
- `open-onboarding-flow.ts:71` is a `storage.local` read on the onboarding path, not the delivery layer.
- The three `expect.any(String)` in the duplicate-classifier tests (`:245`, `:266`, `:316`) keep their loose matcher — same weakness, but they predate this PR and are not part of its diff.
- WALLET-1386 touches `sdk-response-to-tab.ts` as well but changes delivery *behaviour* (cross-checking `tabId` against the request descriptor) rather than logging. It lands separately, after this.


[WALLET-1393]: https://make-software.atlassian.net/browse/WALLET-1393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
