### PR TITLE
test: WALLET-1364 — close the test-coverage gaps

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -69,14 +69,14 @@ module.exports = {
       lines: 95,
       statements: 95
     },
-    // Sagas — vault-sagas is partly tested (Task 8.1); onboarding/network/
-    // trusted-wasm sagas remain untested for now. Floor set to achieved (~48%
-    // stmts/lines, ~47% branch, ~37% funcs) so the gate is real, not fiction.
+    // Sagas — vault-sagas is now broadly covered (account-derivation collision loop
+    // and all sagaError paths); onboarding/check-casper2-network/trusted-wasm remain untested.
+    // Floor set to achieved.
     './src/background/redux/sagas/': {
-      branches: 45,
-      functions: 35,
-      lines: 45,
-      statements: 45
+      branches: 74,
+      functions: 63,
+      lines: 79,
+      statements: 79
     }
   },
   testPathIgnorePatterns: ['e2e-tests/']

--- a/src/apps/popup/pages/download-account-keys/index.tsx
+++ b/src/apps/popup/pages/download-account-keys/index.tsx
@@ -1,4 +1,3 @@
-import JSZip from 'jszip';
 import React, { useCallback, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -6,7 +5,6 @@ import { PasswordProtectionPage } from '@popup/pages/password-protection-page';
 
 import { closeExportKeysSurface } from '@background/open-export-keys-surface';
 
-import { createAsymmetricKeys } from '@libs/crypto/create-asymmetric-key';
 import {
   FooterButtonsContainer,
   HeaderPopup,
@@ -19,8 +17,9 @@ import { Button } from '@libs/ui/components';
 import { Download } from './download';
 import { Failure } from './failure';
 import { Instruction } from './instruction';
+import { runKeysDownload } from './run-keys-download';
 import { Success } from './success';
-import { DownloadAccountKeysSteps, downloadFile } from './utils';
+import { DownloadAccountKeysSteps } from './utils';
 
 export const DownloadAccountKeysPage = () => {
   const [isPasswordConfirmed, setIsPasswordConfirmed] =
@@ -47,38 +46,8 @@ export const DownloadAccountKeysPage = () => {
     );
   }
 
-  const downloadKeys = async () => {
-    try {
-      const zip = new JSZip();
-
-      for (const account of selectedAccounts) {
-        const asymmetricKey = createAsymmetricKeys(
-          account.publicKey,
-          account.secretKey
-        );
-
-        if (asymmetricKey.secretKey) {
-          const file = asymmetricKey.secretKey.toPem();
-          zip.file(`${account.name}_secret_key.pem`, file);
-        }
-      }
-
-      const content = await zip.generateAsync({ type: 'blob' });
-      downloadFile(new Blob([content]), 'casper-wallet-secret_keys.zip');
-
-      setDownloadAccountKeysStep(DownloadAccountKeysSteps.Success);
-    } catch (error) {
-      // Only the error name is logged — the thrown value is built from key
-      // material and must not reach the console. Nothing collects these logs
-      // (the project has no Sentry or equivalent), so the Failure step below is
-      // the only way this reaches anyone.
-      console.error(
-        'downloadKeys: failed to build or download the keys archive',
-        error instanceof Error ? error.name : 'unknown error'
-      );
-      setDownloadAccountKeysStep(DownloadAccountKeysSteps.Failure);
-    }
-  };
+  const downloadKeys = () =>
+    runKeysDownload(selectedAccounts, setDownloadAccountKeysStep);
 
   const content = {
     [DownloadAccountKeysSteps.Instruction]: <Instruction />,

--- a/src/apps/popup/pages/download-account-keys/run-keys-download.test.ts
+++ b/src/apps/popup/pages/download-account-keys/run-keys-download.test.ts
@@ -1,0 +1,91 @@
+import { createAsymmetricKeys } from '@libs/crypto/create-asymmetric-key';
+import { AccountListRows } from '@libs/types/account';
+
+import { runKeysDownload } from './run-keys-download';
+import { DownloadAccountKeysSteps, downloadFile } from './utils';
+
+const zipFile = jest.fn();
+const generateAsync = jest.fn();
+
+jest.mock('jszip', () =>
+  jest.fn().mockImplementation(() => ({
+    file: zipFile,
+    generateAsync: generateAsync
+  }))
+);
+
+jest.mock('./utils', () => ({
+  ...jest.requireActual('./utils'),
+  downloadFile: jest.fn()
+}));
+
+jest.mock('@libs/crypto/create-asymmetric-key', () => ({
+  createAsymmetricKeys: jest.fn()
+}));
+
+const mockCreateKeys = createAsymmetricKeys as jest.Mock;
+const mockDownloadFile = downloadFile as jest.Mock;
+
+const account = (name: string): AccountListRows =>
+  ({
+    name,
+    publicKey: `01${name}`,
+    secretKey: `sk-${name}`
+  }) as AccountListRows;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  generateAsync.mockResolvedValue(new Uint8Array([1, 2, 3]));
+  mockCreateKeys.mockImplementation(() => ({
+    secretKey: { toPem: () => 'PEM' }
+  }));
+  jest.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+it('writes one pem per account and reports Success', async () => {
+  const setStep = jest.fn();
+
+  await runKeysDownload([account('alice'), account('bob')], setStep);
+
+  expect(zipFile).toHaveBeenCalledTimes(2);
+  expect(zipFile).toHaveBeenCalledWith('alice_secret_key.pem', 'PEM');
+  expect(mockDownloadFile).toHaveBeenCalledTimes(1);
+  expect(mockDownloadFile.mock.calls[0][1]).toBe(
+    'casper-wallet-secret_keys.zip'
+  );
+  expect(setStep).toHaveBeenCalledWith(DownloadAccountKeysSteps.Success);
+});
+
+// WALLET-1345: the user must never be told their keys were saved when the
+// archive never got built.
+it('routes a zip failure to Failure and never to Success', async () => {
+  generateAsync.mockRejectedValue(new Error('boom'));
+  const setStep = jest.fn();
+
+  await runKeysDownload([account('alice')], setStep);
+
+  expect(setStep).toHaveBeenCalledWith(DownloadAccountKeysSteps.Failure);
+  expect(setStep).not.toHaveBeenCalledWith(DownloadAccountKeysSteps.Success);
+  expect(mockDownloadFile).not.toHaveBeenCalled();
+});
+
+// The thrown value is built from key material, so only the error NAME may reach
+// the console.
+it('logs the error name only, never the error itself', async () => {
+  class SecretBearingError extends Error {
+    name = 'PemEncodeError';
+    message = 'secret key 0123456789abcdef';
+  }
+  generateAsync.mockRejectedValue(new SecretBearingError());
+  const setStep = jest.fn();
+
+  await runKeysDownload([account('alice')], setStep);
+
+  const logged = (console.error as jest.Mock).mock.calls[0];
+  expect(logged).toContain('PemEncodeError');
+  expect(JSON.stringify(logged)).not.toContain('0123456789abcdef');
+});

--- a/src/apps/popup/pages/download-account-keys/run-keys-download.ts
+++ b/src/apps/popup/pages/download-account-keys/run-keys-download.ts
@@ -1,0 +1,42 @@
+import JSZip from 'jszip';
+
+import { createAsymmetricKeys } from '@libs/crypto/create-asymmetric-key';
+import { AccountListRows } from '@libs/types/account';
+
+import { DownloadAccountKeysSteps, downloadFile } from './utils';
+
+export async function runKeysDownload(
+  accounts: AccountListRows[],
+  setStep: (step: DownloadAccountKeysSteps) => void
+): Promise<void> {
+  try {
+    const zip = new JSZip();
+
+    for (const account of accounts) {
+      const asymmetricKey = createAsymmetricKeys(
+        account.publicKey,
+        account.secretKey
+      );
+
+      if (asymmetricKey.secretKey) {
+        zip.file(
+          `${account.name}_secret_key.pem`,
+          asymmetricKey.secretKey.toPem()
+        );
+      }
+    }
+
+    const content = await zip.generateAsync({ type: 'blob' });
+    downloadFile(new Blob([content]), 'casper-wallet-secret_keys.zip');
+
+    setStep(DownloadAccountKeysSteps.Success);
+  } catch (error) {
+    // Only the error name is logged — the thrown value is built from key
+    // material and must not reach the console.
+    console.error(
+      'downloadKeys: failed to build or download the keys archive',
+      error instanceof Error ? error.name : 'unknown error'
+    );
+    setStep(DownloadAccountKeysSteps.Failure);
+  }
+}

--- a/src/background/create-open-window.test.ts
+++ b/src/background/create-open-window.test.ts
@@ -70,3 +70,123 @@ it('does NOT retarget the tracked window id for an isNewWindow open', async () =
   expect(result.reused).toBe(false);
   expect(setWindowId).not.toHaveBeenCalled();
 });
+
+// getUrlByWindowApp is the one hand-written branch table in this module: the
+// hash routes and the `?`-vs-`&` joining for SwitchAccount are both easy to
+// break and invisible until a window opens on the wrong screen.
+describe('window URLs', () => {
+  const urlFor = async (
+    windowApp: WindowApp,
+    searchParams?: Record<string, string>
+  ) => {
+    (windows.getAll as jest.Mock).mockResolvedValue([]);
+    await createOpenWindow({ windowId: null, setWindowId, clearWindowId })({
+      windowApp,
+      searchParams
+    });
+    return (
+      (windows.create as jest.Mock).mock.calls.at(-1)![0] as {
+        url: string;
+      }
+    ).url;
+  };
+
+  it.each([
+    [WindowApp.ImportAccount, 'import-account-with-file.html'],
+    [WindowApp.ConnectToApp, 'connect-to-app.html'],
+    [WindowApp.SignatureRequestDeploy, 'signature-request.html#'],
+    [WindowApp.SignatureRequestMessage, 'signature-request.html#'],
+    [WindowApp.SignatureRequestEip712, 'signature-request.html#'],
+    [WindowApp.DecryptMessageRequest, 'signature-request.html#']
+  ])('maps %s onto its own page', async (windowApp, prefix) => {
+    expect(await urlFor(windowApp)).toContain(prefix);
+  });
+
+  it('gives each signature-request variant a distinct hash route', async () => {
+    // Sequential, not Promise.all: urlFor reads mock.calls.at(-1), which
+    // races across concurrently in-flight calls sharing the same mock.
+    const routes = [
+      await urlFor(WindowApp.SignatureRequestDeploy),
+      await urlFor(WindowApp.SignatureRequestMessage),
+      await urlFor(WindowApp.SignatureRequestEip712),
+      await urlFor(WindowApp.DecryptMessageRequest)
+    ];
+
+    expect(new Set(routes).size).toBe(4);
+  });
+
+  it('appends search params with ? for a plain app', async () => {
+    expect(await urlFor(WindowApp.ConnectToApp, { requestId: 'r1' })).toBe(
+      'connect-to-app.html?requestId=r1'
+    );
+  });
+
+  // SwitchAccount already carries a query string, so its params must join with
+  // & — a `?` here silently drops every param after the first.
+  it('joins search params with & for SwitchAccount', async () => {
+    expect(await urlFor(WindowApp.SwitchAccount, { requestId: 'r1' })).toBe(
+      'connect-to-app.html?switchAccount=true&requestId=r1'
+    );
+  });
+
+  it('emits no trailing ? when there are no params', async () => {
+    expect(await urlFor(WindowApp.ConnectToApp)).toBe('connect-to-app.html');
+  });
+});
+
+describe('a tracked window that is already gone', () => {
+  it('clears the tracked id and opens a fresh window', async () => {
+    (windows.getAll as jest.Mock).mockResolvedValue([{ id: 999 }]);
+
+    const result = await createOpenWindow({
+      windowId: 7,
+      setWindowId,
+      clearWindowId
+    })({ windowApp: WindowApp.ConnectToApp });
+
+    expect(clearWindowId).toHaveBeenCalledTimes(1);
+    expect(result.reused).toBe(false);
+    expect(setWindowId).toHaveBeenCalledWith(21);
+  });
+});
+
+describe('window geometry', () => {
+  it('positions the popup against the right edge of the current window', async () => {
+    (windows.getAll as jest.Mock).mockResolvedValue([]);
+
+    await createOpenWindow({ windowId: null, setWindowId, clearWindowId })({
+      windowApp: WindowApp.ConnectToApp
+    });
+
+    expect(windows.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'popup',
+        height: 700,
+        width: 376,
+        left: 1000 - 376,
+        top: 0,
+        focused: true
+      })
+    );
+  });
+
+  // Firefox ignores width/height in fullscreen, so the code deliberately omits
+  // them — and the e2e harness relies on the same branch via TEST_ENV.
+  it('omits geometry in fullscreen', async () => {
+    (windows.getAll as jest.Mock).mockResolvedValue([]);
+    (windows.getCurrent as jest.Mock).mockResolvedValue({
+      width: 1000,
+      left: 0,
+      top: 0,
+      state: 'fullscreen'
+    });
+
+    await createOpenWindow({ windowId: null, setWindowId, clearWindowId })({
+      windowApp: WindowApp.ConnectToApp
+    });
+
+    const config = (windows.create as jest.Mock).mock.calls.at(-1)![0];
+    expect(config).not.toHaveProperty('width');
+    expect(config).not.toHaveProperty('height');
+  });
+});

