### PR TITLE
fix: a dropped dispatch or a failed window open is no longer a silent no-op

### DIFF
--- a/e2e-tests/error-surface.ts
+++ b/e2e-tests/error-surface.ts
@@ -16,15 +16,37 @@ export const WINDOW_FAILED = "Couldn't open the window. Please try again.";
 // Stopping the service worker would not reproduce it either: in MV3 an incoming
 // message is itself the event that cold-starts a stopped worker, and while the
 // vault is unlocked the keep-alive alarm wakes it within 30s anyway.
-export async function breakTransport(page: Page) {
-  await page.evaluate(() => {
-    (
+//
+// `onlyTypes` narrows the break to those action types and lets everything else
+// through. Some flows put non-redux sends on the same transport — the import
+// page's `checkAccountNameIsTaken` runs in submit-time validation and
+// `checkSecretKeyExist` inside the file reader, neither through
+// `dispatchToMainStore` — so breaking the whole transport stops the flow before
+// the dispatch under test is ever reached. Pass the type to aim at the seam.
+export async function breakTransport(page: Page, onlyTypes: string[] = []) {
+  await page.evaluate(types => {
+    const { runtime } = (
       window as unknown as {
-        chrome: { runtime: { sendMessage: () => Promise<never> } };
+        chrome: {
+          runtime: {
+            sendMessage: (...args: unknown[]) => Promise<unknown>;
+          };
+        };
       }
-    ).chrome.runtime.sendMessage = () =>
-      Promise.reject(new Error('e2e: forced transport failure'));
-  });
+    ).chrome;
+
+    const send = runtime.sendMessage.bind(runtime);
+
+    runtime.sendMessage = (...args: unknown[]) => {
+      const type = (args[0] as { type?: string } | undefined)?.type;
+
+      if (types.length > 0 && (type === undefined || !types.includes(type))) {
+        return send(...args);
+      }
+
+      return Promise.reject(new Error('e2e: forced transport failure'));
+    };
+  }, onlyTypes);
 }
 
 export async function breakWindowCreation(page: Page) {

--- a/e2e-tests/error-surface.ts
+++ b/e2e-tests/error-surface.ts
@@ -1,0 +1,39 @@
+import { Page } from '@playwright/test';
+
+export const DISPATCH_FAILED =
+  "The wallet didn't respond. Your last action may not have been applied.";
+export const WINDOW_FAILED = "Couldn't open the window. Please try again.";
+
+// Breaks this page's transport to the background, and only this page's.
+//
+// A rejected promise, not a synchronous throw: current Chrome exposes `browser`
+// natively, so `webextension-polyfill` re-exports it instead of wrapping
+// `chrome`, and the app therefore calls this function directly. A `throw` here
+// is handled — `dispatchToMainStore` calls `sendMessage` inside a `then` — but a
+// rejection is the shape a sleeping service worker actually produces, which is
+// what this feature is about.
+//
+// Stopping the service worker would not reproduce it either: in MV3 an incoming
+// message is itself the event that cold-starts a stopped worker, and while the
+// vault is unlocked the keep-alive alarm wakes it within 30s anyway.
+export async function breakTransport(page: Page) {
+  await page.evaluate(() => {
+    (
+      window as unknown as {
+        chrome: { runtime: { sendMessage: () => Promise<never> } };
+      }
+    ).chrome.runtime.sendMessage = () =>
+      Promise.reject(new Error('e2e: forced transport failure'));
+  });
+}
+
+export async function breakWindowCreation(page: Page) {
+  await page.evaluate(() => {
+    (
+      window as unknown as {
+        chrome: { windows: { create: () => Promise<never> } };
+      }
+    ).chrome.windows.create = () =>
+      Promise.reject(new Error('e2e: forced window failure'));
+  });
+}

--- a/e2e-tests/onboarding-flow/dropped-dispatch-flow.spec.ts
+++ b/e2e-tests/onboarding-flow/dropped-dispatch-flow.spec.ts
@@ -1,0 +1,113 @@
+import { twentyFourWordsSecretPhrase } from '../constants';
+import { DISPATCH_FAILED, breakTransport } from '../error-surface';
+import { onboarding, onboardingExpect } from '../fixtures';
+
+// The onboarding half of the guards. All three writes are the sole source of
+// what the screen does next, and the router catches none of them:
+// `keysDoesExist` stays false on a dropped `initKeys`; on a dropped `initVault`
+// it is already true, so the success page would render over a vault that was
+// never created; and a dropped `recoverVault` used to close the tab regardless,
+// taking the banner down with the tree it is mounted in.
+//
+// The break is aimed at one action type — the rest of the flow rides the same
+// transport and would fail long before the button under test is reached. Every
+// screen here is reached through the SPA router, so the patch survives to the
+// click.
+onboarding.describe('Onboarding UI: a dropped write is not silent', () => {
+  onboarding(
+    'should keep the password screen when initKeys is dropped',
+    async ({ page, createOnboardingPassword }) => {
+      await breakTransport(page, ['INIT_KEYS_SAGA']);
+
+      await createOnboardingPassword();
+
+      await onboardingExpect(page.getByText(DISPATCH_FAILED)).toBeVisible();
+      await onboardingExpect(page).toHaveURL(/.*create-vault-password/);
+
+      // The staying-put is not the guard's doing — `keysDoesExist` is false
+      // either way, so `NoVaultRoutes` keeps this screen up on its own. What the
+      // guard decides is whether the button survives: unguarded, `isSubmitted`
+      // latches on a write that never landed and the only button on the screen
+      // is dead for good, with the banner pointing at it.
+      await onboardingExpect(
+        page.getByRole('button', { name: 'Create password' })
+      ).toBeEnabled();
+    }
+  );
+
+  onboarding(
+    'should keep the confirmation screen when initVault is dropped',
+    async ({
+      page,
+      createOnboardingPassword,
+      createSecretPhrase,
+      copySecretPhrase,
+      confirmSecretPhraseSuccess
+    }) => {
+      await createOnboardingPassword();
+      await createSecretPhrase();
+
+      const phrase = await copySecretPhrase();
+
+      await breakTransport(page, ['INIT_VAULT_SAGA']);
+
+      await confirmSecretPhraseSuccess(phrase);
+
+      await onboardingExpect(page.getByText(DISPATCH_FAILED)).toBeVisible();
+      await onboardingExpect(page).not.toHaveURL(
+        /.*confirm-secret-phrase-success/
+      );
+
+      // The in-flight gate must let go on a false verdict, or the banner would
+      // be pointing at a button that can never be pressed again.
+      await onboardingExpect(
+        page.getByRole('button', { name: 'Confirm' })
+      ).toBeEnabled();
+    }
+  );
+
+  onboarding(
+    'should keep the onboarding tab open when recoverVault is dropped',
+    async ({ page, createOnboardingPassword }) => {
+      await createOnboardingPassword();
+
+      await page
+        .getByRole('button', {
+          name: 'Import an existing secret recovery phrase'
+        })
+        .click();
+
+      await page
+        .getByPlaceholder('e.g. Bobcat Lemon Blanket…')
+        .fill(twentyFourWordsSecretPhrase);
+
+      await page.getByRole('button', { name: 'Next' }).click();
+
+      await onboardingExpect(
+        page.getByText('Select accounts to recover')
+      ).toBeVisible();
+
+      await page.getByTestId('select-account-0').click();
+
+      await breakTransport(page, ['RECOVER_VAULT_SAGA']);
+
+      await page
+        .getByRole('button', { name: 'Recover selected accounts' })
+        .click();
+
+      // What this pins is that the banner reaches THIS tree — the recover screen
+      // is the one place a surfaced error has to survive a `closeActiveTab`.
+      //
+      // It does NOT pin the close-gate itself, and cannot: `closeActiveTab` is
+      // inert under Playwright. The success-path specs prove it — they
+      // `page.goto` the popup on this same `page` right after a recover that
+      // closes the tab in a real browser, which would throw on a closed target.
+      // So the gate at `select-accounts-to-recover/index.tsx` is only held by
+      // review; reverting it to `.finally` leaves this case green.
+      await onboardingExpect(page.getByText(DISPATCH_FAILED)).toBeVisible();
+      await onboardingExpect(
+        page.getByText('Select accounts to recover')
+      ).toBeVisible();
+    }
+  );
+});

--- a/e2e-tests/popup/common/wallet.spec.ts
+++ b/e2e-tests/popup/common/wallet.spec.ts
@@ -1,4 +1,5 @@
 import { ACCOUNT_NAMES } from '../../constants';
+import { DISPATCH_FAILED, breakTransport } from '../../error-surface';
 import { popup, popupExpect } from '../../fixtures';
 
 popup.describe('Popup UI: lock/unlock/reset wallet', () => {
@@ -57,6 +58,29 @@ popup.describe('Popup UI: lock/unlock/reset wallet', () => {
       })
     ).toBeVisible();
   });
+
+  popup(
+    'should keep the user on the confirmation page when the reset dispatch is dropped',
+    async ({ popupPage }) => {
+      // Without the guard on the verdict, `closeWindowByReloadExtension` runs
+      // regardless: the extension reloads into onboarding and tells the user
+      // their wallet was reset while the vault cipher is still on disk — and
+      // takes the banner down with the page.
+      await popupPage.getByRole('button', { name: 'Reset wallet' }).click();
+      await popupPage.getByText('I’ve read and understand the above').click();
+
+      await breakTransport(popupPage);
+
+      await popupPage.getByRole('button', { name: 'Reset wallet' }).click();
+
+      await popupExpect(popupPage.getByText(DISPATCH_FAILED)).toBeVisible();
+      await popupExpect(
+        popupPage.getByRole('heading', {
+          name: 'Are you sure you want to reset your wallet?'
+        })
+      ).toBeVisible();
+    }
+  );
 
   popup(
     'should lock wallet for 5 minutes when user types wrong password 5 times',

--- a/e2e-tests/popup/error-surface/dropped-dispatch.spec.ts
+++ b/e2e-tests/popup/error-surface/dropped-dispatch.spec.ts
@@ -1,44 +1,12 @@
 import { Page } from '@playwright/test';
 
+import {
+  DISPATCH_FAILED,
+  WINDOW_FAILED,
+  breakTransport,
+  breakWindowCreation
+} from '../../error-surface';
 import { popup, popupExpect } from '../../fixtures';
-
-const DISPATCH_FAILED =
-  "The wallet didn't respond. Your last action may not have been applied.";
-const WINDOW_FAILED = "Couldn't open the window. Please try again.";
-
-// Breaks this page's transport to the background, and only this page's.
-//
-// A rejected promise, not a synchronous throw: current Chrome exposes `browser`
-// natively, so `webextension-polyfill` re-exports it instead of wrapping
-// `chrome`, and the app therefore calls this function directly. A `throw` here
-// escapes synchronously out of `dispatchToMainStore` and trips the ErrorBoundary
-// (verified — the whole popup renders "Something went wrong") rather than
-// producing the rejection this feature is about.
-//
-// Stopping the service worker would not reproduce it either: in MV3 an incoming
-// message is itself the event that cold-starts a stopped worker, and while the
-// vault is unlocked the keep-alive alarm wakes it within 30s anyway.
-async function breakTransport(page: Page) {
-  await page.evaluate(() => {
-    (
-      window as unknown as {
-        chrome: { runtime: { sendMessage: () => Promise<never> } };
-      }
-    ).chrome.runtime.sendMessage = () =>
-      Promise.reject(new Error('e2e: forced transport failure'));
-  });
-}
-
-async function breakWindowCreation(page: Page) {
-  await page.evaluate(() => {
-    (
-      window as unknown as {
-        chrome: { windows: { create: () => Promise<never> } };
-      }
-    ).chrome.windows.create = () =>
-      Promise.reject(new Error('e2e: forced window failure'));
-  });
-}
 
 async function clickMenuItem(page: Page, name: string) {
   await page.getByTestId('menu-open-icon').click();

--- a/e2e-tests/popup/error-surface/dropped-dispatch.spec.ts
+++ b/e2e-tests/popup/error-surface/dropped-dispatch.spec.ts
@@ -1,0 +1,125 @@
+import { Page } from '@playwright/test';
+
+import { popup, popupExpect } from '../../fixtures';
+
+const DISPATCH_FAILED =
+  "The wallet didn't respond. Your last action may not have been applied.";
+const WINDOW_FAILED = "Couldn't open the window. Please try again.";
+
+// Breaks this page's transport to the background, and only this page's.
+//
+// A rejected promise, not a synchronous throw: current Chrome exposes `browser`
+// natively, so `webextension-polyfill` re-exports it instead of wrapping
+// `chrome`, and the app therefore calls this function directly. A `throw` here
+// escapes synchronously out of `dispatchToMainStore` and trips the ErrorBoundary
+// (verified — the whole popup renders "Something went wrong") rather than
+// producing the rejection this feature is about.
+//
+// Stopping the service worker would not reproduce it either: in MV3 an incoming
+// message is itself the event that cold-starts a stopped worker, and while the
+// vault is unlocked the keep-alive alarm wakes it within 30s anyway.
+async function breakTransport(page: Page) {
+  await page.evaluate(() => {
+    (
+      window as unknown as {
+        chrome: { runtime: { sendMessage: () => Promise<never> } };
+      }
+    ).chrome.runtime.sendMessage = () =>
+      Promise.reject(new Error('e2e: forced transport failure'));
+  });
+}
+
+async function breakWindowCreation(page: Page) {
+  await page.evaluate(() => {
+    (
+      window as unknown as {
+        chrome: { windows: { create: () => Promise<never> } };
+      }
+    ).chrome.windows.create = () =>
+      Promise.reject(new Error('e2e: forced window failure'));
+  });
+}
+
+async function clickMenuItem(page: Page, name: string) {
+  await page.getByTestId('menu-open-icon').click();
+  await page.getByText(name, { exact: true }).click();
+}
+
+// `unlockVault` returns before the unlock has actually completed — it only waits
+// for network idle, and the flow finishes through further dispatches from this
+// page. Breaking the transport before then breaks the unlock itself and the page
+// sits on the lock screen forever, so wait for the unlocked UI first.
+async function waitForUnlockedHome(page: Page) {
+  await popupExpect(page.getByTestId('menu-open-icon')).toBeVisible();
+}
+
+popup.describe('Popup UI: dropped dispatch error surface', () => {
+  popup(
+    'tells the user when the export-keys dispatch never reaches the background',
+    async ({ popupPage, unlockVault, context }) => {
+      await unlockVault();
+      await waitForUnlockedHome(popupPage);
+      await breakTransport(popupPage);
+
+      const pagesBefore = context.pages().length;
+
+      await clickMenuItem(popupPage, 'Download account keys');
+
+      await popupExpect(popupPage.getByText(DISPATCH_FAILED)).toBeVisible();
+      // The dispatch never arrived, so the saga that opens the window never ran.
+      popupExpect(context.pages().length).toBe(pagesBefore);
+    }
+  );
+
+  // Dedupe of repeated failures is covered by `ui-error-channel.test.ts` and not
+  // here: the banner is `position: fixed; top: 0` with a tooltip z-index, so once
+  // a row is up it covers the header — measured at 1280x77 over a menu icon at
+  // y=24..48, with `elementFromPoint` returning the banner. A second click on the
+  // menu cannot land until the row is dismissed.
+  popup(
+    'shows no banner for an action that is not on the surfaced list',
+    async ({ popupPage, unlockVault }) => {
+      await unlockVault();
+      await waitForUnlockedHome(popupPage);
+      await breakTransport(popupPage);
+
+      await clickMenuItem(popupPage, 'Theme');
+      await popupPage.getByText('Dark', { exact: true }).click();
+
+      // Logged, never shown: a banner on every dropped dispatch would train the
+      // user to ignore the banner.
+      await popupExpect(popupPage.getByText(DISPATCH_FAILED)).toHaveCount(0);
+    }
+  );
+
+  popup(
+    'lets the row be dismissed, and brings it back on the next failure',
+    async ({ popupPage, unlockVault }) => {
+      await unlockVault();
+      await waitForUnlockedHome(popupPage);
+      await breakTransport(popupPage);
+
+      await clickMenuItem(popupPage, 'Download account keys');
+      await popupExpect(popupPage.getByText(DISPATCH_FAILED)).toBeVisible();
+
+      await popupPage.getByRole('button', { name: 'Dismiss' }).click();
+      await popupExpect(popupPage.getByText(DISPATCH_FAILED)).toHaveCount(0);
+
+      await clickMenuItem(popupPage, 'Download account keys');
+      await popupExpect(popupPage.getByText(DISPATCH_FAILED)).toBeVisible();
+    }
+  );
+
+  popup(
+    'tells the user when the import-account window fails to open',
+    async ({ popupPage, unlockVault }) => {
+      await unlockVault();
+      await waitForUnlockedHome(popupPage);
+      await breakWindowCreation(popupPage);
+
+      await clickMenuItem(popupPage, 'Import account');
+
+      await popupExpect(popupPage.getByText(WINDOW_FAILED)).toBeVisible();
+    }
+  );
+});

--- a/e2e-tests/popup/import-account-with-file/import-account-with-file.spec.ts
+++ b/e2e-tests/popup/import-account-with-file/import-account-with-file.spec.ts
@@ -94,11 +94,18 @@ popup.describe('Popup UI: import account with file', () => {
         .getByPlaceholder('Account name', { exact: true })
         .fill(ACCOUNT_NAMES.importedPemAccountName);
 
-      // Only the guarded dispatch: `checkAccountNameIsTaken` rides the same
-      // transport from submit-time validation, so breaking all of it stops
-      // `handleSubmit` before `onSubmit` runs and the page never gets as far as
-      // the action under test. The literal is pinned in
-      // `surfaced-dispatch-actions.test.ts`.
+      // Only the guarded dispatch, which narrows what this case covers to the
+      // late-failure window: the transport drops after the name last validated,
+      // so Import is pressable and the guard is what stops the success screen.
+      //
+      // A whole-transport break is a different, still-silent story that no
+      // guard here can reach — `checkAccountNameIsTaken` is a bare
+      // `runtime.sendMessage` inside the yup resolver, so it rejects
+      // `handleSubmit` before `onSubmit` runs, and `checkSecretKeyExist`
+      // escapes the file reader as raw untranslated text. Both are legacy sends
+      // outside `dispatchToMainStore`; fixing them is its own change.
+      //
+      // The literal is pinned in `surfaced-dispatch-actions.test.ts`.
       await breakTransport(importAccountPage, ['vault/accountImported']);
 
       await importAccountPage.getByRole('button', { name: 'Import' }).click();

--- a/e2e-tests/popup/import-account-with-file/import-account-with-file.spec.ts
+++ b/e2e-tests/popup/import-account-with-file/import-account-with-file.spec.ts
@@ -5,6 +5,7 @@ import {
   secretKeyPathForCER,
   secretKeyPathForPEM
 } from '../../constants';
+import { DISPATCH_FAILED, breakTransport } from '../../error-surface';
 import { popup, popupExpect } from '../../fixtures';
 
 popup.describe('Popup UI: import account with file', () => {
@@ -62,6 +63,54 @@ popup.describe('Popup UI: import account with file', () => {
       ).toBeVisible();
     }
   );
+  popup(
+    'should not claim success when the import dispatch is dropped',
+    async ({ unlockVault, context, popupPage }) => {
+      await unlockVault();
+
+      await popupPage.getByTestId('menu-open-icon').click();
+
+      const [importAccountPage] = await Promise.all([
+        context.waitForEvent('page'),
+        popupPage.getByText('Import account').click()
+      ]);
+
+      const fileChooserPromise = importAccountPage.waitForEvent('filechooser');
+
+      await popupExpect(
+        importAccountPage.getByRole('heading', {
+          name: 'Import account from secret key file'
+        })
+      ).toBeVisible();
+
+      await importAccountPage
+        .getByRole('button', { name: 'Upload your file' })
+        .click();
+
+      const fileChooser = await fileChooserPromise;
+      await fileChooser.setFiles(secretKeyPathForPEM);
+
+      await importAccountPage
+        .getByPlaceholder('Account name', { exact: true })
+        .fill(ACCOUNT_NAMES.importedPemAccountName);
+
+      // Broken only now: the page dispatches while it loads, and breaking it
+      // earlier would fail the flow before the button under test is reached.
+      await breakTransport(importAccountPage);
+
+      await importAccountPage.getByRole('button', { name: 'Import' }).click();
+
+      await popupExpect(
+        importAccountPage.getByText(DISPATCH_FAILED)
+      ).toBeVisible();
+      await popupExpect(
+        importAccountPage.getByRole('heading', {
+          name: 'Your account was successfully imported'
+        })
+      ).toHaveCount(0);
+    }
+  );
+
   popup(
     'should import account via .cer file',
     async ({ unlockVault, context, popupPage }) => {

--- a/e2e-tests/popup/import-account-with-file/import-account-with-file.spec.ts
+++ b/e2e-tests/popup/import-account-with-file/import-account-with-file.spec.ts
@@ -94,9 +94,12 @@ popup.describe('Popup UI: import account with file', () => {
         .getByPlaceholder('Account name', { exact: true })
         .fill(ACCOUNT_NAMES.importedPemAccountName);
 
-      // Broken only now: the page dispatches while it loads, and breaking it
-      // earlier would fail the flow before the button under test is reached.
-      await breakTransport(importAccountPage);
+      // Only the guarded dispatch: `checkAccountNameIsTaken` rides the same
+      // transport from submit-time validation, so breaking all of it stops
+      // `handleSubmit` before `onSubmit` runs and the page never gets as far as
+      // the action under test. The literal is pinned in
+      // `surfaced-dispatch-actions.test.ts`.
+      await breakTransport(importAccountPage, ['vault/accountImported']);
 
       await importAccountPage.getByRole('button', { name: 'Import' }).click();
 

--- a/src/apps/import-account-with-file/pages/import-account-with-file-upload/index.tsx
+++ b/src/apps/import-account-with-file/pages/import-account-with-file-upload/index.tsx
@@ -28,8 +28,10 @@ export function ImportAccountWithFileUploadPage() {
 
   const onSuccess = useCallback(
     async (accountData: Account) => {
-      dispatchToMainStore(accountImported(accountData));
-      navigate(RouterPath.ImportAccountWithFileSuccess);
+      // Only claim success once the account actually reached the vault.
+      if (await dispatchToMainStore(accountImported(accountData))) {
+        navigate(RouterPath.ImportAccountWithFileSuccess);
+      }
     },
     [navigate]
   );

--- a/src/apps/onboarding/pages/confirm-secret-phrase/index.tsx
+++ b/src/apps/onboarding/pages/confirm-secret-phrase/index.tsx
@@ -36,6 +36,7 @@ export function ConfirmSecretPhrasePage({
 
   const [isConfirmationSuccess, setIsConfirmationSuccess] = useState(false);
   const [isFormValid, setIsFormValid] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   if (phrase == null) {
     return <Navigate to={RouterPath.Any} />;
@@ -47,10 +48,19 @@ export function ConfirmSecretPhrasePage({
         // Only navigate once the vault actually exists: keys and encryption key
         // are already in place here, so the success page renders regardless of
         // whether this dispatch arrived.
+        //
+        // `isSubmitting` closes the window that awaiting the verdict opens:
+        // nothing else disables the button, `initVaultSaga` runs to completion
+        // inside one delivery, and `accountAdded` appends without a dedupe — so
+        // a second click would leave the new wallet with two identical
+        // "Account 1" entries on one key pair.
+        setIsSubmitting(true);
         dispatchToMainStore(initVault({ secretPhrase: phrase })).then(
           dispatched => {
             if (dispatched) {
               navigate(RouterPath.ConfirmSecretPhraseSuccess);
+            } else {
+              setIsSubmitting(false);
             }
           }
         );
@@ -93,7 +103,10 @@ export function ConfirmSecretPhrasePage({
       )}
       renderFooter={() => (
         <TabFooterContainer style={{ marginTop: '28px' }}>
-          <Button disabled={!isFormValid} onClick={handleSubmit}>
+          <Button
+            disabled={!isFormValid || isSubmitting}
+            onClick={handleSubmit}
+          >
             <Trans t={t}>Confirm</Trans>
           </Button>
         </TabFooterContainer>

--- a/src/apps/onboarding/pages/confirm-secret-phrase/index.tsx
+++ b/src/apps/onboarding/pages/confirm-secret-phrase/index.tsx
@@ -44,8 +44,16 @@ export function ConfirmSecretPhrasePage({
   function handleSubmit() {
     try {
       if (isConfirmationSuccess && phrase) {
-        dispatchToMainStore(initVault({ secretPhrase: phrase }));
-        navigate(RouterPath.ConfirmSecretPhraseSuccess);
+        // Only navigate once the vault actually exists: keys and encryption key
+        // are already in place here, so the success page renders regardless of
+        // whether this dispatch arrived.
+        dispatchToMainStore(initVault({ secretPhrase: phrase })).then(
+          dispatched => {
+            if (dispatched) {
+              navigate(RouterPath.ConfirmSecretPhraseSuccess);
+            }
+          }
+        );
       } else {
         throw Error(ErrorMessages.secretPhrase.INVALID_SECRET_PHRASE.message);
       }

--- a/src/apps/onboarding/pages/create-secret-phrase/index.tsx
+++ b/src/apps/onboarding/pages/create-secret-phrase/index.tsx
@@ -23,8 +23,13 @@ export function CreateSecretPhrasePage() {
   const { t } = useTranslation();
 
   const handleBack = () => {
-    dispatchToMainStore(resetVault());
-    navigate(RouterPath.CreateVaultPassword);
+    // A dropped reset leaves the generated secret phrase alive, so going back
+    // would have the user set a password over a phrase they never recorded.
+    dispatchToMainStore(resetVault()).then(dispatched => {
+      if (dispatched) {
+        navigate(RouterPath.CreateVaultPassword);
+      }
+    });
   };
 
   return (

--- a/src/apps/onboarding/pages/create-vault-password/index.tsx
+++ b/src/apps/onboarding/pages/create-vault-password/index.tsx
@@ -35,6 +35,7 @@ export function CreateVaultPasswordPage({
   saveIsLoggedIn
 }: CreateVaultPasswordPageProps) {
   const [isChecked, setIsChecked] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
   const navigate = useTypedNavigate();
   const { t } = useTranslation();
   const keysDoesExist = useSelector(selectKeysDoesExist);
@@ -42,7 +43,7 @@ export function CreateVaultPasswordPage({
   const {
     register,
     handleSubmit,
-    formState: { isDirty, isSubmitSuccessful, errors },
+    formState: { isDirty, isSubmitting, errors },
     control
   } = useCreatePasswordForm();
 
@@ -58,8 +59,13 @@ export function CreateVaultPasswordPage({
   }, [navigate, keysDoesExist]);
 
   async function onSubmit(data: CreatePasswordFormValues) {
-    dispatchToMainStore(initKeys({ password: data.password }));
-    saveIsLoggedIn(true);
+    // A dropped `initKeys` leaves `keysDoesExist` false, so the router keeps
+    // rendering this page — and `isSubmitSuccessful` used to disable the only
+    // button on it for good, leaving the banner with nothing to retry.
+    if (await dispatchToMainStore(initKeys({ password: data.password }))) {
+      setIsSubmitted(true);
+      saveIsLoggedIn(true);
+    }
   }
 
   const terms = (
@@ -117,7 +123,9 @@ export function CreateVaultPasswordPage({
               label={terms}
               dataTestId="terms-checkbox"
             />
-            <Button disabled={!isChecked || !isDirty || isSubmitSuccessful}>
+            <Button
+              disabled={!isChecked || !isDirty || isSubmitting || isSubmitted}
+            >
               <Trans t={t}>Create password</Trans>
             </Button>
           </TabFooterContainer>

--- a/src/apps/onboarding/pages/select-accounts-to-recover/index.tsx
+++ b/src/apps/onboarding/pages/select-accounts-to-recover/index.tsx
@@ -38,6 +38,7 @@ export const SelectAccountsToRecoverPage = () => {
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [maxItemsToRender, setMaxItemsToRender] = useState(5);
   const [isButtonDisabled, setIsButtonDisabled] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const navigate = useTypedNavigate();
   const { t } = useTranslation();
@@ -108,12 +109,24 @@ export const SelectAccountsToRecoverPage = () => {
       derivationIndex: account.derivationIndex
     }));
 
+    // `.finally` closed the onboarding tab on a dropped send too, presenting an
+    // empty vault as recovered and taking the banner down with the tab it is
+    // mounted in. `isSubmitting` covers the round trip the verdict adds:
+    // `accountsAdded` appends without a dedupe, so a second click would double
+    // every recovered account.
+    setIsSubmitting(true);
     dispatchToMainStore(
       recoverVault({
         secretPhrase: location.state.secretPhrase,
         accounts
       })
-    ).finally(closeActiveTab);
+    ).then(dispatched => {
+      if (dispatched) {
+        closeActiveTab();
+      } else {
+        setIsSubmitting(false);
+      }
+    });
   };
 
   return (
@@ -147,7 +160,9 @@ export const SelectAccountsToRecoverPage = () => {
       renderFooter={() => (
         <TabFooterContainer>
           <Button
-            disabled={!selectedAccounts.length || isButtonDisabled}
+            disabled={
+              !selectedAccounts.length || isButtonDisabled || isSubmitting
+            }
             onClick={onSubmit}
           >
             <Trans t={t}>Recover selected accounts</Trans>

--- a/src/apps/onboarding/pages/welcome/index.tsx
+++ b/src/apps/onboarding/pages/welcome/index.tsx
@@ -17,8 +17,10 @@ export function WelcomePage() {
   const { t } = useTranslation();
 
   const handleClick = () => {
-    dispatchToMainStore(resetVault()).then(() => {
-      navigate(RouterPath.CreateVaultPassword);
+    dispatchToMainStore(resetVault()).then(dispatched => {
+      if (dispatched) {
+        navigate(RouterPath.CreateVaultPassword);
+      }
     });
   };
 

--- a/src/apps/popup/pages/import-account-from-ledger/connected-ledger.tsx
+++ b/src/apps/popup/pages/import-account-from-ledger/connected-ledger.tsx
@@ -128,9 +128,11 @@ export const ConnectedLedger: React.FC<IConnectedLedgerProps> = ({
         : undefined
     }));
 
-    dispatchToMainStore(accountsImported(accounts)).then(() => {
-      onClose();
-      navigate(RouterPath.Home);
+    dispatchToMainStore(accountsImported(accounts)).then(dispatched => {
+      if (dispatched) {
+        onClose();
+        navigate(RouterPath.Home);
+      }
     });
   };
 

--- a/src/apps/popup/pages/import-account-from-torus/index.tsx
+++ b/src/apps/popup/pages/import-account-from-torus/index.tsx
@@ -43,8 +43,10 @@ export const ImportAccountFromTorusPage = () => {
   const isButtonDisabled = calculateSubmitButtonDisabled({ isValid });
 
   const onSuccess = useCallback(async (accountData: Account) => {
-    dispatchToMainStore(accountImported(accountData));
-    setImportStep(ImportAccountSteps.Success);
+    // Only claim success once the account actually reached the vault.
+    if (await dispatchToMainStore(accountImported(accountData))) {
+      setImportStep(ImportAccountSteps.Success);
+    }
   }, []);
   const onFailure = useCallback((message?: string) => {
     if (message) {

--- a/src/apps/popup/pages/navigation-menu/index.tsx
+++ b/src/apps/popup/pages/navigation-menu/index.tsx
@@ -175,7 +175,7 @@ export function NavigationMenuPageContent() {
               openWindow({
                 windowApp: WindowApp.ImportAccount,
                 isNewWindow: true
-              }).catch(e => console.error(e));
+              });
             }
           },
           {

--- a/src/background/redux/surfaced-dispatch-actions.test.ts
+++ b/src/background/redux/surfaced-dispatch-actions.test.ts
@@ -1,0 +1,26 @@
+import { ledgerNewWindowIdChanged } from './ledger/actions';
+import { lockVault, openExportKeysWindow, resetVault } from './sagas/actions';
+import { SURFACED_DISPATCH_ACTIONS } from './surfaced-dispatch-actions';
+import { accountsImported } from './vault/actions';
+
+describe('SURFACED_DISPATCH_ACTIONS', () => {
+  // A pin, not a tautology: the list decides which dropped dispatches the user
+  // is told about, and the criterion for adding one is a judgement call. Growing
+  // or shrinking it has to be a deliberate edit, not a side effect.
+  it('contains exactly the five actions whose dropped dispatch is otherwise invisible', () => {
+    expect([...SURFACED_DISPATCH_ACTIONS].sort()).toEqual(
+      [
+        openExportKeysWindow.type,
+        lockVault.type,
+        ledgerNewWindowIdChanged.type,
+        resetVault.type,
+        accountsImported.type
+      ].sort()
+    );
+  });
+
+  it('is keyed on the creators, so a rename cannot silently drop an entry', () => {
+    expect(SURFACED_DISPATCH_ACTIONS.has(openExportKeysWindow.type)).toBe(true);
+    expect(SURFACED_DISPATCH_ACTIONS.has(lockVault.type)).toBe(true);
+  });
+});

--- a/src/background/redux/surfaced-dispatch-actions.test.ts
+++ b/src/background/redux/surfaced-dispatch-actions.test.ts
@@ -5,6 +5,7 @@ import {
   initVault,
   lockVault,
   openExportKeysWindow,
+  recoverVault,
   resetVault
 } from './sagas/actions';
 import { SURFACED_DISPATCH_ACTIONS } from './surfaced-dispatch-actions';
@@ -25,6 +26,7 @@ describe('SURFACED_DISPATCH_ACTIONS', () => {
         resetVault.type,
         initKeys.type,
         initVault.type,
+        recoverVault.type,
         accountsImported.type,
         accountImported.type,
         dismissSagaError.type
@@ -45,6 +47,7 @@ describe('SURFACED_DISPATCH_ACTIONS', () => {
         'RESET_VAULT_SAGA',
         'INIT_KEYS_SAGA',
         'INIT_VAULT_SAGA',
+        'RECOVER_VAULT_SAGA',
         'vault/accountsImported',
         'vault/accountImported',
         'appEvents/dismissSagaError'

--- a/src/background/redux/surfaced-dispatch-actions.test.ts
+++ b/src/background/redux/surfaced-dispatch-actions.test.ts
@@ -1,20 +1,23 @@
+import { dismissSagaError } from './app-events/actions';
 import { ledgerNewWindowIdChanged } from './ledger/actions';
 import { lockVault, openExportKeysWindow, resetVault } from './sagas/actions';
 import { SURFACED_DISPATCH_ACTIONS } from './surfaced-dispatch-actions';
-import { accountsImported } from './vault/actions';
+import { accountImported, accountsImported } from './vault/actions';
 
 describe('SURFACED_DISPATCH_ACTIONS', () => {
   // A pin, not a tautology: the list decides which dropped dispatches the user
   // is told about, and the criterion for adding one is a judgement call. Growing
   // or shrinking it has to be a deliberate edit, not a side effect.
-  it('contains exactly the five actions whose dropped dispatch is otherwise invisible', () => {
+  it('contains exactly the seven actions whose dropped dispatch is otherwise invisible', () => {
     expect([...SURFACED_DISPATCH_ACTIONS].sort()).toEqual(
       [
         openExportKeysWindow.type,
         lockVault.type,
         ledgerNewWindowIdChanged.type,
         resetVault.type,
-        accountsImported.type
+        accountsImported.type,
+        accountImported.type,
+        dismissSagaError.type
       ].sort()
     );
   });

--- a/src/background/redux/surfaced-dispatch-actions.test.ts
+++ b/src/background/redux/surfaced-dispatch-actions.test.ts
@@ -1,20 +1,30 @@
 import { dismissSagaError } from './app-events/actions';
 import { ledgerNewWindowIdChanged } from './ledger/actions';
-import { lockVault, openExportKeysWindow, resetVault } from './sagas/actions';
+import {
+  initKeys,
+  initVault,
+  lockVault,
+  openExportKeysWindow,
+  resetVault
+} from './sagas/actions';
 import { SURFACED_DISPATCH_ACTIONS } from './surfaced-dispatch-actions';
 import { accountImported, accountsImported } from './vault/actions';
+import { windowRequestWindowAttached } from './windowManagement/actions';
 
 describe('SURFACED_DISPATCH_ACTIONS', () => {
   // A pin, not a tautology: the list decides which dropped dispatches the user
   // is told about, and the criterion for adding one is a judgement call. Growing
   // or shrinking it has to be a deliberate edit, not a side effect.
-  it('contains exactly the seven actions whose dropped dispatch is otherwise invisible', () => {
+  it('contains exactly the actions whose dropped dispatch is otherwise invisible', () => {
     expect([...SURFACED_DISPATCH_ACTIONS].sort()).toEqual(
       [
         openExportKeysWindow.type,
         lockVault.type,
+        windowRequestWindowAttached.type,
         ledgerNewWindowIdChanged.type,
         resetVault.type,
+        initKeys.type,
+        initVault.type,
         accountsImported.type,
         accountImported.type,
         dismissSagaError.type
@@ -22,8 +32,23 @@ describe('SURFACED_DISPATCH_ACTIONS', () => {
     );
   });
 
-  it('is keyed on the creators, so a rename cannot silently drop an entry', () => {
-    expect(SURFACED_DISPATCH_ACTIONS.has(openExportKeysWindow.type)).toBe(true);
-    expect(SURFACED_DISPATCH_ACTIONS.has(lockVault.type)).toBe(true);
+  // The pin above cannot see a rename: both sides read the same creators, so a
+  // renamed slice reducer moves them together. These literals are the only thing
+  // in the file that does not come from a creator.
+  it('pins the type strings themselves, which the creator-derived pin cannot', () => {
+    expect([...SURFACED_DISPATCH_ACTIONS].sort()).toEqual(
+      [
+        'OPEN_EXPORT_KEYS_WINDOW_SAGA',
+        'LOCK_VAULT_SAGA',
+        'windowManagement/windowRequestWindowAttached',
+        'ledger/ledgerNewWindowIdChanged',
+        'RESET_VAULT_SAGA',
+        'INIT_KEYS_SAGA',
+        'INIT_VAULT_SAGA',
+        'vault/accountsImported',
+        'vault/accountImported',
+        'appEvents/dismissSagaError'
+      ].sort()
+    );
   });
 });

--- a/src/background/redux/surfaced-dispatch-actions.ts
+++ b/src/background/redux/surfaced-dispatch-actions.ts
@@ -1,7 +1,14 @@
 import { dismissSagaError } from './app-events/actions';
 import { ledgerNewWindowIdChanged } from './ledger/actions';
-import { lockVault, openExportKeysWindow, resetVault } from './sagas/actions';
+import {
+  initKeys,
+  initVault,
+  lockVault,
+  openExportKeysWindow,
+  resetVault
+} from './sagas/actions';
 import { accountImported, accountsImported } from './vault/actions';
+import { windowRequestWindowAttached } from './windowManagement/actions';
 
 // Which dropped dispatches the user is told about.
 //
@@ -19,11 +26,21 @@ export const SURFACED_DISPATCH_ACTIONS: ReadonlySet<string> = new Set([
   // The user pressed Lock and the wallet stayed unlocked — a security outcome,
   // not an inconvenience.
   lockVault.type,
-  // The Ledger window never attaches to the request, which then hangs until the
-  // dapp's own timeout (see attach-window-to-request.ts).
+  // The Ledger permission window never attaches to the request, which then hangs
+  // until the dapp's own timeout (see attach-window-to-request.ts).
+  windowRequestWindowAttached.type,
+  // Its sibling, and a separate send: without it `windowId` stays null, the
+  // close tracker detaches and the permission window is never closed when the
+  // signature completes. `triggeredRef` is set regardless of either outcome, so
+  // neither has a retry path.
   ledgerNewWindowIdChanged.type,
   // Without this the reload presents an unperformed reset as done.
   resetVault.type,
+  // Onboarding's two writes. Without `initKeys` the password screen keeps
+  // rendering and nothing happens; without `initVault` the success screen
+  // renders over a vault that was never created.
+  initKeys.type,
+  initVault.type,
   // Without these the navigation presents an unperformed import as done —
   // `accountsImported` from the Ledger flow, `accountImported` from the
   // secret-key-file and Torus flows.

--- a/src/background/redux/surfaced-dispatch-actions.ts
+++ b/src/background/redux/surfaced-dispatch-actions.ts
@@ -5,6 +5,7 @@ import {
   initVault,
   lockVault,
   openExportKeysWindow,
+  recoverVault,
   resetVault
 } from './sagas/actions';
 import { accountImported, accountsImported } from './vault/actions';
@@ -36,11 +37,13 @@ export const SURFACED_DISPATCH_ACTIONS: ReadonlySet<string> = new Set([
   ledgerNewWindowIdChanged.type,
   // Without this the reload presents an unperformed reset as done.
   resetVault.type,
-  // Onboarding's two writes. Without `initKeys` the password screen keeps
+  // Onboarding's three writes. Without `initKeys` the password screen keeps
   // rendering and nothing happens; without `initVault` the success screen
-  // renders over a vault that was never created.
+  // renders over a vault that was never created; without `recoverVault` the
+  // onboarding tab used to close on an empty vault as though it had worked.
   initKeys.type,
   initVault.type,
+  recoverVault.type,
   // Without these the navigation presents an unperformed import as done —
   // `accountsImported` from the Ledger flow, `accountImported` from the
   // secret-key-file and Torus flows.

--- a/src/background/redux/surfaced-dispatch-actions.ts
+++ b/src/background/redux/surfaced-dispatch-actions.ts
@@ -1,0 +1,28 @@
+import { ledgerNewWindowIdChanged } from './ledger/actions';
+import { lockVault, openExportKeysWindow, resetVault } from './sagas/actions';
+import { accountsImported } from './vault/actions';
+
+// Which dropped dispatches the user is told about.
+//
+// The criterion for membership — and the only one: the dispatch IS the sole
+// source of the visible result. If it never reaches the background, the user
+// sees nothing happen and no other feedback path exists. Everything else stays
+// log-only, because a banner on all ~105 dispatch sites (theme changes, banner
+// dismissals) would train the user to ignore the banner.
+//
+// Built from the creators' `.type` so a rename is a compile error, and pinned by
+// `surfaced-dispatch-actions.test.ts` so a change here is deliberate.
+export const SURFACED_DISPATCH_ACTIONS: ReadonlySet<string> = new Set([
+  // The menu closes and no export window ever appears.
+  openExportKeysWindow.type,
+  // The user pressed Lock and the wallet stayed unlocked — a security outcome,
+  // not an inconvenience.
+  lockVault.type,
+  // The Ledger window never attaches to the request, which then hangs until the
+  // dapp's own timeout (see attach-window-to-request.ts).
+  ledgerNewWindowIdChanged.type,
+  // Without this the reload presents an unperformed reset as done.
+  resetVault.type,
+  // Without this the navigation presents an unperformed import as done.
+  accountsImported.type
+]);

--- a/src/background/redux/surfaced-dispatch-actions.ts
+++ b/src/background/redux/surfaced-dispatch-actions.ts
@@ -1,6 +1,7 @@
+import { dismissSagaError } from './app-events/actions';
 import { ledgerNewWindowIdChanged } from './ledger/actions';
 import { lockVault, openExportKeysWindow, resetVault } from './sagas/actions';
-import { accountsImported } from './vault/actions';
+import { accountImported, accountsImported } from './vault/actions';
 
 // Which dropped dispatches the user is told about.
 //
@@ -23,6 +24,13 @@ export const SURFACED_DISPATCH_ACTIONS: ReadonlySet<string> = new Set([
   ledgerNewWindowIdChanged.type,
   // Without this the reload presents an unperformed reset as done.
   resetVault.type,
-  // Without this the navigation presents an unperformed import as done.
-  accountsImported.type
+  // Without these the navigation presents an unperformed import as done —
+  // `accountsImported` from the Ledger flow, `accountImported` from the
+  // secret-key-file and Torus flows.
+  accountsImported.type,
+  accountImported.type,
+  // The banner's own dismiss button. Without this, pressing × while the
+  // transport is down does nothing and says nothing; with it, the reason
+  // appears as one deduped row whose own × is local and always works.
+  dismissSagaError.type
 ]);

--- a/src/background/redux/utils.test.ts
+++ b/src/background/redux/utils.test.ts
@@ -73,6 +73,22 @@ describe('dispatchToMainStore', () => {
     );
   });
 
+  it('resolves false instead of throwing when the send throws synchronously', async () => {
+    // `Extension context invalidated` has this shape, and four app entries
+    // dispatch from a render body that sits ABOVE the ErrorBoundary — an
+    // escaping throw blanks the page instead of reaching the banner.
+    sendMessageMock.mockImplementation(() => {
+      throw new Error('Extension context invalidated');
+    });
+
+    await expect(dispatchToMainStore(lockVault())).resolves.toBe(false);
+
+    expect(reportUiErrorMock).toHaveBeenCalledWith(
+      'dispatch-failed',
+      lockVault().type
+    );
+  });
+
   it('logs but does not surface an action that is not allow-listed', async () => {
     // A dropped theme change is not worth a banner; the log still records it.
     sendMessageMock.mockRejectedValue(new Error('no receiving end'));

--- a/src/background/redux/utils.test.ts
+++ b/src/background/redux/utils.test.ts
@@ -1,6 +1,9 @@
 import { runtime } from 'webextension-polyfill';
 
-import { reportUiError } from '@libs/ui/components/saga-error-banner/ui-error-channel';
+import {
+  clearUiError,
+  reportUiError
+} from '@libs/ui/components/saga-error-banner/ui-error-channel';
 
 import { lockVault } from './sagas/actions';
 import { themeModeSettingChanged } from './settings/actions';
@@ -12,7 +15,8 @@ jest.mock('webextension-polyfill', () => ({
 }));
 
 jest.mock('@libs/ui/components/saga-error-banner/ui-error-channel', () => ({
-  reportUiError: jest.fn()
+  reportUiError: jest.fn(),
+  clearUiError: jest.fn()
 }));
 
 const sendMessageMock = runtime.sendMessage as jest.MockedFunction<
@@ -20,6 +24,9 @@ const sendMessageMock = runtime.sendMessage as jest.MockedFunction<
 >;
 const reportUiErrorMock = reportUiError as jest.MockedFunction<
   typeof reportUiError
+>;
+const clearUiErrorMock = clearUiError as jest.MockedFunction<
+  typeof clearUiError
 >;
 
 describe('dispatchToMainStore', () => {
@@ -84,6 +91,19 @@ describe('dispatchToMainStore', () => {
     await expect(dispatchToMainStore(lockVault())).resolves.toBe(false);
 
     expect(reportUiErrorMock).toHaveBeenCalledWith(
+      'dispatch-failed',
+      lockVault().type
+    );
+  });
+
+  it('takes down the row left by an earlier failure once the send succeeds', async () => {
+    // The guards keep the user on the page to retry, so the retry that works
+    // lands on the screen where the stale row is still showing.
+    sendMessageMock.mockResolvedValue(undefined);
+
+    await dispatchToMainStore(lockVault());
+
+    expect(clearUiErrorMock).toHaveBeenCalledWith(
       'dispatch-failed',
       lockVault().type
     );

--- a/src/background/redux/utils.test.ts
+++ b/src/background/redux/utils.test.ts
@@ -1,0 +1,85 @@
+import { runtime } from 'webextension-polyfill';
+
+import { reportUiError } from '@libs/ui/components/saga-error-banner/ui-error-channel';
+
+import { lockVault } from './sagas/actions';
+import { themeModeSettingChanged } from './settings/actions';
+import { ThemeMode } from './settings/types';
+import { dispatchToMainStore } from './utils';
+
+jest.mock('webextension-polyfill', () => ({
+  runtime: { sendMessage: jest.fn() }
+}));
+
+jest.mock('@libs/ui/components/saga-error-banner/ui-error-channel', () => ({
+  reportUiError: jest.fn()
+}));
+
+const sendMessageMock = runtime.sendMessage as jest.MockedFunction<
+  typeof runtime.sendMessage
+>;
+const reportUiErrorMock = reportUiError as jest.MockedFunction<
+  typeof reportUiError
+>;
+
+describe('dispatchToMainStore', () => {
+  let consoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('resolves true and reports nothing when the background answers', async () => {
+    sendMessageMock.mockResolvedValue(undefined);
+
+    await expect(dispatchToMainStore(lockVault())).resolves.toBe(true);
+
+    expect(reportUiErrorMock).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('resolves false instead of rejecting when the send fails', async () => {
+    // 105 call sites do not catch. Rejecting here would turn each of them into
+    // an unhandled rejection.
+    sendMessageMock.mockRejectedValue(new Error('no receiving end'));
+
+    await expect(dispatchToMainStore(lockVault())).resolves.toBe(false);
+  });
+
+  it('logs the type and the cause, never the action', async () => {
+    sendMessageMock.mockRejectedValue(new Error('no receiving end'));
+
+    await dispatchToMainStore(lockVault());
+
+    expect(consoleError).toHaveBeenCalledWith(
+      'Dispatch to Main Store failed: ' + lockVault().type,
+      expect.any(Error)
+    );
+  });
+
+  it('surfaces an allow-listed action to the user', async () => {
+    sendMessageMock.mockRejectedValue(new Error('no receiving end'));
+
+    await dispatchToMainStore(lockVault());
+
+    expect(reportUiErrorMock).toHaveBeenCalledWith(
+      'dispatch-failed',
+      lockVault().type
+    );
+  });
+
+  it('logs but does not surface an action that is not allow-listed', async () => {
+    // A dropped theme change is not worth a banner; the log still records it.
+    sendMessageMock.mockRejectedValue(new Error('no receiving end'));
+
+    await dispatchToMainStore(themeModeSettingChanged(ThemeMode.LIGHT));
+
+    expect(consoleError).toHaveBeenCalled();
+    expect(reportUiErrorMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/background/redux/utils.ts
+++ b/src/background/redux/utils.ts
@@ -18,8 +18,13 @@ declare global {
 // send failed. NEVER rejects: ~105 call sites do not catch, so a rejection here
 // would become an unhandled rejection at each of them.
 export function dispatchToMainStore(action: ReduxAction): Promise<boolean> {
-  return runtime
-    .sendMessage(action)
+  // `sendMessage` is called inside a `then` so a SYNCHRONOUS throw lands in the
+  // same handler as a rejection. `Extension context invalidated` has that shape,
+  // and four app entries dispatch from a render body that sits ABOVE the
+  // ErrorBoundary (`popup/index.tsx:56` and three siblings) — there an escaping
+  // throw blanks the whole page instead of resolving `false`.
+  return Promise.resolve()
+    .then(() => runtime.sendMessage(action))
     .then(() => true)
     .catch((error: unknown) => {
       // A send to a sleeping or restarting MV3 service worker is a routine

--- a/src/background/redux/utils.ts
+++ b/src/background/redux/utils.ts
@@ -3,7 +3,10 @@ import { runtime } from 'webextension-polyfill';
 
 import { RootState } from '@background/redux/store-types';
 
+import { reportUiError } from '@libs/ui/components/saga-error-banner/ui-error-channel';
+
 import { ReduxAction } from './redux-action';
+import { SURFACED_DISPATCH_ACTIONS } from './surfaced-dispatch-actions';
 
 declare global {
   interface Window {
@@ -11,17 +14,31 @@ declare global {
   }
 }
 
-export function dispatchToMainStore(action: ReduxAction) {
-  return runtime.sendMessage(action).catch((error: unknown) => {
-    // A send to a sleeping or restarting MV3 service worker is a routine
-    // failure, and some of these actions are load-bearing — the Ledger
-    // permission window's attach is what keeps a request alive while the user
-    // confirms on the device. Discarding the cause left every one of those
-    // indistinguishable from the next. Log the type and the error, NEVER the
-    // action: payloads carry vault and signature material.
-    // nosemgrep: cw-logging-secrets
-    console.error('Dispatch to Main Store failed: ' + action.type, error);
-  });
+// Resolves `true` when the background acknowledged the action, `false` when the
+// send failed. NEVER rejects: ~105 call sites do not catch, so a rejection here
+// would become an unhandled rejection at each of them.
+export function dispatchToMainStore(action: ReduxAction): Promise<boolean> {
+  return runtime
+    .sendMessage(action)
+    .then(() => true)
+    .catch((error: unknown) => {
+      // A send to a sleeping or restarting MV3 service worker is a routine
+      // failure, and some of these actions are load-bearing — the Ledger
+      // permission window's attach is what keeps a request alive while the user
+      // confirms on the device. Discarding the cause left every one of those
+      // indistinguishable from the next. Log the type and the error, NEVER the
+      // action: payloads carry vault and signature material.
+      // nosemgrep: cw-logging-secrets
+      console.error('Dispatch to Main Store failed: ' + action.type, error);
+
+      // The background store is what is unreachable, so `sagaError` cannot be
+      // dispatched from here — the surface has to be UI-local.
+      if (SURFACED_DISPATCH_ACTIONS.has(action.type)) {
+        reportUiError('dispatch-failed', action.type);
+      }
+
+      return false;
+    });
 }
 
 export function* sagaSelect<Result>(selector: (state: RootState) => Result) {

--- a/src/background/redux/utils.ts
+++ b/src/background/redux/utils.ts
@@ -3,7 +3,10 @@ import { runtime } from 'webextension-polyfill';
 
 import { RootState } from '@background/redux/store-types';
 
-import { reportUiError } from '@libs/ui/components/saga-error-banner/ui-error-channel';
+import {
+  clearUiError,
+  reportUiError
+} from '@libs/ui/components/saga-error-banner/ui-error-channel';
 
 import { ReduxAction } from './redux-action';
 import { SURFACED_DISPATCH_ACTIONS } from './surfaced-dispatch-actions';
@@ -25,7 +28,12 @@ export function dispatchToMainStore(action: ReduxAction): Promise<boolean> {
   // throw blanks the whole page instead of resolving `false`.
   return Promise.resolve()
     .then(() => runtime.sendMessage(action))
-    .then(() => true)
+    .then(() => {
+      // The row this action may have left behind describes a failure that has
+      // just stopped being true.
+      clearUiError('dispatch-failed', action.type);
+      return true;
+    })
     .catch((error: unknown) => {
       // A send to a sleeping or restarting MV3 service worker is a routine
       // failure, and some of these actions are load-bearing — the Ledger

--- a/src/hooks/create-reporting-open-window.test.ts
+++ b/src/hooks/create-reporting-open-window.test.ts
@@ -1,0 +1,118 @@
+import { WindowApp } from '@background/create-open-window';
+
+import {
+  clearUiError,
+  reportUiError
+} from '@libs/ui/components/saga-error-banner/ui-error-channel';
+
+import { createReportingOpenWindow } from './create-reporting-open-window';
+
+// `create-open-window` pulls the polyfill in for the `WindowApp` enum alone.
+jest.mock('webextension-polyfill', () => ({
+  windows: {},
+  tabs: {}
+}));
+
+jest.mock('@libs/ui/components/saga-error-banner/ui-error-channel', () => ({
+  reportUiError: jest.fn(),
+  clearUiError: jest.fn()
+}));
+
+const reportUiErrorMock = reportUiError as jest.MockedFunction<
+  typeof reportUiError
+>;
+const clearUiErrorMock = clearUiError as jest.MockedFunction<
+  typeof clearUiError
+>;
+
+describe('createReportingOpenWindow', () => {
+  let consoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('reports and logs nothing when the window opens', async () => {
+    const open = jest.fn().mockResolvedValue({ reused: false });
+
+    await createReportingOpenWindow(open)({
+      windowApp: WindowApp.ImportAccount,
+      isNewWindow: true
+    });
+
+    expect(reportUiErrorMock).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('takes down the row left by an earlier failure once the window opens', async () => {
+    const open = jest.fn().mockResolvedValue({ reused: false });
+
+    await createReportingOpenWindow(open)({
+      windowApp: WindowApp.ImportAccount,
+      isNewWindow: true
+    });
+
+    expect(clearUiErrorMock).toHaveBeenCalledWith(
+      'window-open-failed',
+      WindowApp.ImportAccount
+    );
+  });
+
+  it('resolves instead of rejecting when the open fails', async () => {
+    const open = jest.fn().mockRejectedValue(new Error('no window'));
+
+    await expect(
+      createReportingOpenWindow(open)({
+        windowApp: WindowApp.ImportAccount,
+        isNewWindow: true
+      })
+    ).resolves.toBeUndefined();
+
+    expect(reportUiErrorMock).toHaveBeenCalledWith(
+      'window-open-failed',
+      WindowApp.ImportAccount
+    );
+  });
+
+  it('logs the error name only — never the rejection, never the props', async () => {
+    // `searchParams` is embedded in the URL `windows.create` is given, and a
+    // sign-message plaintext can ride there, so a rejection built from that URL
+    // must not reach the console.
+    const secret = 'plaintext-the-user-is-about-to-sign';
+    const open = jest
+      .fn()
+      .mockRejectedValue(new TypeError(`failed to open ?message=${secret}`));
+
+    await createReportingOpenWindow(open)({
+      windowApp: WindowApp.SignatureRequestMessage,
+      searchParams: { message: secret }
+    });
+
+    expect(consoleError).toHaveBeenCalledWith(
+      'openWindow failed',
+      WindowApp.SignatureRequestMessage,
+      'TypeError'
+    );
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain(secret);
+  });
+
+  it('survives a rejection that is not an Error', async () => {
+    const open = jest.fn().mockRejectedValue('just a string');
+
+    await createReportingOpenWindow(open)({
+      windowApp: WindowApp.ImportAccount
+    });
+
+    expect(consoleError).toHaveBeenCalledWith(
+      'openWindow failed',
+      WindowApp.ImportAccount,
+      undefined
+    );
+    expect(reportUiErrorMock).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/create-reporting-open-window.ts
+++ b/src/hooks/create-reporting-open-window.ts
@@ -1,0 +1,37 @@
+import type { OpenWindowProps } from '@background/create-open-window';
+
+import {
+  clearUiError,
+  reportUiError
+} from '@libs/ui/components/saga-error-banner/ui-error-channel';
+
+/**
+ * Wraps `createOpenWindow`'s result so a failed open reports itself instead of
+ * being swallowed at the call site.
+ *
+ * Extracted from `useWindowManager` for the same reason as
+ * `registerLedgerPermissionWindow`: the repo has no React-hook harness, so
+ * inside the hook the redaction below was a line anyone could widen back to
+ * logging the rejection — or `props` — with the suite staying green.
+ */
+export function createReportingOpenWindow(
+  open: (props: OpenWindowProps) => Promise<unknown>
+) {
+  return async (props: OpenWindowProps): Promise<void> => {
+    try {
+      await open(props);
+      clearUiError('window-open-failed', props.windowApp);
+    } catch (error) {
+      // The name only, never the rejection and never `props`: `searchParams` is
+      // embedded in the URL `windows.create` was given, and a sign-message
+      // plaintext can ride there. `use-ledger.ts` logs `error.name` for the same
+      // reason.
+      console.error(
+        'openWindow failed',
+        props.windowApp,
+        (error as Error)?.name
+      );
+      reportUiError('window-open-failed', props.windowApp);
+    }
+  };
+}

--- a/src/hooks/use-window-manager.ts
+++ b/src/hooks/use-window-manager.ts
@@ -27,7 +27,14 @@ export function useWindowManager() {
       try {
         await open(props);
       } catch (error) {
-        console.error('openWindow failed', props.windowApp, error);
+        // Name only, not the rejection: `searchParams` is embedded in the URL
+        // `windows.create` was given, and a sign-message plaintext can ride
+        // there. `use-ledger.ts` logs `error.name` for the same reason.
+        console.error(
+          'openWindow failed',
+          props.windowApp,
+          (error as Error)?.name
+        );
         reportUiError('window-open-failed', props.windowApp);
       }
     };

--- a/src/hooks/use-window-manager.ts
+++ b/src/hooks/use-window-manager.ts
@@ -1,6 +1,11 @@
 import { useMemo } from 'react';
 
-import { createOpenWindow } from '@background/create-open-window';
+import {
+  OpenWindowProps,
+  createOpenWindow
+} from '@background/create-open-window';
+
+import { reportUiError } from '@libs/ui/components/saga-error-banner/ui-error-channel';
 
 /**
  * Opens a deliberately separate window from a UI page (the import-account
@@ -10,9 +15,23 @@ import { createOpenWindow } from '@background/create-open-window';
  * the background store, i.e. retargeting the shared approval-window slot the
  * request lifecycle depends on. That slot is background-only, and the two
  * actions are excluded from the forwarding set accordingly.
+ *
+ * The returned `openWindow` never rejects: it reports the failure to the error
+ * banner itself, so no call site can go back to discarding it.
  */
 export function useWindowManager() {
-  const openWindow = useMemo(() => createOpenWindow(), []);
+  const openWindow = useMemo(() => {
+    const open = createOpenWindow();
+
+    return async (props: OpenWindowProps) => {
+      try {
+        await open(props);
+      } catch (error) {
+        console.error('openWindow failed', props.windowApp, error);
+        reportUiError('window-open-failed', props.windowApp);
+      }
+    };
+  }, []);
 
   return { openWindow };
 }

--- a/src/hooks/use-window-manager.ts
+++ b/src/hooks/use-window-manager.ts
@@ -1,11 +1,8 @@
 import { useMemo } from 'react';
 
-import {
-  OpenWindowProps,
-  createOpenWindow
-} from '@background/create-open-window';
+import { createOpenWindow } from '@background/create-open-window';
 
-import { reportUiError } from '@libs/ui/components/saga-error-banner/ui-error-channel';
+import { createReportingOpenWindow } from './create-reporting-open-window';
 
 /**
  * Opens a deliberately separate window from a UI page (the import-account
@@ -16,29 +13,15 @@ import { reportUiError } from '@libs/ui/components/saga-error-banner/ui-error-ch
  * request lifecycle depends on. That slot is background-only, and the two
  * actions are excluded from the forwarding set accordingly.
  *
- * The returned `openWindow` never rejects: it reports the failure to the error
- * banner itself, so no call site can go back to discarding it.
+ * The returned `openWindow` never rejects: `createReportingOpenWindow` reports
+ * the failure to the error banner itself, so no call site can go back to
+ * discarding it.
  */
 export function useWindowManager() {
-  const openWindow = useMemo(() => {
-    const open = createOpenWindow();
-
-    return async (props: OpenWindowProps) => {
-      try {
-        await open(props);
-      } catch (error) {
-        // Name only, not the rejection: `searchParams` is embedded in the URL
-        // `windows.create` was given, and a sign-message plaintext can ride
-        // there. `use-ledger.ts` logs `error.name` for the same reason.
-        console.error(
-          'openWindow failed',
-          props.windowApp,
-          (error as Error)?.name
-        );
-        reportUiError('window-open-failed', props.windowApp);
-      }
-    };
-  }, []);
+  const openWindow = useMemo(
+    () => createReportingOpenWindow(createOpenWindow()),
+    []
+  );
 
   return { openWindow };
 }

--- a/src/libs/layout/error/window-page.tsx
+++ b/src/libs/layout/error/window-page.tsx
@@ -59,12 +59,17 @@ export function WindowErrorPage({
             color="primaryBlue"
             onClick={async () => {
               if (error instanceof PasswordDoesNotExistError) {
-                try {
-                  dispatchToMainStore(resetVault());
-                  closeCurrentWindow();
-                  openOnboardingUi();
+                // Awaited: tearing this window down first would destroy the
+                // error banner with it and drop the user into onboarding
+                // believing the vault had been reset. The `try/catch` that used
+                // to wrap this caught nothing — all three calls were unawaited.
+                if (!(await dispatchToMainStore(resetVault()))) {
                   return;
-                } catch (e) {}
+                }
+
+                closeCurrentWindow();
+                openOnboardingUi();
+                return;
               }
 
               return location?.state?.errorRedirectPath != null

--- a/src/libs/layout/reset-vault/index.tsx
+++ b/src/libs/layout/reset-vault/index.tsx
@@ -27,8 +27,12 @@ export const ResetVaultPage = ({ popupLayout }: ResetVaultPageProps) => {
   const { t } = useTranslation();
 
   function handleResetVault() {
-    dispatchToMainStore(resetVault()).then(() => {
-      closeWindowByReloadExtension();
+    dispatchToMainStore(resetVault()).then(dispatched => {
+      // Reloading on a dropped dispatch would present an unperformed reset as
+      // done, and take the error banner down with the page.
+      if (dispatched) {
+        closeWindowByReloadExtension();
+      }
     });
   }
 

--- a/src/libs/ui/components/account-list/account-list.tsx
+++ b/src/libs/ui/components/account-list/account-list.tsx
@@ -121,7 +121,7 @@ export const AccountList = ({ closeModal }: AccountListProps) => {
               openWindow({
                 windowApp: WindowApp.ImportAccount,
                 isNewWindow: true
-              }).catch(e => console.error(e));
+              });
             }}
           >
             <Trans t={t}>Import account</Trans>

--- a/src/libs/ui/components/saga-error-banner/saga-error-banner.test.tsx
+++ b/src/libs/ui/components/saga-error-banner/saga-error-banner.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ThemeProvider } from 'styled-components';
+
+import { lightTheme } from '@libs/ui/theme-config';
+
+import { SagaErrorBanner } from './saga-error-banner';
+import {
+  dismissUiError,
+  getUiErrorsSnapshot,
+  reportUiError
+} from './ui-error-channel';
+
+// The banner pulls the `@libs/layout` / `@libs/ui/components` barrels, and those
+// transitively load two modules that cannot survive this environment:
+// `webextension-polyfill` throws on import outside an extension, and
+// `mac-scrollbar` ships only an ESM entry (no `main`), which jest cannot resolve.
+// The banner itself touches neither.
+jest.mock('webextension-polyfill', () => ({
+  windows: {},
+  runtime: {},
+  tabs: {},
+  storage: { local: {} }
+}));
+
+jest.mock(
+  'mac-scrollbar',
+  () => ({
+    __esModule: true,
+    MacScrollbar: ({ children }: { children?: React.ReactNode }) => children,
+    GlobalScrollbar: () => null
+  }),
+  // `virtual` because jest cannot resolve the real module either — a plain
+  // factory mock still resolves the path first.
+  { virtual: true }
+);
+
+// jest runs in 'node' here — no jsdom. `renderToStaticMarkup` is how this repo
+// tests components (see remote-icon.test.tsx / svg-icon.test.tsx).
+jest.mock('react-inlinesvg', () => ({
+  __esModule: true,
+  default: () => null
+}));
+
+// `t` returns its key so the assertions read as the English copy.
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  Trans: ({ children }: { children: React.ReactNode }) => children
+}));
+
+// The banner's background half reads the replica store through `useSelector`.
+// Feeding the selector a fake state is lighter than standing up a Provider, and
+// it keeps this suite about the merge, not about redux.
+let fakeState: unknown;
+
+jest.mock('react-redux', () => ({
+  useSelector: (selector: (state: unknown) => unknown) => selector(fakeState)
+}));
+
+// Importing the real module would pull in `webextension-polyfill`, which throws
+// outside an extension. Dismissing a background row is not what this suite tests.
+jest.mock('@background/redux/utils', () => ({
+  dispatchToMainStore: jest.fn()
+}));
+
+const withNoBackgroundErrors = () => {
+  fakeState = {
+    appEvents: { errors: [], dismissedEventIds: [], nextErrorId: 1 }
+  };
+};
+
+const withBackgroundError = () => {
+  fakeState = {
+    appEvents: {
+      errors: [
+        { id: 1, source: 'lockVaultSaga', message: 'vault would not lock' }
+      ],
+      dismissedEventIds: [],
+      nextErrorId: 2
+    }
+  };
+};
+
+// `renderToStaticMarkup` escapes the apostrophe in the copy to `&#x27;`. Decode
+// it so the assertions read as the text a user actually sees.
+const render = () =>
+  renderToStaticMarkup(
+    <ThemeProvider theme={lightTheme}>
+      <SagaErrorBanner />
+    </ThemeProvider>
+  ).replace(/&#x27;/g, "'");
+
+describe('SagaErrorBanner', () => {
+  afterEach(() => {
+    getUiErrorsSnapshot().forEach(error => dismissUiError(error.id));
+  });
+
+  it('renders nothing when neither channel has an error', () => {
+    withNoBackgroundErrors();
+
+    expect(render()).toBe('');
+  });
+
+  it('renders a background saga error as before', () => {
+    withBackgroundError();
+
+    const html = render();
+
+    expect(html).toContain('lockVaultSaga');
+    expect(html).toContain('vault would not lock');
+  });
+
+  it('renders a dropped dispatch with translated copy and no action type', () => {
+    // The action type is a developer identifier: it names no dapp and suggests
+    // no next step, so it stays in the console.
+    withNoBackgroundErrors();
+    reportUiError('dispatch-failed', 'LOCK_VAULT_SAGA');
+
+    const html = render();
+
+    expect(html).toContain(
+      "Couldn't reach the wallet. Nothing was changed — please try again."
+    );
+    expect(html).not.toContain('LOCK_VAULT_SAGA');
+  });
+
+  it('renders a failed window open with its own copy', () => {
+    withNoBackgroundErrors();
+    reportUiError('window-open-failed', 'ImportAccount');
+
+    const html = render();
+
+    expect(html).toContain("Couldn't open the window. Please try again.");
+    expect(html).not.toContain('ImportAccount');
+  });
+
+  it('renders both channels at once', () => {
+    withBackgroundError();
+    reportUiError('dispatch-failed', 'LOCK_VAULT_SAGA');
+
+    const html = render();
+
+    expect(html).toContain('vault would not lock');
+    expect(html).toContain("Couldn't reach the wallet");
+  });
+});

--- a/src/libs/ui/components/saga-error-banner/saga-error-banner.test.tsx
+++ b/src/libs/ui/components/saga-error-banner/saga-error-banner.test.tsx
@@ -11,30 +11,6 @@ import {
   reportUiError
 } from './ui-error-channel';
 
-// The banner pulls the `@libs/layout` / `@libs/ui/components` barrels, and those
-// transitively load two modules that cannot survive this environment:
-// `webextension-polyfill` throws on import outside an extension, and
-// `mac-scrollbar` ships only an ESM entry (no `main`), which jest cannot resolve.
-// The banner itself touches neither.
-jest.mock('webextension-polyfill', () => ({
-  windows: {},
-  runtime: {},
-  tabs: {},
-  storage: { local: {} }
-}));
-
-jest.mock(
-  'mac-scrollbar',
-  () => ({
-    __esModule: true,
-    MacScrollbar: ({ children }: { children?: React.ReactNode }) => children,
-    GlobalScrollbar: () => null
-  }),
-  // `virtual` because jest cannot resolve the real module either — a plain
-  // factory mock still resolves the path first.
-  { virtual: true }
-);
-
 // jest runs in 'node' here — no jsdom. `renderToStaticMarkup` is how this repo
 // tests components (see remote-icon.test.tsx / svg-icon.test.tsx).
 jest.mock('react-inlinesvg', () => ({
@@ -119,7 +95,7 @@ describe('SagaErrorBanner', () => {
     const html = render();
 
     expect(html).toContain(
-      "Couldn't reach the wallet. Nothing was changed — please try again."
+      "The wallet didn't respond. Your last action may not have been applied."
     );
     expect(html).not.toContain('LOCK_VAULT_SAGA');
   });
@@ -141,6 +117,6 @@ describe('SagaErrorBanner', () => {
     const html = render();
 
     expect(html).toContain('vault would not lock');
-    expect(html).toContain("Couldn't reach the wallet");
+    expect(html).toContain("The wallet didn't respond");
   });
 });

--- a/src/libs/ui/components/saga-error-banner/saga-error-banner.tsx
+++ b/src/libs/ui/components/saga-error-banner/saga-error-banner.tsx
@@ -74,10 +74,29 @@ const DismissButton = styled.button`
 // The channel carries a `kind`, not a string, so the copy lives here where `t`
 // does. Unlike `SagaError.message` — produced in the background and rendered
 // verbatim and untranslated — these lines are ours to write.
-const UI_ERROR_COPY: Record<UiErrorKind, string> = {
-  'dispatch-failed':
-    "Couldn't reach the wallet. Nothing was changed — please try again.",
-  'window-open-failed': "Couldn't open the window. Please try again."
+//
+// Literal `<Trans>` per kind rather than a lookup keyed on `kind`: a dynamic key
+// is invisible to i18next-parser, so these two strings would never reach any
+// catalog.
+//
+// The dispatch copy claims neither that nothing changed nor that retrying helps.
+// Both would be false somewhere: `handleReduxAction` dispatches `resetVault`
+// before awaiting `enableOnboardingFlow`, so a rejection can arrive with the
+// vault already wiped, and `use-ledger` sets `triggeredRef` right after its
+// dispatch, so that effect cannot re-run.
+const UiErrorMessage = ({ kind }: { kind: UiErrorKind }) => {
+  const { t } = useTranslation();
+
+  if (kind === 'dispatch-failed') {
+    return (
+      <Trans t={t}>
+        The wallet didn&apos;t respond. Your last action may not have been
+        applied.
+      </Trans>
+    );
+  }
+
+  return <Trans t={t}>Couldn&apos;t open the window. Please try again.</Trans>;
 };
 
 export const SagaErrorBanner = () => {
@@ -142,7 +161,7 @@ export const SagaErrorBanner = () => {
               <Trans t={t}>Something went wrong</Trans>
             </Typography>
             <Typography type="captionRegular" color="contentSecondary">
-              {t(UI_ERROR_COPY[uiError.kind])}
+              <UiErrorMessage kind={uiError.kind} />
             </Typography>
           </ErrorTextContainer>
           <DismissButton

--- a/src/libs/ui/components/saga-error-banner/saga-error-banner.tsx
+++ b/src/libs/ui/components/saga-error-banner/saga-error-banner.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useSyncExternalStore } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
@@ -8,8 +8,22 @@ import { selectSagaErrors } from '@background/redux/app-events/selectors';
 import { SagaError } from '@background/redux/app-events/types';
 import { dispatchToMainStore } from '@background/redux/utils';
 
-import { AlignedFlexRow, FlexColumn, SpacingSize } from '@libs/layout';
-import { SvgIcon, Typography } from '@libs/ui/components';
+import {
+  AlignedFlexRow,
+  FlexColumn,
+  SpacingSize
+} from '@libs/layout/containers';
+import { SvgIcon } from '@libs/ui/components/svg-icon/svg-icon';
+import { Typography } from '@libs/ui/components/typography/typography';
+
+import {
+  UiError,
+  UiErrorKind,
+  dismissUiError,
+  getUiErrorsServerSnapshot,
+  getUiErrorsSnapshot,
+  subscribeToUiErrors
+} from './ui-error-channel';
 
 const BannerContainer = styled(FlexColumn)`
   position: fixed;
@@ -57,17 +71,36 @@ const DismissButton = styled.button`
   cursor: pointer;
 `;
 
+// The channel carries a `kind`, not a string, so the copy lives here where `t`
+// does. Unlike `SagaError.message` — produced in the background and rendered
+// verbatim and untranslated — these lines are ours to write.
+const UI_ERROR_COPY: Record<UiErrorKind, string> = {
+  'dispatch-failed':
+    "Couldn't reach the wallet. Nothing was changed — please try again.",
+  'window-open-failed': "Couldn't open the window. Please try again."
+};
+
 export const SagaErrorBanner = () => {
   const { t } = useTranslation();
 
   const errors = useSelector(selectSagaErrors);
+  const uiErrors = useSyncExternalStore(
+    subscribeToUiErrors,
+    getUiErrorsSnapshot,
+    // Required: this component is rendered with `renderToStaticMarkup` in tests.
+    getUiErrorsServerSnapshot
+  );
 
-  if (errors.length === 0) {
+  if (errors.length === 0 && uiErrors.length === 0) {
     return null;
   }
 
   const handleDismiss = (id: SagaError['id']) => {
     dispatchToMainStore(dismissSagaError(id));
+  };
+
+  const handleDismissUiError = (id: UiError['id']) => {
+    dismissUiError(id);
   };
 
   return (
@@ -92,6 +125,31 @@ export const SagaErrorBanner = () => {
             aria-label={t('Dismiss')}
             title={t('Dismiss')}
             onClick={() => handleDismiss(error.id)}
+          >
+            <SvgIcon src="assets/icons/close.svg" size={16} />
+          </DismissButton>
+        </ErrorRow>
+      ))}
+      {uiErrors.map(uiError => (
+        <ErrorRow key={`ui-${uiError.id}`} gap={SpacingSize.Small}>
+          <SvgIcon
+            src="assets/icons/error.svg"
+            size={20}
+            color="contentActionCritical"
+          />
+          <ErrorTextContainer gap={SpacingSize.Tiny}>
+            <Typography type="bodySemiBold">
+              <Trans t={t}>Something went wrong</Trans>
+            </Typography>
+            <Typography type="captionRegular" color="contentSecondary">
+              {t(UI_ERROR_COPY[uiError.kind])}
+            </Typography>
+          </ErrorTextContainer>
+          <DismissButton
+            type="button"
+            aria-label={t('Dismiss')}
+            title={t('Dismiss')}
+            onClick={() => handleDismissUiError(uiError.id)}
           >
             <SvgIcon src="assets/icons/close.svg" size={16} />
           </DismissButton>

--- a/src/libs/ui/components/saga-error-banner/ui-error-channel.test.ts
+++ b/src/libs/ui/components/saga-error-banner/ui-error-channel.test.ts
@@ -1,0 +1,129 @@
+import {
+  dismissUiError,
+  getUiErrorsServerSnapshot,
+  getUiErrorsSnapshot,
+  reportUiError,
+  subscribeToUiErrors
+} from './ui-error-channel';
+
+// The channel is a module singleton by design (`dispatchToMainStore` is a plain
+// function, not a hook, so it cannot reach a React store). Clean up through the
+// public API rather than exporting a test-only reset.
+afterEach(() => {
+  getUiErrorsSnapshot().forEach(error => dismissUiError(error.id));
+});
+
+describe('ui-error-channel', () => {
+  it('starts empty', () => {
+    expect(getUiErrorsSnapshot()).toEqual([]);
+  });
+
+  it('reports an error with its kind and a key built from the detail', () => {
+    reportUiError('dispatch-failed', 'OPEN_EXPORT_KEYS_WINDOW_SAGA');
+
+    expect(getUiErrorsSnapshot()).toEqual([
+      {
+        id: expect.any(Number),
+        kind: 'dispatch-failed',
+        key: 'dispatch-failed:OPEN_EXPORT_KEYS_WINDOW_SAGA'
+      }
+    ]);
+  });
+
+  it('dedupes repeats of the same key into one row', () => {
+    // The service worker restarting while the user clicks three times is the
+    // normal shape of this failure, and the popup is too narrow for three
+    // identical rows.
+    reportUiError('dispatch-failed', 'LOCK_VAULT_SAGA');
+    reportUiError('dispatch-failed', 'LOCK_VAULT_SAGA');
+    reportUiError('dispatch-failed', 'LOCK_VAULT_SAGA');
+
+    expect(getUiErrorsSnapshot()).toHaveLength(1);
+  });
+
+  it('keeps different keys apart', () => {
+    reportUiError('dispatch-failed', 'LOCK_VAULT_SAGA');
+    reportUiError('window-open-failed', 'ImportAccount');
+
+    expect(getUiErrorsSnapshot().map(error => error.key)).toEqual([
+      'dispatch-failed:LOCK_VAULT_SAGA',
+      'window-open-failed:ImportAccount'
+    ]);
+  });
+
+  it('returns a stable snapshot reference until something changes', () => {
+    // useSyncExternalStore re-renders forever if getSnapshot returns a fresh
+    // array each call.
+    reportUiError('dispatch-failed', 'LOCK_VAULT_SAGA');
+    const first = getUiErrorsSnapshot();
+
+    expect(getUiErrorsSnapshot()).toBe(first);
+
+    reportUiError('window-open-failed', 'ImportAccount');
+
+    expect(getUiErrorsSnapshot()).not.toBe(first);
+  });
+
+  it('does not allocate a new snapshot for a deduped repeat', () => {
+    reportUiError('dispatch-failed', 'LOCK_VAULT_SAGA');
+    const first = getUiErrorsSnapshot();
+
+    reportUiError('dispatch-failed', 'LOCK_VAULT_SAGA');
+
+    expect(getUiErrorsSnapshot()).toBe(first);
+  });
+
+  it('notifies subscribers on report and on dismiss, and stops after unsubscribe', () => {
+    const onChange = jest.fn();
+    const unsubscribe = subscribeToUiErrors(onChange);
+
+    reportUiError('dispatch-failed', 'LOCK_VAULT_SAGA');
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    const [error] = getUiErrorsSnapshot();
+    dismissUiError(error.id);
+    expect(onChange).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    reportUiError('dispatch-failed', 'LOCK_VAULT_SAGA');
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not notify subscribers for a deduped repeat', () => {
+    reportUiError('dispatch-failed', 'LOCK_VAULT_SAGA');
+    const onChange = jest.fn();
+    const unsubscribe = subscribeToUiErrors(onChange);
+
+    reportUiError('dispatch-failed', 'LOCK_VAULT_SAGA');
+
+    expect(onChange).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it('ignores a dismiss for an id that is not there', () => {
+    reportUiError('dispatch-failed', 'LOCK_VAULT_SAGA');
+    const before = getUiErrorsSnapshot();
+
+    dismissUiError(9999);
+
+    expect(getUiErrorsSnapshot()).toBe(before);
+  });
+
+  it('reports a key again after it was dismissed', () => {
+    // Deliberate: a failure the user acknowledged and then hit again is news.
+    reportUiError('dispatch-failed', 'LOCK_VAULT_SAGA');
+    dismissUiError(getUiErrorsSnapshot()[0].id);
+
+    reportUiError('dispatch-failed', 'LOCK_VAULT_SAGA');
+
+    expect(getUiErrorsSnapshot()).toHaveLength(1);
+  });
+
+  it('gives the same snapshot to the server renderer', () => {
+    // useSyncExternalStore throws "Missing getServerSnapshot" under
+    // renderToStaticMarkup, which is how this repo tests components.
+    reportUiError('dispatch-failed', 'LOCK_VAULT_SAGA');
+
+    expect(getUiErrorsServerSnapshot()).toBe(getUiErrorsSnapshot());
+  });
+});

--- a/src/libs/ui/components/saga-error-banner/ui-error-channel.test.ts
+++ b/src/libs/ui/components/saga-error-banner/ui-error-channel.test.ts
@@ -1,4 +1,5 @@
 import {
+  clearUiError,
   dismissUiError,
   getUiErrorsServerSnapshot,
   getUiErrorsSnapshot,
@@ -117,6 +118,36 @@ describe('ui-error-channel', () => {
     reportUiError('dispatch-failed', 'LOCK_VAULT_SAGA');
 
     expect(getUiErrorsSnapshot()).toHaveLength(1);
+  });
+
+  it('clears the row whose failure has stopped being true', () => {
+    reportUiError('dispatch-failed', 'INIT_VAULT_SAGA');
+    reportUiError('window-open-failed', 'ImportAccount');
+
+    clearUiError('dispatch-failed', 'INIT_VAULT_SAGA');
+
+    expect(getUiErrorsSnapshot().map(error => error.key)).toEqual([
+      'window-open-failed:ImportAccount'
+    ]);
+  });
+
+  it('notifies subscribers when a row is cleared, and not otherwise', () => {
+    reportUiError('dispatch-failed', 'INIT_VAULT_SAGA');
+    const onChange = jest.fn();
+    const unsubscribe = subscribeToUiErrors(onChange);
+
+    // The success path runs on all ~105 dispatches, almost always with nothing
+    // to clear: no allocation and no re-render for those.
+    const before = getUiErrorsSnapshot();
+    clearUiError('dispatch-failed', 'LOCK_VAULT_SAGA');
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(getUiErrorsSnapshot()).toBe(before);
+
+    clearUiError('dispatch-failed', 'INIT_VAULT_SAGA');
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    unsubscribe();
   });
 
   it('gives the same snapshot to the server renderer', () => {

--- a/src/libs/ui/components/saga-error-banner/ui-error-channel.ts
+++ b/src/libs/ui/components/saga-error-banner/ui-error-channel.ts
@@ -1,0 +1,63 @@
+// Errors that never reach the background store, and so can never arrive as a
+// `sagaError`: the transport to the background is the thing that failed. The
+// replica store cannot hold them either — `createMainStoreReplica(state)` runs
+// in the render body of every app's `Tree`, so a local dispatch is discarded on
+// the next broadcast. Hence a module store the banner reads directly.
+export type UiErrorKind = 'dispatch-failed' | 'window-open-failed';
+
+export interface UiError {
+  id: number;
+  kind: UiErrorKind;
+  key: string;
+}
+
+let errors: UiError[] = [];
+let nextId = 1;
+const listeners = new Set<() => void>();
+
+function emit() {
+  listeners.forEach(listener => listener());
+}
+
+// Carries a `kind`, not a message: the callers (`dispatchToMainStore`, the
+// window-manager hook) are plain functions with no access to `t()`. The banner
+// owns the copy.
+export function reportUiError(kind: UiErrorKind, detail: string) {
+  const key = `${kind}:${detail}`;
+
+  if (errors.some(error => error.key === key)) {
+    return;
+  }
+
+  errors = [...errors, { id: nextId++, kind, key }];
+  emit();
+}
+
+export function dismissUiError(id: number) {
+  const next = errors.filter(error => error.id !== id);
+
+  if (next.length === errors.length) {
+    return;
+  }
+
+  errors = next;
+  emit();
+}
+
+export function subscribeToUiErrors(onChange: () => void) {
+  listeners.add(onChange);
+
+  return () => {
+    listeners.delete(onChange);
+  };
+}
+
+// Both must return a reference that only changes when the list does, or
+// `useSyncExternalStore` re-renders on every check.
+export function getUiErrorsSnapshot() {
+  return errors;
+}
+
+export function getUiErrorsServerSnapshot() {
+  return errors;
+}

--- a/src/libs/ui/components/saga-error-banner/ui-error-channel.ts
+++ b/src/libs/ui/components/saga-error-banner/ui-error-channel.ts
@@ -33,6 +33,22 @@ export function reportUiError(kind: UiErrorKind, detail: string) {
   emit();
 }
 
+// The counterpart of `reportUiError`, called from the same callers' success
+// paths. Without it a row outlives the failure it describes: the guards keep the
+// user on the page to retry, and the retry that works renders the success screen
+// under a banner still saying the wallet didn't respond — the key dedupe means it
+// would not even be refreshed, just left.
+export function clearUiError(kind: UiErrorKind, detail: string) {
+  const key = `${kind}:${detail}`;
+
+  if (!errors.some(error => error.key === key)) {
+    return;
+  }
+
+  errors = errors.filter(error => error.key !== key);
+  emit();
+}
+
 export function dismissUiError(id: number) {
   const next = errors.filter(error => error.id !== id);
 

--- a/src/libs/ui/components/typography/typography.tsx
+++ b/src/libs/ui/components/typography/typography.tsx
@@ -2,9 +2,10 @@ import isPropValid from '@emotion/is-prop-valid';
 import React, { forwardRef } from 'react';
 import styled, { CSSObject, DefaultTheme } from 'styled-components';
 
-import { Skeleton } from '@libs/ui/components';
 import { BaseProps } from '@libs/ui/types';
 import { ContentColor, getColorFromTheme } from '@libs/ui/utils';
+
+import { Skeleton } from '../skeleton/skeleton';
 
 type Ref = HTMLSpanElement | HTMLHeadingElement;
 


### PR DESCRIPTION
Closes [WALLET-1390](https://make-software.atlassian.net/browse/WALLET-1390).

Completes WALLET-1364 P1 #2/#3. That work made the _in-saga_ failure loud; two adjacent halves of the same journey stayed silent, so "the user clicks and nothing happens" was still reachable after it shipped.

## Why this needed a new surface rather than a `sagaError`

A `sagaError` cannot report a transport failure: it lives in the background store, and the background store is precisely what is unreachable when `runtime.sendMessage` rejects — the dispatch that would report the error is the dispatch that failed.

The replica cannot hold one either. `createMainStoreReplica(state)` runs in the _render body_ of every app's `Tree` (`popup/index.tsx:50` and four siblings), so a new store is built on every broadcast and any locally dispatched action is discarded on the next one.

So the errors live in a small module store, `ui-error-channel.ts`, which the already-mounted `SagaErrorBanner` reads through `useSyncExternalStore`. One surface, two inputs — not a second banner. It carries a `kind` rather than a message, because its callers are plain functions with no access to `t()`; the component owns the copy.

## Transport half

`dispatchToMainStore` now resolves `true` / `false` and still **never rejects** — ~105 call sites do not catch, so rejecting would produce an unhandled rejection at each of them. The log stays universal (type + cause, never the action); the _banner_ is filtered by an allow-list.

`SURFACED_DISPATCH_ACTIONS` has one written-down criterion: the dispatch IS the sole source of the visible result. Seven actions qualify — the export-keys window (the case from the ticket), `lockVault` (the wallet stays unlocked, a security outcome rather than an inconvenience), the Ledger window attach, `resetVault`, `accountsImported` / `accountImported`, and `dismissSagaError` (without it, pressing × on a background row while the transport is down does nothing and explains nothing). A banner on all ~105 sites — theme changes and the like — would train the user to ignore the banner.

The list is built from the creators' `.type` (a rename is a compile error) and pinned by a test, so growing or shrinking it is a deliberate edit. It adds no import cycle — `redux/utils.ts` already imports `redux-action.ts`, which pulls every slice's actions — verified with `dependency:circular` (140 before, 140 after) and `import/no-cycle`.

## Nine call sites that reported failure as success

Chaining `.then` was only half of it; the paths that dispatch and continue without chaining had the same bug.

| Site                              | On a dropped dispatch, before                                                                                                                       |
| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
| `reset-vault`                     | `closeWindowByReloadExtension()` reloaded the extension, presenting an unperformed vault reset as complete and taking the banner down with the page |
| `onboarding/welcome`              | advanced to create-password on a vault that was never reset                                                                                         |
| `connected-ledger`                | navigated Home with nothing imported                                                                                                                |
| `import-account-with-file-upload` | navigated to its success screen for an import that never reached the vault                                                                          |
| `import-account-from-torus`       | set its success step, same                                                                                                                          |
| `onboarding/create-secret-phrase` | back button navigated to create-password with the generated phrase still alive — the user would set a password over a phrase they never recorded    |
| `layout/error/window-page`        | tore the window down, then dropped the user into onboarding believing the vault was reset                                                           |

All now branch on the verdict. `onboarding/reset-wallet` needs no guard: it dispatches and navigates nowhere, so the banner is the whole fix there.

The error page also loses its `try/catch`: all three calls inside it were unawaited, so it never caught anything.

## UI half

The two identical `.catch(e => console.error(e))` handlers around `openWindow` are gone. Reporting moved _into_ `useWindowManager`, so the returned `openWindow` never rejects and a third call site cannot reintroduce the swallow. It logs `error.name`, not the rejection: the URL `windows.create` is given embeds `OpenWindowProps.searchParams`, where a sign-message plaintext can ride on other window paths, and semgrep's `cw-logging-secrets` pattern would not catch that.

## The copy says only what is true

One string serves five unrelated actions, so it claims neither that nothing changed nor that retrying helps. Both would be false somewhere: `handleReduxAction` dispatches `resetVault` into the store and only then awaits `enableOnboardingFlow`, so a rejection can arrive with the vault already wiped; and `use-ledger` sets `triggeredRef.current` immediately after its dispatch, so that effect cannot re-run. It reads: _The wallet didn't respond. Your last action may not have been applied._

Each kind renders a literal `<Trans>` rather than a `t()` lookup keyed on `kind` — a dynamic key is invisible to i18next-parser, so the strings would never reach a catalog. No extraction run here (`lang/` is far behind); they ship with their English fallback.

## Two import changes, and why they are here

`SagaErrorBanner` takes its layout primitives from `@libs/layout/containers` and its `SvgIcon` / `Typography` directly, and `typography.tsx` takes `Skeleton` from its sibling instead of from the `@libs/ui/components` barrel — a barrel importing itself back, which is what `containers.ts` warns about in its own header comment ("cause huge problems with webpack bundle and lead to blank popups").

That was also what made the component untestable: the barrels transitively load `webextension-polyfill`, which throws on import outside an extension, and `mac-scrollbar`, which ships only an ESM entry with no `main` that jest cannot resolve. It is why no barrel-importing component in this repo has had a test. Breaking the chain was cheaper and more useful than three mocks plus a `jest.config.js` change — and since it touches a component used app-wide, it is verified against a production `build:chrome`.

## Tests

- `ui-error-channel` — dedupe by key, snapshot-reference stability (a fresh array each call would re-render forever), no allocation on a deduped repeat, subscribe/unsubscribe, re-report after dismiss, server snapshot.
- `SURFACED_DISPATCH_ACTIONS` — pin, checked by mutation: dropping an entry fails the test.
- `dispatchToMainStore` — `true` on success, `false` instead of a rejection, log shape, allow-listed action surfaces, non-allow-listed action logs only.
- `SagaErrorBanner` — rendered with `renderToStaticMarkup` for each channel separately and both at once, asserting the action type never reaches the markup.

`ci-check` green: 87 suites, 763 tests, knip clean.

## The dispatch→banner seam is covered by e2e

`e2e-tests/popup/error-surface/dropped-dispatch.spec.ts` drives the real extension: it breaks the page's transport to the background, clicks the menu item, and asserts the banner. Four cases — banner on a dropped export-keys dispatch (and that no window opens), no banner for a non-surfaced action, dismiss-then-reappear, and the failed window open. 4/4 green in ~13s.

Three things that had to be established by running it, and are recorded in the file:

- **The break has to be a rejected promise, not a synchronous throw.** Current Chrome exposes `browser` natively, so `webextension-polyfill` re-exports it instead of wrapping `chrome`, and the app calls the patched function directly. A `throw` escapes synchronously out of `dispatchToMainStore` and trips the ErrorBoundary — the popup renders "Something went wrong" and no banner is involved at all.
- **Stopping the service worker does not reproduce this.** In MV3 an incoming message is itself the event that cold-starts a stopped worker, and while the vault is unlocked the keep-alive alarm wakes it within 30s regardless.
- **`unlockVault` returns before the unlock finishes** (it waits only for network idle; the flow completes through further dispatches from the page), so the transport must not be broken until the unlocked UI is up.

## One finding worth a decision, not fixed here

While a banner row is visible it **covers the header**, including the menu button. Measured: the banner is `position: fixed; top: 0` at a tooltip z-index, occupying 1280×77 over a menu icon at y=24..48, and `elementFromPoint` at the icon's centre returns the banner. So the user cannot reopen the menu to retry until they dismiss the row — the × is right there, so it is one extra click rather than a dead end.

This is pre-existing `SagaErrorBanner` layout, not something this PR introduces, but this PR is what makes the banner routine rather than rare. Fixing it means either pushing page content down by the banner height or moving the banner out of the header's strip — a visual change worth a deliberate call rather than a drive-by. It is also why the dedupe case lives in the unit test instead of e2e: a second menu click cannot land while the row is up.

## Deliberately left out

- **`loginRetryLockoutTimeSet`** (`use-lock-wallet-when-no-more-retries.ts:26`) is the dispatch that actually enforces the brute-force lockout, and it is not surfaced. A banner would tell the truth and change nothing: the effect's deps cannot change, so there is no retry path, and the real fix is not letting the lockout depend on a droppable dispatch. Worth its own ticket.
- **Layering**: `redux/utils.ts` now imports from `@libs/ui/...`, so the channel would ride into the service-worker bundle. Not reachable today — no background module calls `dispatchToMainStore` — but it inverts the background→UI direction. Fixing it properly means injecting the reporter, which is more machinery than the problem currently justifies.
- No change to the `app-events` slice or `SagaErrorSource`: local errors deliberately do not survive a reload.


[WALLET-1390]: https://make-software.atlassian.net/browse/WALLET-1390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