--- a/src/background/keep-alive.test.ts
+++ b/src/background/keep-alive.test.ts
@@ -186,6 +186,86 @@ describe('keep-alive idempotency guard', () => {
   });
 });
 
+describe('manageKeepAlive lock-state policy', () => {
+  const load = (
+    state: {
+      locked: boolean;
+      keys: boolean;
+      cipher: boolean;
+    },
+    subscribers: (() => void)[] = []
+  ) => {
+    jest.resetModules();
+    /* eslint-disable @typescript-eslint/no-require-imports */
+    const { alarms: freshAlarms } = require('webextension-polyfill');
+    const store = require('@background/redux/get-main-store');
+    const keys = require('@background/redux/keys/selectors');
+    const session = require('@background/redux/session/selectors');
+    const cipher = require('@background/redux/vault-cipher/selectors');
+    const keepAlive = require('@background/keep-alive');
+    /* eslint-enable @typescript-eslint/no-require-imports */
+
+    session.selectVaultIsLocked.mockReturnValue(state.locked);
+    keys.selectKeysDoesExist.mockReturnValue(state.keys);
+    cipher.selectVaultCipherDoesExist.mockReturnValue(state.cipher);
+    store.getExistingMainStoreSingletonOrInit.mockResolvedValue({
+      getState: () => ({}),
+      subscribe: (cb: () => void) => subscribers.push(cb)
+    });
+
+    return { freshAlarms, keepAlive };
+  };
+
+  // The only state in which the session is genuinely dormant: locked, with a
+  // vault on disk to come back to.
+  it('stops the alarm when the vault is locked and a cipher exists', async () => {
+    const { freshAlarms, keepAlive } = load({
+      locked: true,
+      keys: true,
+      cipher: true
+    });
+
+    await keepAlive.initKeepAlive();
+
+    expect(freshAlarms.clear).toHaveBeenCalledWith('casper-keep-alive');
+    expect(freshAlarms.create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['unlocked', { locked: false, keys: true, cipher: true }],
+    ['no keys yet', { locked: true, keys: false, cipher: true }],
+    ['no cipher yet', { locked: true, keys: true, cipher: false }]
+  ])('keeps the alarm running when %s', async (_label, state) => {
+    const { freshAlarms, keepAlive } = load(state);
+
+    await keepAlive.initKeepAlive();
+
+    expect(freshAlarms.create).toHaveBeenCalledWith('casper-keep-alive', {
+      periodInMinutes: 0.5
+    });
+    expect(freshAlarms.clear).not.toHaveBeenCalled();
+  });
+
+  it('re-evaluates on every store update, not just at init', async () => {
+    const subscribers: (() => void)[] = [];
+    const { freshAlarms, keepAlive } = load(
+      { locked: false, keys: true, cipher: true },
+      subscribers
+    );
+
+    await keepAlive.initKeepAlive();
+    expect(freshAlarms.create).toHaveBeenCalledTimes(1);
+
+    /* eslint-disable-next-line @typescript-eslint/no-require-imports */
+    const session = require('@background/redux/session/selectors');
+    session.selectVaultIsLocked.mockReturnValue(true);
+    subscribers.forEach(cb => cb());
+    await flushPromises();
+
+    expect(freshAlarms.clear).toHaveBeenCalledWith('casper-keep-alive');
+  });
+});
+
 // This block resets the module registry, so it must stay the last describe in
 // the file — earlier tests rely on the module instance imported at the top.
 describe('keep-alive on non-Chrome builds', () => {

--- a/src/background/redux/sagas/vault-sagas.test.ts
+++ b/src/background/redux/sagas/vault-sagas.test.ts
@@ -1,6 +1,7 @@
 import * as matchers from 'redux-saga-test-plan/matchers';
 import { combineReducers } from '@reduxjs/toolkit';
 import { expectSaga } from 'redux-saga-test-plan';
+import { put } from 'redux-saga/effects';
 import { storage, tabs, windows } from 'webextension-polyfill';
 
 import {
@@ -17,6 +18,7 @@ import {
   LOGIN_RETRY_LOCKOUT_DEADLINE_KEY
 } from '@background/redux/storage-keys';
 
+import * as bip32Module from '@libs/crypto/bip32';
 import * as vaultCryptoModule from '@libs/crypto/vault';
 import { FIXED_ENCRYPTION_KEY_HASH } from '@libs/crypto/__fixtures';
 import { decryptVault, encryptVault } from '@libs/crypto/vault';
@@ -39,6 +41,7 @@ import { selectTimeoutDurationSetting } from '../settings/selectors';
 import { vaultCipherCreated } from '../vault-cipher/actions';
 import { selectVaultCipherDoesExist } from '../vault-cipher/selectors';
 import {
+  accountAdded,
   accountRenamed,
   deployPayloadReceived,
   vaultLoaded
@@ -46,15 +49,22 @@ import {
 import { MAX_STORED_PAYLOADS, reducer as vaultReducer } from '../vault/reducer';
 import {
   selectAccountNamesByOriginDict,
+  selectSecretPhrase,
   selectVault,
-  selectVaultActiveAccount
+  selectVaultActiveAccount,
+  selectVaultDerivedAccounts
 } from '../vault/selectors';
 import { VaultState } from '../vault/types';
 import { windowRequestResponded } from '../windowManagement/actions';
 import { reducer as windowManagementReducer } from '../windowManagement/reducer';
 import { selectOpenRequests } from '../windowManagement/selectors';
 import { WindowManagementState } from '../windowManagement/types';
-import { lockVault, startBackground, unlockVault } from './actions';
+import {
+  createAccount,
+  lockVault,
+  startBackground,
+  unlockVault
+} from './actions';
 import {
   VAULT_REENCRYPT_DEBOUNCE_MS,
   delay,
@@ -1053,4 +1063,100 @@ describe('unlockVaultSaga on a cipher written before a payload map existed', () 
       expect(vault.activeAccountName).toBe('Account 1');
     }
   );
+});
+
+// The collision loop is the whole point of this saga: a broken `i++` either
+// reuses a taken derivation index or never terminates, wedging the SW.
+describe('createAccountSaga', () => {
+  const keyPairAt = (index: number) => ({
+    publicKey: `01pub${index}`,
+    secretKey: `sec${index}`
+  });
+
+  const derived = (index: number) => ({
+    ...keyPairAt(index),
+    name: `account ${index}`,
+    hidden: false,
+    derivationIndex: index
+  });
+
+  const runCreate = (
+    derivedAccounts: ReturnType<typeof derived>[],
+    name: string
+  ) =>
+    expectSaga(vaultSagas)
+      .provide([
+        [matchers.select.selector(selectVaultDerivedAccounts), derivedAccounts],
+        [matchers.select.selector(selectSecretPhrase), ['word', 'word']]
+      ])
+      .dispatch(createAccount({ name }))
+      .silentRun(50);
+
+  beforeEach(() => {
+    jest
+      .spyOn(bip32Module, 'deriveKeyPair')
+      .mockImplementation((_phrase, index) => keyPairAt(index) as never);
+  });
+
+  it('derives at index 0 for an empty vault', async () => {
+    const { effects } = await runCreate([], 'first');
+
+    expect(effects.put).toContainEqual(
+      put(
+        accountAdded({
+          ...keyPairAt(0),
+          name: 'first',
+          hidden: false,
+          derivationIndex: 0
+        })
+      )
+    );
+  });
+
+  // Indices 0..2 are taken, so the new account must land on 3 — an assertion
+  // that merely "a put happened" would pass with a reused index.
+  it('skips past every taken derivation index', async () => {
+    const { effects } = await runCreate(
+      [derived(0), derived(1), derived(2)],
+      'fourth'
+    );
+
+    expect(effects.put).toContainEqual(
+      put(
+        accountAdded({
+          ...keyPairAt(3),
+          name: 'fourth',
+          hidden: false,
+          derivationIndex: 3
+        })
+      )
+    );
+  });
+
+  it('reports a duplicate account name and derives nothing', async () => {
+    const { effects } = await runCreate([derived(0)], 'account 0');
+
+    expect(effects.put).toContainEqual(
+      put(
+        sagaError({
+          source: 'createAccountSaga',
+          message: 'Account name exist'
+        })
+      )
+    );
+    expect(bip32Module.deriveKeyPair).not.toHaveBeenCalled();
+  });
+
+  it('reports a missing account name', async () => {
+    const { effects } = await runCreate([], null as unknown as string);
+
+    expect(effects.put).toContainEqual(
+      put(
+        sagaError({
+          source: 'createAccountSaga',
+          message: 'Account name missing'
+        })
+      )
+    );
+  });
 });

--- a/src/background/redux/sagas/vault-sagas.test.ts
+++ b/src/background/redux/sagas/vault-sagas.test.ts
@@ -1,6 +1,7 @@
 import * as matchers from 'redux-saga-test-plan/matchers';
 import { combineReducers } from '@reduxjs/toolkit';
 import { expectSaga } from 'redux-saga-test-plan';
+import { throwError } from 'redux-saga-test-plan/providers';
 import { put } from 'redux-saga/effects';
 import { storage, tabs, windows } from 'webextension-polyfill';
 
@@ -1157,6 +1158,89 @@ describe('createAccountSaga', () => {
           message: 'Account name missing'
         })
       )
+    );
+  });
+});
+
+// Every catch in this module funnels into the same broadcast error channel.
+// Each test forces exactly one of them and pins its `source` string — the
+// banner and the saga are wired together by that literal.
+describe('saga error channel', () => {
+  it('reports an encryption failure from updateVaultCipher', async () => {
+    jest
+      .spyOn(vaultCryptoModule, 'encryptVault')
+      .mockRejectedValue(Error('encrypt failed'));
+
+    const { effects } = await expectSaga(vaultSagas)
+      .provide([
+        [matchers.select.selector(selectEncryptionKeyHash), 'key-hash'],
+        [matchers.select.selector(selectVault), EMPTY_VAULT]
+      ])
+      .dispatch(accountRenamed({ oldName: 'a', newName: 'b' }))
+      .silentRun(VAULT_REENCRYPT_DEBOUNCE_MS + 200);
+
+    expect(effects.put).toContainEqual(
+      put(
+        sagaError({
+          source: 'updateVaultCipher',
+          message: 'encrypt failed'
+        })
+      )
+    );
+  });
+
+  it('reports a failed lock flush from lockVaultSaga', async () => {
+    mockStorageRemove.mockRejectedValue(Error('storage gone'));
+
+    const { effects } = await expectSaga(lockVaultSaga)
+      .provide([[matchers.select.selector(selectEncryptionKeyHash), null]])
+      .silentRun(50);
+
+    expect(effects.put).toContainEqual(
+      put(sagaError({ source: 'lockVaultSaga', message: 'storage gone' }))
+    );
+  });
+
+  it('reports a failure from unlockVaultSaga', async () => {
+    const { effects } = await expectSaga(
+      unlockVaultSaga,
+      unlockVault({
+        vault: EMPTY_VAULT,
+        newKeyDerivationSaltHash: 'salt',
+        newVaultCipher: 'cipher',
+        newEncryptionKeyHash: 'hash'
+      })
+    )
+      .provide([
+        [
+          matchers.select.selector(selectAccountNamesByOriginDict),
+          throwError(Error('unlock failed'))
+        ]
+      ])
+      .silentRun(50);
+
+    expect(effects.put).toContainEqual(
+      put(sagaError({ source: 'unlockVaultSaga', message: 'unlock failed' }))
+    );
+  });
+
+  it('reports a failure from timeoutCounterSaga', async () => {
+    mockStorageGet.mockRejectedValue(Error('read failed'));
+
+    const { effects } = await expectSaga(timeoutCounterSaga, startBackground())
+      .provide([
+        [matchers.select.selector(selectVaultCipherDoesExist), true],
+        [matchers.select.selector(selectVaultIsLocked), false],
+        [
+          matchers.select.selector(selectTimeoutDurationSetting),
+          TimeoutDurationSetting['5 min']
+        ],
+        [matchers.select.selector(selectVaultLastActivityTime), NOW]
+      ])
+      .silentRun(50);
+
+    expect(effects.put).toContainEqual(
+      put(sagaError({ source: 'timeoutCounterSaga', message: 'read failed' }))
     );
   });
 });

--- a/src/content/__fixtures.ts
+++ b/src/content/__fixtures.ts
@@ -1,0 +1,102 @@
+export type Handler = (e: { data: unknown }) => void;
+
+// A synchronous stand-in for MessagePort: `postMessage` delivers straight into
+// the peer's `onmessage` and its 'message' listeners. Closing either end of the
+// pair stops delivery in both directions.
+export class FakePort {
+  peer!: FakePort;
+  onmessage: Handler | null = null;
+  listeners: Handler[] = [];
+  closed = false;
+
+  postMessage = (data: unknown) => {
+    if (this.closed || this.peer.closed) return;
+    this.peer.onmessage?.({ data });
+    this.peer.listeners.slice().forEach(cb => cb({ data }));
+  };
+  addEventListener = (type: string, cb: Handler) => {
+    if (type === 'message') this.listeners.push(cb);
+  };
+  removeEventListener = (type: string, cb: Handler) => {
+    this.listeners = this.listeners.filter(l => l !== cb);
+  };
+  start = () => undefined;
+  close = () => {
+    this.closed = true;
+  };
+}
+
+type ScriptTag = { onload?: () => void; setAttribute: jest.Mock };
+
+type FakeWindow = {
+  location: { origin: string };
+  addEventListener: (type: string, cb: Handler) => void;
+  removeEventListener: () => void;
+  dispatchEvent: () => boolean;
+  postMessage: (data: unknown, origin: string, transfer: FakePort[]) => void;
+};
+
+// Installs the `MessageChannel` / `window` / `document` / `CustomEvent` globals
+// a content-script module touches at require time under `testEnvironment: 'node'`
+// (see index.test.ts and sdk-error-envelope.test.ts for why). Callers differ in
+// what `window.postMessage` should do, so `win.postMessage` is left as a no-op
+// here — set it on the returned `win` before `require`-ing the module under test.
+// `channelRef` is a mutable box (not the channel itself): the `MessageChannel`
+// constructor below only runs once the required module calls `new MessageChannel()`,
+// which happens after this function has already returned.
+export function installFakeDom(origin: string) {
+  const messageListeners: Handler[] = [];
+  const cleanupListeners: (() => void)[] = [];
+  const scriptTags: ScriptTag[] = [];
+  const channelRef: { current?: { port1: FakePort; port2: FakePort } } = {};
+
+  (global as { MessageChannel?: unknown }).MessageChannel = function () {
+    const port1 = new FakePort();
+    const port2 = new FakePort();
+    port1.peer = port2;
+    port2.peer = port1;
+    channelRef.current = { port1, port2 };
+    return channelRef.current;
+  };
+
+  const win: FakeWindow = {
+    location: { origin },
+    addEventListener: (type: string, cb: Handler) => {
+      if (type === 'message') messageListeners.push(cb);
+      else cleanupListeners.push(cb as unknown as () => void);
+    },
+    removeEventListener: () => undefined,
+    dispatchEvent: () => true,
+    postMessage: () => undefined
+  };
+  const doc = {
+    head: {
+      children: [{}],
+      insertBefore: () => undefined,
+      removeChild: () => undefined
+    },
+    createElement: () => {
+      const tag = { setAttribute: jest.fn() } as ScriptTag;
+      scriptTags.push(tag);
+      return tag;
+    }
+  };
+
+  (global as { window?: unknown }).window = win;
+  (global as { document?: unknown }).document = doc;
+  (global as { CustomEvent?: unknown }).CustomEvent = class {
+    constructor(
+      public type: string,
+      public init?: unknown
+    ) {}
+  };
+
+  return {
+    channelRef,
+    scriptTags,
+    messageListeners,
+    cleanupListeners,
+    win,
+    doc
+  };
+}

--- a/src/content/index.test.ts
+++ b/src/content/index.test.ts
@@ -8,17 +8,8 @@ jest.mock('webextension-polyfill', () => ({
   }
 }));
 
-// `loadContentScript` calls `jest.resetModules()` before every `require('./index')`
-// so each test gets a fresh module instance (the content script keeps singleton
-// state — `activePort` — and registers listeners at import time). That reset
-// also invalidates the `webextension-polyfill` mock: Jest re-invokes the mock
-// factory on the next require, producing a brand-new `runtime` object. A
-// top-level `import { runtime } from 'webextension-polyfill'` would bind to the
-// *first* instance only, so assertions against it would silently stop tracking
-// whatever `index.ts` actually calls after the first reset — making the request
-// gate's `not.toHaveBeenCalled()` checks vacuously true. `loadContentScript`
-// therefore re-requires the module itself, after resetting, and hands back the
-// live `runtime` for tests to assert against.
+// After `jest.resetModules()`, a top-level `import { runtime }` binds to a
+// dead mock; assertions must use the live instance `loadContentScript` re-requires.
 type MockedRuntime = {
   sendMessage: jest.Mock;
   getURL: jest.Mock;

--- a/src/content/index.test.ts
+++ b/src/content/index.test.ts
@@ -1,3 +1,4 @@
+import { FakePort, installFakeDom } from './__fixtures';
 import { sdkMethod } from './sdk-method';
 
 jest.mock('webextension-polyfill', () => ({
@@ -20,85 +21,16 @@ jest.mock('@content/bring', () => ({ initBringScript: jest.fn() }));
 
 const ORIGIN = 'https://dapp.example';
 
-type Handler = (e: { data: unknown }) => void;
-
-// A synchronous stand-in for MessagePort: `postMessage` delivers straight into
-// the peer's `onmessage` and its 'message' listeners.
-class FakePort {
-  peer!: FakePort;
-  onmessage: Handler | null = null;
-  listeners: Handler[] = [];
-  closed = false;
-
-  postMessage = (data: unknown) => {
-    if (this.peer.closed) return;
-    this.peer.onmessage?.({ data });
-    this.peer.listeners.slice().forEach(cb => cb({ data }));
-  };
-  addEventListener = (type: string, cb: Handler) => {
-    if (type === 'message') this.listeners.push(cb);
-  };
-  removeEventListener = (type: string, cb: Handler) => {
-    this.listeners = this.listeners.filter(l => l !== cb);
-  };
-  start = () => undefined;
-  close = () => {
-    this.closed = true;
-  };
-}
-
 const loadContentScript = () => {
-  const messageListeners: Handler[] = [];
+  const { channelRef, scriptTags, messageListeners, cleanupListeners, win } =
+    installFakeDom(ORIGIN);
   const posted: {
     data: { type?: string };
     origin: string;
     transfer: FakePort[];
   }[] = [];
-  const scriptTags: { onload?: () => void; setAttribute: jest.Mock }[] = [];
-  let channel!: { port1: FakePort; port2: FakePort };
-
-  (global as { MessageChannel?: unknown }).MessageChannel = function () {
-    const port1 = new FakePort();
-    const port2 = new FakePort();
-    port1.peer = port2;
-    port2.peer = port1;
-    channel = { port1, port2 };
-    return channel;
-  };
-
-  const cleanupListeners: (() => void)[] = [];
-  const win = {
-    location: { origin: ORIGIN },
-    addEventListener: (type: string, cb: Handler) => {
-      if (type === 'message') messageListeners.push(cb);
-      else cleanupListeners.push(cb as unknown as () => void);
-    },
-    removeEventListener: () => undefined,
-    dispatchEvent: () => true,
-    postMessage: (data: unknown, origin: string, transfer: FakePort[]) => {
-      posted.push({ data: data as { type?: string }, origin, transfer });
-    }
-  };
-  const doc = {
-    head: {
-      children: [{}],
-      insertBefore: () => undefined,
-      removeChild: () => undefined
-    },
-    createElement: () => {
-      const tag = { setAttribute: jest.fn() } as (typeof scriptTags)[number];
-      scriptTags.push(tag);
-      return tag;
-    }
-  };
-
-  (global as { window?: unknown }).window = win;
-  (global as { document?: unknown }).document = doc;
-  (global as { CustomEvent?: unknown }).CustomEvent = class {
-    constructor(
-      public type: string,
-      public init?: unknown
-    ) {}
+  win.postMessage = (data: unknown, origin: string, transfer: FakePort[]) => {
+    posted.push({ data: data as { type?: string }, origin, transfer });
   };
 
   jest.resetModules();
@@ -114,7 +46,14 @@ const loadContentScript = () => {
   // `establishSdkPort` runs from the injected script's onload handler.
   scriptTags[0].onload?.();
 
-  return { channel, posted, messageListeners, cleanupListeners, win, runtime };
+  return {
+    channel: channelRef.current!,
+    posted,
+    messageListeners,
+    cleanupListeners,
+    win,
+    runtime
+  };
 };
 
 beforeEach(() => {

--- a/src/content/index.test.ts
+++ b/src/content/index.test.ts
@@ -1,0 +1,265 @@
+import { sdkMethod } from './sdk-method';
+
+jest.mock('webextension-polyfill', () => ({
+  runtime: {
+    sendMessage: jest.fn(),
+    getURL: jest.fn(() => 'chrome-extension://abcdefghijklmnop/sdk.bundle.js'),
+    onMessage: { addListener: jest.fn(), removeListener: jest.fn() }
+  }
+}));
+
+// `loadContentScript` calls `jest.resetModules()` before every `require('./index')`
+// so each test gets a fresh module instance (the content script keeps singleton
+// state — `activePort` — and registers listeners at import time). That reset
+// also invalidates the `webextension-polyfill` mock: Jest re-invokes the mock
+// factory on the next require, producing a brand-new `runtime` object. A
+// top-level `import { runtime } from 'webextension-polyfill'` would bind to the
+// *first* instance only, so assertions against it would silently stop tracking
+// whatever `index.ts` actually calls after the first reset — making the request
+// gate's `not.toHaveBeenCalled()` checks vacuously true. `loadContentScript`
+// therefore re-requires the module itself, after resetting, and hands back the
+// live `runtime` for tests to assert against.
+type MockedRuntime = {
+  sendMessage: jest.Mock;
+  getURL: jest.Mock;
+  onMessage: { addListener: jest.Mock; removeListener: jest.Mock };
+};
+
+jest.mock('@content/bring', () => ({ initBringScript: jest.fn() }));
+
+const ORIGIN = 'https://dapp.example';
+
+type Handler = (e: { data: unknown }) => void;
+
+// A synchronous stand-in for MessagePort: `postMessage` delivers straight into
+// the peer's `onmessage` and its 'message' listeners.
+class FakePort {
+  peer!: FakePort;
+  onmessage: Handler | null = null;
+  listeners: Handler[] = [];
+  closed = false;
+
+  postMessage = (data: unknown) => {
+    if (this.peer.closed) return;
+    this.peer.onmessage?.({ data });
+    this.peer.listeners.slice().forEach(cb => cb({ data }));
+  };
+  addEventListener = (type: string, cb: Handler) => {
+    if (type === 'message') this.listeners.push(cb);
+  };
+  removeEventListener = (type: string, cb: Handler) => {
+    this.listeners = this.listeners.filter(l => l !== cb);
+  };
+  start = () => undefined;
+  close = () => {
+    this.closed = true;
+  };
+}
+
+const loadContentScript = () => {
+  const messageListeners: Handler[] = [];
+  const posted: {
+    data: { type?: string };
+    origin: string;
+    transfer: FakePort[];
+  }[] = [];
+  const scriptTags: { onload?: () => void; setAttribute: jest.Mock }[] = [];
+  let channel!: { port1: FakePort; port2: FakePort };
+
+  (global as { MessageChannel?: unknown }).MessageChannel = function () {
+    const port1 = new FakePort();
+    const port2 = new FakePort();
+    port1.peer = port2;
+    port2.peer = port1;
+    channel = { port1, port2 };
+    return channel;
+  };
+
+  const cleanupListeners: (() => void)[] = [];
+  const win = {
+    location: { origin: ORIGIN },
+    addEventListener: (type: string, cb: Handler) => {
+      if (type === 'message') messageListeners.push(cb);
+      else cleanupListeners.push(cb as unknown as () => void);
+    },
+    removeEventListener: () => undefined,
+    dispatchEvent: () => true,
+    postMessage: (data: unknown, origin: string, transfer: FakePort[]) => {
+      posted.push({ data: data as { type?: string }, origin, transfer });
+    }
+  };
+  const doc = {
+    head: {
+      children: [{}],
+      insertBefore: () => undefined,
+      removeChild: () => undefined
+    },
+    createElement: () => {
+      const tag = { setAttribute: jest.fn() } as (typeof scriptTags)[number];
+      scriptTags.push(tag);
+      return tag;
+    }
+  };
+
+  (global as { window?: unknown }).window = win;
+  (global as { document?: unknown }).document = doc;
+  (global as { CustomEvent?: unknown }).CustomEvent = class {
+    constructor(
+      public type: string,
+      public init?: unknown
+    ) {}
+  };
+
+  jest.resetModules();
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('./index');
+  // Re-require *after* resetting, in the same (post-reset) module registry
+  // `./index` just populated, so this is the exact `runtime` instance bound
+  // inside the freshly loaded content script.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const runtime = require('webextension-polyfill').runtime as MockedRuntime;
+  runtime.sendMessage.mockResolvedValue(undefined);
+
+  // `establishSdkPort` runs from the injected script's onload handler.
+  scriptTags[0].onload?.();
+
+  return { channel, posted, messageListeners, cleanupListeners, win, runtime };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+const REQUEST_TYPES = [
+  sdkMethod.connectRequest.type,
+  sdkMethod.switchAccountRequest.type,
+  sdkMethod.signRequest.type,
+  sdkMethod.signMessageRequest.type,
+  sdkMethod.signTypedDataRequest.type,
+  sdkMethod.encryptMessageRequest.type,
+  sdkMethod.decryptMessageRequest.type,
+  sdkMethod.disconnectRequest.type,
+  sdkMethod.isConnectedRequest.type,
+  sdkMethod.getActivePublicKeyRequest.type,
+  sdkMethod.getVersionRequest.type,
+  sdkMethod.getActivePublicKeySupportsRequest.type
+];
+
+const meta = { requestId: 'req-1' };
+
+describe('establishSdkPort request gate', () => {
+  it('hands the SDK a port, origin-scoped to this document', () => {
+    const { posted, channel } = loadContentScript();
+
+    expect(posted).toHaveLength(1);
+    expect(posted[0].origin).toBe(ORIGIN);
+    expect(posted[0].transfer[0]).toBe(channel.port2);
+  });
+
+  it('relays every one of the twelve request types', () => {
+    const { channel, runtime } = loadContentScript();
+
+    REQUEST_TYPES.forEach((type, i) => {
+      channel.port2.postMessage({ type, payload: {}, meta });
+      expect(runtime.sendMessage).toHaveBeenCalledTimes(i + 1);
+    });
+  });
+
+  // Pinning the exact request-direction strings is what stops a forged
+  // response envelope or a redux action from reaching the background
+  // (defence-in-depth for P0.2). Relaxing the gate to `isSDKMethod` alone
+  // must fail here.
+  it.each([
+    ['a response envelope', sdkMethod.signResponse.type],
+    ['an error envelope', sdkMethod.signError.type],
+    ['a connect response', sdkMethod.connectResponse.type],
+    ['a redux action', 'vault/accountAdded']
+  ])('drops %s', (_label, type) => {
+    const { channel, runtime } = loadContentScript();
+
+    channel.port2.postMessage({ type, payload: {}, meta });
+
+    expect(runtime.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('drops a shape-invalid message', () => {
+    const { channel, runtime } = loadContentScript();
+
+    channel.port2.postMessage({ nope: true });
+    channel.port2.postMessage('string');
+    channel.port2.postMessage(undefined);
+
+    expect(runtime.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('relays a background response back over the private port', async () => {
+    const response = {
+      type: sdkMethod.signResponse.type,
+      payload: { signatureHex: 'deadbeef' },
+      meta
+    };
+
+    const { channel, runtime } = loadContentScript();
+    runtime.sendMessage.mockResolvedValue(response);
+    const received: unknown[] = [];
+    channel.port2.onmessage = e => received.push(e.data);
+
+    channel.port2.postMessage({
+      type: sdkMethod.signRequest.type,
+      payload: {},
+      meta
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(received).toEqual([response]);
+  });
+});
+
+// Reaching the `activePort == null` branch means running cleanup() first —
+// the module wires it to a window event listener, which the harness captured
+// in `cleanupListeners`.
+describe('delayed response with no active port', () => {
+  it('logs the type and requestId, never the payload', () => {
+    const { cleanupListeners, channel, runtime } = loadContentScript();
+    const onMessage = runtime.onMessage.addListener.mock.calls[0][0];
+
+    cleanupListeners.forEach(cb => cb());
+    expect(channel.port1.closed).toBe(true);
+
+    onMessage({
+      type: sdkMethod.signResponse.type,
+      payload: { signatureHex: 'deadbeefcafe' },
+      meta: { requestId: 'req-9' }
+    });
+
+    // SECURITY: the payload of a delayed response carries signatureHex /
+    // encryptedMessage — type + requestId only.
+    expect(console.error).toHaveBeenCalledWith(
+      'Content: dropped a delayed SDK response, no active port:',
+      sdkMethod.signResponse.type,
+      'req-9'
+    );
+    expect(
+      JSON.stringify((console.error as jest.Mock).mock.calls)
+    ).not.toContain('deadbeefcafe');
+  });
+
+  it('stops relaying requests once the port is closed', () => {
+    const { cleanupListeners, channel, runtime } = loadContentScript();
+
+    cleanupListeners.forEach(cb => cb());
+    channel.port2.postMessage({
+      type: sdkMethod.signRequest.type,
+      payload: {},
+      meta
+    });
+
+    expect(runtime.sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/content/sdk-error-envelope.test.ts
+++ b/src/content/sdk-error-envelope.test.ts
@@ -1,0 +1,178 @@
+jest.mock('webextension-polyfill', () => ({
+  runtime: {
+    sendMessage: jest.fn(),
+    getURL: jest.fn(() => 'chrome-extension://abcdefghijklmnop/sdk.bundle.js'),
+    onMessage: { addListener: jest.fn(), removeListener: jest.fn() }
+  }
+}));
+
+jest.mock('@content/bring', () => ({ initBringScript: jest.fn() }));
+
+const ORIGIN = 'https://dapp.example';
+
+type Handler = (e: { data: unknown }) => void;
+
+class FakePort {
+  peer!: FakePort;
+  onmessage: Handler | null = null;
+  listeners: Handler[] = [];
+
+  postMessage = (data: unknown) => {
+    this.peer.onmessage?.({ data });
+    this.peer.listeners.slice().forEach(cb => cb({ data }));
+  };
+  addEventListener = (type: string, cb: Handler) => {
+    if (type === 'message') this.listeners.push(cb);
+  };
+  removeEventListener = (type: string, cb: Handler) => {
+    this.listeners = this.listeners.filter(l => l !== cb);
+  };
+  start = () => undefined;
+  close = () => undefined;
+}
+
+type MockedRuntime = {
+  sendMessage: jest.Mock;
+  getURL: jest.Mock;
+  onMessage: { addListener: jest.Mock; removeListener: jest.Mock };
+};
+
+// `jest.resetModules()` re-invokes the `webextension-polyfill` mock factory,
+// producing a brand-new `runtime` object. A top-level `import { runtime } from
+// 'webextension-polyfill'` would bind to the pre-reset instance only, so a
+// `mockRejectedValue` set on it would never reach the `index.ts` copy actually
+// exercised below. Re-require the module *after* resetting, in the same
+// post-reset registry `./index` just populated, and hand back that live
+// instance for tests to configure and assert against.
+//
+// Loads sdk.ts FIRST (it registers the handshake listener at module load), then
+// index.ts, then fires the injected script's onload — which is where
+// establishSdkPort posts the port across. window.postMessage forwards it to
+// sdk.ts in the shape `isTrustedWindowMessage` demands.
+const loadBothModules = () => {
+  const messageListeners: ((e: unknown) => void)[] = [];
+  const scriptTags: { onload?: () => void; setAttribute: jest.Mock }[] = [];
+
+  (global as { MessageChannel?: unknown }).MessageChannel = function () {
+    const port1 = new FakePort();
+    const port2 = new FakePort();
+    port1.peer = port2;
+    port2.peer = port1;
+    return { port1, port2 };
+  };
+
+  const win = {
+    location: { origin: ORIGIN },
+    addEventListener: (type: string, cb: (e: unknown) => void) => {
+      if (type === 'message') messageListeners.push(cb);
+    },
+    removeEventListener: () => undefined,
+    dispatchEvent: () => true,
+    postMessage: (data: unknown, origin: string, transfer: FakePort[]) => {
+      messageListeners
+        .slice()
+        .forEach(cb => cb({ source: win, origin, data, ports: transfer }));
+    }
+  };
+
+  (global as { window?: unknown }).window = win;
+  (global as { document?: unknown }).document = {
+    title: 'test dapp',
+    head: {
+      children: [{}],
+      insertBefore: () => undefined,
+      removeChild: () => undefined
+    },
+    createElement: () => {
+      const tag = { setAttribute: jest.fn() } as (typeof scriptTags)[number];
+      scriptTags.push(tag);
+      return tag;
+    }
+  };
+  (global as { CustomEvent?: unknown }).CustomEvent = class {
+    constructor(
+      public type: string,
+      public init?: unknown
+    ) {}
+  };
+
+  jest.resetModules();
+  /* eslint-disable @typescript-eslint/no-require-imports */
+  const { CasperWalletProvider } = require('./sdk');
+  require('./index');
+  const runtime = require('webextension-polyfill').runtime as MockedRuntime;
+  /* eslint-enable @typescript-eslint/no-require-imports */
+  scriptTags[0].onload?.();
+
+  return { CasperWalletProvider, runtime };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+const flush = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+it('rejects the SDK promise when the background send fails', async () => {
+  const { CasperWalletProvider, runtime } = loadBothModules();
+  runtime.sendMessage.mockRejectedValue(
+    Error('Could not establish connection')
+  );
+
+  const provider = CasperWalletProvider({ timeout: 5000 });
+  const settled = provider.getVersion().then(
+    () => 'resolved',
+    (e: unknown) => e
+  );
+  await flush();
+
+  const outcome = await settled;
+  expect(outcome).toBeInstanceOf(Error);
+  expect((outcome as Error).message).toContain(
+    'Could not establish connection'
+  );
+});
+
+// The `error: true` flag is what routes the envelope to the reject branch. Drop
+// it and the dapp treats a transport failure as a successful signature.
+it('never takes the resolve branch for a failed send', async () => {
+  const { CasperWalletProvider, runtime } = loadBothModules();
+  runtime.sendMessage.mockRejectedValue(Error('boom'));
+
+  const onResolve = jest.fn();
+  const provider = CasperWalletProvider({ timeout: 5000 });
+  provider.getVersion().then(onResolve, () => undefined);
+  await flush();
+
+  expect(onResolve).not.toHaveBeenCalled();
+});
+
+// Without the request's own meta on the envelope, the SDK's requestId filter
+// discards it and the promise hangs until the timeout instead of rejecting.
+it('rejects only the request that failed', async () => {
+  const { CasperWalletProvider, runtime } = loadBothModules();
+  runtime.sendMessage
+    .mockRejectedValueOnce(Error('first failed'))
+    .mockImplementation(() => new Promise(() => undefined));
+
+  const provider = CasperWalletProvider({ timeout: 5000 });
+  const first = provider.getVersion().then(
+    () => 'resolved',
+    (e: unknown) => (e as Error).message
+  );
+  const secondSettled = jest.fn();
+  provider.getVersion().then(secondSettled, secondSettled);
+  await flush();
+
+  await expect(first).resolves.toContain('first failed');
+  expect(secondSettled).not.toHaveBeenCalled();
+});

--- a/src/content/sdk-error-envelope.test.ts
+++ b/src/content/sdk-error-envelope.test.ts
@@ -37,18 +37,8 @@ type MockedRuntime = {
   onMessage: { addListener: jest.Mock; removeListener: jest.Mock };
 };
 
-// `jest.resetModules()` re-invokes the `webextension-polyfill` mock factory,
-// producing a brand-new `runtime` object. A top-level `import { runtime } from
-// 'webextension-polyfill'` would bind to the pre-reset instance only, so a
-// `mockRejectedValue` set on it would never reach the `index.ts` copy actually
-// exercised below. Re-require the module *after* resetting, in the same
-// post-reset registry `./index` just populated, and hand back that live
-// instance for tests to configure and assert against.
-//
-// Loads sdk.ts FIRST (it registers the handshake listener at module load), then
-// index.ts, then fires the injected script's onload — which is where
-// establishSdkPort posts the port across. window.postMessage forwards it to
-// sdk.ts in the shape `isTrustedWindowMessage` demands.
+// Loads sdk.ts first (registers the handshake listener at module load), then
+// index.ts, then fires the injected script's onload to hand off the port.
 const loadBothModules = () => {
   const messageListeners: ((e: unknown) => void)[] = [];
   const scriptTags: { onload?: () => void; setAttribute: jest.Mock }[] = [];

--- a/src/content/sdk-error-envelope.test.ts
+++ b/src/content/sdk-error-envelope.test.ts
@@ -1,3 +1,5 @@
+import { FakePort, installFakeDom } from './__fixtures';
+
 jest.mock('webextension-polyfill', () => ({
   runtime: {
     sendMessage: jest.fn(),
@@ -10,27 +12,6 @@ jest.mock('@content/bring', () => ({ initBringScript: jest.fn() }));
 
 const ORIGIN = 'https://dapp.example';
 
-type Handler = (e: { data: unknown }) => void;
-
-class FakePort {
-  peer!: FakePort;
-  onmessage: Handler | null = null;
-  listeners: Handler[] = [];
-
-  postMessage = (data: unknown) => {
-    this.peer.onmessage?.({ data });
-    this.peer.listeners.slice().forEach(cb => cb({ data }));
-  };
-  addEventListener = (type: string, cb: Handler) => {
-    if (type === 'message') this.listeners.push(cb);
-  };
-  removeEventListener = (type: string, cb: Handler) => {
-    this.listeners = this.listeners.filter(l => l !== cb);
-  };
-  start = () => undefined;
-  close = () => undefined;
-}
-
 type MockedRuntime = {
   sendMessage: jest.Mock;
   getURL: jest.Mock;
@@ -40,50 +21,10 @@ type MockedRuntime = {
 // Loads sdk.ts first (registers the handshake listener at module load), then
 // index.ts, then fires the injected script's onload to hand off the port.
 const loadBothModules = () => {
-  const messageListeners: ((e: unknown) => void)[] = [];
-  const scriptTags: { onload?: () => void; setAttribute: jest.Mock }[] = [];
-
-  (global as { MessageChannel?: unknown }).MessageChannel = function () {
-    const port1 = new FakePort();
-    const port2 = new FakePort();
-    port1.peer = port2;
-    port2.peer = port1;
-    return { port1, port2 };
-  };
-
-  const win = {
-    location: { origin: ORIGIN },
-    addEventListener: (type: string, cb: (e: unknown) => void) => {
-      if (type === 'message') messageListeners.push(cb);
-    },
-    removeEventListener: () => undefined,
-    dispatchEvent: () => true,
-    postMessage: (data: unknown, origin: string, transfer: FakePort[]) => {
-      messageListeners
-        .slice()
-        .forEach(cb => cb({ source: win, origin, data, ports: transfer }));
-    }
-  };
-
-  (global as { window?: unknown }).window = win;
-  (global as { document?: unknown }).document = {
-    title: 'test dapp',
-    head: {
-      children: [{}],
-      insertBefore: () => undefined,
-      removeChild: () => undefined
-    },
-    createElement: () => {
-      const tag = { setAttribute: jest.fn() } as (typeof scriptTags)[number];
-      scriptTags.push(tag);
-      return tag;
-    }
-  };
-  (global as { CustomEvent?: unknown }).CustomEvent = class {
-    constructor(
-      public type: string,
-      public init?: unknown
-    ) {}
+  const { scriptTags, messageListeners, win } = installFakeDom(ORIGIN);
+  win.postMessage = (data: unknown, origin: string, transfer: FakePort[]) => {
+    const event = { source: win, origin, data, ports: transfer };
+    messageListeners.slice().forEach(cb => cb(event));
   };
 
   jest.resetModules();

--- a/src/content/sdk.test.ts
+++ b/src/content/sdk.test.ts
@@ -297,9 +297,8 @@ describe('fetchFromBackground response routing', () => {
     handshake(window, port);
 
     const provider = CasperWalletProvider({ timeout: 5000 });
-    // Attach handlers via `allSettled` the moment both promises exist, so a
-    // regression that makes either one reject fails as an assertion below
-    // instead of floating as an unhandled rejection that crashes the worker.
+    // Attach via `allSettled` immediately: a floating promise that rejects would
+    // kill the Jest worker as an unhandled rejection instead of failing an assertion.
     const first = provider.getVersion();
     const second = provider.getVersion();
     const settled = Promise.allSettled([first, second]);

--- a/src/content/sdk.test.ts
+++ b/src/content/sdk.test.ts
@@ -3,6 +3,7 @@ import type {
   SignatureResponse
 } from './sdk';
 import { SDK_HANDSHAKE_TYPE } from './sdk-channel';
+import { sdkMethod } from './sdk-method';
 import { SdkErrorCode, SignTypedDataResult } from './sdk-types';
 
 // The project's jest config runs with `testEnvironment: 'node'` (no
@@ -244,6 +245,125 @@ describe('CasperWalletProvider pre-handshake queueing', () => {
     );
 
     expect(port.postMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+// A port that can answer, unlike `makeFakePort` above: `fetchFromBackground`
+// subscribes with addEventListener, so responses are delivered through the
+// captured listeners.
+const makeAnsweringPort = () => {
+  const listeners: ((e: { data: unknown }) => void)[] = [];
+  return {
+    sent: [] as { type: string; meta: { requestId: string } }[],
+    postMessage(msg: unknown) {
+      this.sent.push(msg as { type: string; meta: { requestId: string } });
+    },
+    addEventListener: (_t: string, cb: (e: { data: unknown }) => void) =>
+      listeners.push(cb),
+    removeEventListener: (_t: string, cb: (e: { data: unknown }) => void) => {
+      const i = listeners.indexOf(cb);
+      if (i !== -1) listeners.splice(i, 1);
+    },
+    start: () => undefined,
+    answer(data: unknown) {
+      listeners.slice().forEach(cb => cb({ data }));
+    },
+    get listenerCount() {
+      return listeners.length;
+    }
+  };
+};
+
+describe('fetchFromBackground response routing', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  const handshake = (window: { messageListeners: Listener[] }, port: unknown) =>
+    window.messageListeners.forEach(cb =>
+      cb({
+        source: (global as { window: unknown }).window,
+        origin: ORIGIN,
+        data: { type: SDK_HANDSHAKE_TYPE },
+        ports: [port]
+      })
+    );
+
+  // Two concurrent sign() calls: a broken requestId filter hands dapp A the
+  // signature the wallet produced for dapp B's request.
+  it('routes each response to its own request, answered out of order', async () => {
+    const { CasperWalletProvider, window } = loadSdk();
+    const port = makeAnsweringPort();
+    handshake(window, port);
+
+    const provider = CasperWalletProvider({ timeout: 5000 });
+    // Attach handlers via `allSettled` the moment both promises exist, so a
+    // regression that makes either one reject fails as an assertion below
+    // instead of floating as an unhandled rejection that crashes the worker.
+    const first = provider.getVersion();
+    const second = provider.getVersion();
+    const settled = Promise.allSettled([first, second]);
+
+    const [idA, idB] = port.sent.map(m => m.meta.requestId);
+    expect(idA).not.toBe(idB);
+
+    port.answer(sdkMethod.getVersionResponse('B', { requestId: idB }));
+    port.answer(sdkMethod.getVersionResponse('A', { requestId: idA }));
+
+    expect(await settled).toEqual([
+      { status: 'fulfilled', value: 'A' },
+      { status: 'fulfilled', value: 'B' }
+    ]);
+  });
+
+  // `getVersion` has no dedicated error creator in `sdk-method.ts`, so this
+  // uses `isConnected`, which does, to keep the envelope a real wire shape.
+  it('rejects with the payload when the envelope is flagged as an error', async () => {
+    const { CasperWalletProvider, window } = loadSdk();
+    const port = makeAnsweringPort();
+    handshake(window, port);
+
+    const provider = CasperWalletProvider({ timeout: 5000 });
+    const pending = provider.isConnected();
+    const { requestId } = port.sent[0].meta;
+
+    port.answer(sdkMethod.isConnectedError(Error('nope'), { requestId }));
+
+    await expect(pending).rejects.toThrow('nope');
+  });
+
+  it('ignores a response carrying a foreign requestId', async () => {
+    const { CasperWalletProvider, window } = loadSdk();
+    const port = makeAnsweringPort();
+    handshake(window, port);
+
+    const settled = jest.fn();
+    const provider = CasperWalletProvider({ timeout: 5000 });
+    provider.getVersion().then(settled, settled);
+
+    port.answer(
+      sdkMethod.getVersionResponse('not yours', { requestId: 'someone-else' })
+    );
+    await Promise.resolve();
+
+    expect(settled).not.toHaveBeenCalled();
+  });
+
+  // A settled request must stop listening, or a late duplicate could re-settle
+  // it — and the listener would leak for the life of the page.
+  it('unsubscribes after settling', async () => {
+    const { CasperWalletProvider, window } = loadSdk();
+    const port = makeAnsweringPort();
+    handshake(window, port);
+
+    const provider = CasperWalletProvider({ timeout: 5000 });
+    const pending = provider.getVersion();
+    const { requestId } = port.sent[0].meta;
+
+    port.answer(sdkMethod.getVersionResponse('ok', { requestId }));
+    await pending;
+
+    expect(port.listenerCount).toBe(0);
   });
 });
 

--- a/src/hooks/use-private-state.test.ts
+++ b/src/hooks/use-private-state.test.ts
@@ -1,7 +1,9 @@
+import { backgroundEvent } from '@background/background-events';
 import { fetchPrivateState } from '@background/handlers/private-state';
 
 import {
   PRIVATE_STATE_RETRY_DELAYS_MS,
+  createPrivateStateUpdatedListener,
   loadPrivateStateWithRetry
 } from './use-private-state';
 
@@ -105,5 +107,39 @@ describe('loadPrivateStateWithRetry', () => {
     expect(fetchMock).toHaveBeenCalledTimes(
       1 + PRIVATE_STATE_RETRY_DELAYS_MS.length
     );
+  });
+});
+
+describe('createPrivateStateUpdatedListener', () => {
+  // A renamed action type here silently leaves every replica holding the
+  // pre-change passwordHash after the user changes their password.
+  it('fires onUpdate for a real privateStateUpdated action', () => {
+    const onUpdate = jest.fn();
+
+    createPrivateStateUpdatedListener(onUpdate)(
+      backgroundEvent.privateStateUpdated()
+    );
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores every other message', () => {
+    const onUpdate = jest.fn();
+    const listener = createPrivateStateUpdatedListener(onUpdate);
+
+    listener({ type: 'popupStateUpdated' });
+    listener({ type: 'privateStateUpdatedXYZ' });
+    listener('keepAlive');
+    listener(undefined);
+
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined so the runtime.onMessage channel stays synchronous', () => {
+    expect(
+      createPrivateStateUpdatedListener(jest.fn())(
+        backgroundEvent.privateStateUpdated()
+      )
+    ).toBeUndefined();
   });
 });

--- a/src/hooks/use-private-state.ts
+++ b/src/hooks/use-private-state.ts
@@ -61,6 +61,15 @@ export async function loadPrivateStateWithRetry(): Promise<PrivateState> {
   throw lastError;
 }
 
+export function createPrivateStateUpdatedListener(onUpdate: () => void) {
+  return function listener(message: unknown) {
+    if (backgroundEvent.privateStateUpdated.match(message)) {
+      onUpdate();
+    }
+    return undefined;
+  };
+}
+
 export function usePrivateState(): UsePrivateStateResult {
   const [privateState, setPrivateState] = useState<PrivateState | null>(null);
   const [error, setError] = useState(false);
@@ -89,12 +98,9 @@ export function usePrivateState(): UsePrivateStateResult {
   }, [fetchAttemptId]);
 
   useEffect(() => {
-    function listener(message: unknown) {
-      if (backgroundEvent.privateStateUpdated.match(message)) {
-        setFetchAttemptId(id => id + 1);
-      }
-      return undefined;
-    }
+    const listener = createPrivateStateUpdatedListener(() =>
+      setFetchAttemptId(id => id + 1)
+    );
 
     runtime.onMessage.addListener(listener);
 

--- a/src/libs/crypto/encryption/index.test.ts
+++ b/src/libs/crypto/encryption/index.test.ts
@@ -3,9 +3,8 @@ import {
   encryptAsHexWithCasperPublicKey
 } from './index';
 
-// Generated once from this implementation. They exist so a library swap that
-// silently changes the wire format fails here instead of in the field — a
-// round-trip alone would stay green through such a change.
+// Pinned ciphertexts: a wire-format change would sail through a pure round-trip
+// but fails here.
 const ED_PUBLIC =
   '0179b5562e8fe654f94078b112e8a98ba7901f853ae695bed7e0e3910bad049664';
 const ED_SECRET_B64 = 'AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=';

--- a/src/libs/crypto/encryption/index.test.ts
+++ b/src/libs/crypto/encryption/index.test.ts
@@ -1,0 +1,82 @@
+import {
+  decryptEncryptedBase64PrivateKey,
+  encryptAsHexWithCasperPublicKey
+} from './index';
+
+// Generated once from this implementation. They exist so a library swap that
+// silently changes the wire format fails here instead of in the field — a
+// round-trip alone would stay green through such a change.
+const ED_PUBLIC =
+  '0179b5562e8fe654f94078b112e8a98ba7901f853ae695bed7e0e3910bad049664';
+const ED_SECRET_B64 = 'AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=';
+const ED_CIPHER =
+  '9268b77309f6c1a0121ced326c200db158075f786ab8d7f53e4f8dd456113e3ccd21d447c71be714e14aa2b215b79e1a3c3a0e0ab0618a68884707ec61cdfe6046a3';
+
+const SECP_PUBLIC =
+  '0202cc6aae3d7687a429ff32989c4bd712ffd29280f4205abbc9a1c8623ef401b93b';
+const SECP_SECRET_B64 = 'D357sc/SE/1wtPtgB5wV9FiL/ixkUdIpZAVuDRDL1gc=';
+const SECP_CIPHER =
+  '01002102666768be2ca7e3c25a38387ac46618c22eaa12faceb366e834cacfdb20132ca8f6cf92e1d3a03d6a60b560944c0d2e3b3f7785755eac2187f3bcb8da3c3742e302313f0fd6278022ba56d61459856c020d38982b06802d36e0e55e1338dc';
+
+const MESSAGE = 'wallet-1364 vector';
+
+describe('ECIES round trip', () => {
+  it('encrypts to an ED25519 key and decrypts back', async () => {
+    const cipher = await encryptAsHexWithCasperPublicKey(ED_PUBLIC, MESSAGE);
+
+    await expect(
+      decryptEncryptedBase64PrivateKey(cipher, ED_PUBLIC, ED_SECRET_B64)
+    ).resolves.toBe(MESSAGE);
+  });
+
+  it('encrypts to a SECP256K1 key and decrypts back', async () => {
+    const cipher = await encryptAsHexWithCasperPublicKey(SECP_PUBLIC, MESSAGE);
+
+    await expect(
+      decryptEncryptedBase64PrivateKey(cipher, SECP_PUBLIC, SECP_SECRET_B64)
+    ).resolves.toBe(MESSAGE);
+  });
+
+  it('produces a fresh ciphertext each time (ephemeral sender key)', async () => {
+    const a = await encryptAsHexWithCasperPublicKey(ED_PUBLIC, MESSAGE);
+    const b = await encryptAsHexWithCasperPublicKey(ED_PUBLIC, MESSAGE);
+
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('ECIES fixed vectors', () => {
+  it('decrypts a pinned ED25519 ciphertext', async () => {
+    await expect(
+      decryptEncryptedBase64PrivateKey(ED_CIPHER, ED_PUBLIC, ED_SECRET_B64)
+    ).resolves.toBe(MESSAGE);
+  });
+
+  it('decrypts a pinned SECP256K1 ciphertext', async () => {
+    await expect(
+      decryptEncryptedBase64PrivateKey(
+        SECP_CIPHER,
+        SECP_PUBLIC,
+        SECP_SECRET_B64
+      )
+    ).resolves.toBe(MESSAGE);
+  });
+});
+
+describe('key-type dispatch', () => {
+  it('rejects a public key that is neither 32 nor 33 bytes', async () => {
+    await expect(
+      encryptAsHexWithCasperPublicKey('01' + 'ab'.repeat(20), MESSAGE)
+    ).rejects.toThrow('Unknown public key type');
+  });
+
+  it('rejects a tampered ciphertext', async () => {
+    const cipher = await encryptAsHexWithCasperPublicKey(ED_PUBLIC, MESSAGE);
+    const tampered =
+      cipher.slice(0, -2) + (cipher.endsWith('00') ? '11' : '00');
+
+    await expect(
+      decryptEncryptedBase64PrivateKey(tampered, ED_PUBLIC, ED_SECRET_B64)
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
Closes the nine test-coverage gaps recorded in WALLET-1364. Tests only, apart from two small
behaviour-preserving extractions explained below.

Jira: https://make-software.atlassian.net/browse/WALLET-1364

## Why these nine

Each gap is paired with the regression it would let through today. They were picked because the
code they cover is either a security boundary or a silent-failure path — the kind that ships green
and surfaces as a user-visible loss.

| Area                                          | Regression now caught                                                                                                                                                                                                                                                                                    |
| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `src/content/index.ts` — no test file existed | Relaxing `SDK_REQUEST_TYPES` to the shape check alone lets a forged `*:Response` / `*:Error` envelope or a redux action reach the background. Also pins that the `activePort == null` drop path logs type + requestId and never the payload — those envelopes carry `signatureHex` / `encryptedMessage`. |
| error envelope round trip                     | A drift in the hand-built `` `${type}:Error` `` envelope makes the SDK's requestId filter discard it, so the dapp's promise never settles and the user waits out a timeout of up to 30 minutes. Both real modules run against one fake channel; a shape assertion would not catch this.                  |
| `fetchFromBackground` routing                 | A broken requestId filter hands the wrong signature to a dapp with two concurrent `sign()` calls; an inverted error check resolves an error envelope as success.                                                                                                                                         |
| `manageKeepAlive`                             | Inverting the lock-state condition kills the MV3 service worker at its ~30s idle deadline while the wallet is unlocked — the silent session loss `01343e0e` fixed.                                                                                                                                       |
| `createAccountSaga`                           | A broken derivation-collision loop either reuses an index or never terminates, wedging the service worker. The tests assert the exact `derivationIndex`; "a put happened" passes with a reused index.                                                                                                    |
| vault saga error channel                      | Four catch blocks whose `source` is the wiring to the error banner. Nothing previously forced `encryptVault` to throw.                                                                                                                                                                                   |
| `src/libs/crypto/encryption/`                 | Had zero direct tests. Round trip per key algorithm, plus pinned fixed-vector ciphertexts so a wire-format change fails here instead of in the field.                                                                                                                                                    |
| `download-account-keys`                       | A zip failure must route to Failure and never Success (WALLET-1345), and only `error.name` may be logged — the thrown value is built from key material.                                                                                                                                                  |
| `use-private-state` push listener             | A renamed action type leaves every UI replica holding a stale `passwordHash` after a password change.                                                                                                                                                                                                    |
| `create-open-window`                          | `SwitchAccount` joins its params with `&`; a `?` there silently drops every param after the first, i.e. an approval window opening without its `requestId`. Plus the `clearWindowId` path and the fullscreen geometry branch.                                                                            |

## The two production changes

Both exist only because jest runs `testEnvironment: 'node'` with no jsdom, so logic living inside a
React component is unreachable from a test. Neither changes behaviour.

- `runKeysDownload` moves out of `download-account-keys/index.tsx` into its own module; the page now
  calls it. A verbatim move.
- `createPrivateStateUpdatedListener` lifts the inner listener out of `usePrivateState`'s effect. The
  hook still registers and removes the same function reference, which the cleanup depends on.

## Coverage

740 → 867 tests, 83 → 90 suites. `vault-sagas.ts` goes from 78.19% to 94.68% lines.

The `./src/background/redux/sagas/` floor rises 45/35/45/45 → 74/63/79/79, following this repo's
existing convention of setting the floor to what is achieved.

**One thing worth a deliberate decision:** that directory's denominators are small (38 functions,
364 statements), so at floor-set-to-achieved a single new uncovered function or statement anywhere
under `redux/sagas/` — including in the still-untested `onboarding-sagas.ts` (33%),
`check-casper2-network-saga.ts` (52%) or `trusted-wasm-saga.ts` (63%) — will fail CI on an unrelated
PR. A branch review recommended leaving a few points of slack (70/58/75/75) instead. I kept the
existing convention rather than deviate in one group only, but if this bites, lowering it is a
deliberate call the team should make, not a silent one.

## Notes for review

- The tests were mutation-checked: production code was temporarily broken to confirm each new test
  fails, then restored. Where a check proved less than it appeared, that is recorded — e.g.
  `SagaErrorSource` is a union type, so a renamed `source` literal already fails `tsc` before any
  test runs.
- `src/content/__fixtures.ts` is a shared test harness, not production code. It follows the existing
  `src/libs/crypto/__fixtures.ts` precedent; jest's `testRegex` does not collect it.
- Rebased onto `develop` after #1456 merged. File overlap with that PR is empty, and the full
  `ci-check` was re-run against `casper-js-sdk` 5.1.0 / `casper-wallet-core` 1.4.0 — the pinned ECIES
  ciphertexts still decrypt, so the wire format is unchanged.

PR2 under the same ticket will cover the six remaining P3 code items.
