### PR TITLE
fix: WALLET-1364 — close the P3 residual

### DIFF
--- a/src/apps/popup/pages/change-password/index.tsx
+++ b/src/apps/popup/pages/change-password/index.tsx
@@ -49,7 +49,8 @@ export const ChangePasswordPage = () => {
     register,
     handleSubmit,
     formState: { isDirty, errors },
-    control
+    control,
+    setError
   } = useCreatePasswordForm();
 
   const password = useWatch({
@@ -101,13 +102,16 @@ export const ChangePasswordPage = () => {
           vaultCipher: newVaultCipher
         })
       );
+
+      navigate(RouterPath.Home);
     };
 
     worker.onerror = error => {
       console.error(error);
+      setError('password', {
+        message: t('Something went wrong. Please try again.')
+      });
     };
-
-    navigate(RouterPath.Home);
   };
 
   if (!isPasswordConfirmed) {

--- a/src/apps/popup/pages/change-password/index.tsx
+++ b/src/apps/popup/pages/change-password/index.tsx
@@ -39,6 +39,7 @@ interface CreatePasswordWorkerMessageEvent extends MessageEvent {
 export const ChangePasswordPage = () => {
   const [isPasswordConfirmed, setIsPasswordConfirmed] =
     useState<boolean>(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { t } = useTranslation();
   const navigate = useTypedNavigate();
@@ -63,13 +64,16 @@ export const ChangePasswordPage = () => {
   }, []);
 
   const isSubmitButtonDisabled = calculateSubmitButtonDisabled({
-    isDirty
+    isDirty,
+    isSubmitting
   });
 
   const onSubmit = (data: CreatePasswordFormValues) => {
     const worker = new Worker(
       new URL('@background/workers/create-password-worker.ts', import.meta.url)
     );
+
+    setIsSubmitting(true);
 
     worker.postMessage({
       password: data.password,
@@ -111,6 +115,7 @@ export const ChangePasswordPage = () => {
       setError('password', {
         message: t('Something went wrong. Please try again.')
       });
+      setIsSubmitting(false);
     };
   };
 
@@ -146,7 +151,7 @@ export const ChangePasswordPage = () => {
       renderFooter={() => (
         <FooterButtonsContainer>
           <Button disabled={isSubmitButtonDisabled}>
-            <Trans t={t}>Continue</Trans>
+            {isSubmitting ? t('Loading') : <Trans t={t}>Continue</Trans>}
           </Button>
         </FooterButtonsContainer>
       )}

--- a/src/apps/popup/pages/change-password/index.tsx
+++ b/src/apps/popup/pages/change-password/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -12,6 +12,7 @@ import { encryptionKeyHashCreated } from '@background/redux/session/actions';
 import { dispatchToMainStore } from '@background/redux/utils';
 import { vaultCipherCreated } from '@background/redux/vault-cipher/actions';
 import { selectVault } from '@background/redux/vault/selectors';
+import { WorkerResult, isWorkerError } from '@background/workers/types';
 
 import {
   FooterButtonsContainer,
@@ -27,13 +28,13 @@ import {
 import { calculateSubmitButtonDisabled } from '@libs/ui/forms/get-submit-button-state-from-validation';
 
 interface CreatePasswordWorkerMessageEvent extends MessageEvent {
-  data: {
+  data: WorkerResult<{
     passwordHash: string;
     passwordSaltHash: string;
     newEncryptionKeyHash: string;
     keyDerivationSaltHash: string;
     newVaultCipher: string;
-  };
+  }>;
 }
 
 export const ChangePasswordPage = () => {
@@ -45,6 +46,9 @@ export const ChangePasswordPage = () => {
   const navigate = useTypedNavigate();
 
   const vault = useSelector(selectVault);
+
+  const workerRef = useRef<Worker | null>(null);
+  const isMountedRef = useRef(true);
 
   const {
     register,
@@ -58,6 +62,18 @@ export const ChangePasswordPage = () => {
     control,
     name: 'password'
   });
+
+  // the back link stays live while scrypt runs; without this the rotation would
+  // still commit from a stale closure and the old password would stop working
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+      workerRef.current?.terminate();
+      workerRef.current = null;
+    };
+  }, []);
 
   const setPasswordConfirmed = useCallback(() => {
     setIsPasswordConfirmed(true);
@@ -73,6 +89,7 @@ export const ChangePasswordPage = () => {
       new URL('@background/workers/create-password-worker.ts', import.meta.url)
     );
 
+    workerRef.current = worker;
     setIsSubmitting(true);
 
     worker.postMessage({
@@ -80,7 +97,29 @@ export const ChangePasswordPage = () => {
       vault
     });
 
+    const disposeWorker = () => {
+      worker.terminate();
+      workerRef.current = null;
+    };
+
+    const handleFailure = () => {
+      disposeWorker();
+      setError('password', {
+        message: t('Something went wrong. Please try again.')
+      });
+      setIsSubmitting(false);
+    };
+
     worker.onmessage = (event: CreatePasswordWorkerMessageEvent) => {
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      if (isWorkerError(event.data)) {
+        handleFailure();
+        return;
+      }
+
       const {
         passwordHash,
         passwordSaltHash,
@@ -88,6 +127,8 @@ export const ChangePasswordPage = () => {
         keyDerivationSaltHash,
         newVaultCipher
       } = event.data;
+
+      disposeWorker();
 
       dispatchToMainStore(
         keysUpdated({
@@ -110,12 +151,16 @@ export const ChangePasswordPage = () => {
       navigate(RouterPath.Home);
     };
 
+    // only reached by a script load failure — a rejection inside the worker
+    // arrives through onmessage instead
     worker.onerror = error => {
       console.error(error);
-      setError('password', {
-        message: t('Something went wrong. Please try again.')
-      });
-      setIsSubmitting(false);
+
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      handleFailure();
     };
   };
 

--- a/src/apps/popup/pages/download-account-keys/download.tsx
+++ b/src/apps/popup/pages/download-account-keys/download.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 
 import {
   selectConnectedAccountNamesWithActiveOrigin,
-  selectVaultAccountsExceptLedgersAccounts,
+  selectVaultAccountsAvailableForExport,
   selectVaultAccountsPublicKeys,
   selectVaultActiveAccountName
 } from '@background/redux/vault/selectors';
@@ -40,7 +40,7 @@ export const Download = ({
 
   const { t } = useTranslation();
 
-  const accounts = useSelector(selectVaultAccountsExceptLedgersAccounts);
+  const accounts = useSelector(selectVaultAccountsAvailableForExport);
   const connectedAccountNames =
     useSelector(selectConnectedAccountNamesWithActiveOrigin) || [];
   const activeAccountName = useSelector(selectVaultActiveAccountName);

--- a/src/apps/popup/pages/download-account-keys/run-keys-download.test.ts
+++ b/src/apps/popup/pages/download-account-keys/run-keys-download.test.ts
@@ -89,3 +89,28 @@ it('logs the error name only, never the error itself', async () => {
   expect(logged).toContain('PemEncodeError');
   expect(JSON.stringify(logged)).not.toContain('0123456789abcdef');
 });
+
+// A partial archive presented as a complete one is the bug: the user walks away
+// believing every selected key is backed up.
+it('routes to Failure when a selected account produced no key file', async () => {
+  mockCreateKeys
+    .mockImplementationOnce(() => ({ secretKey: { toPem: () => 'PEM' } }))
+    .mockImplementationOnce(() => ({ secretKey: null }));
+  const setStep = jest.fn();
+
+  await runKeysDownload([account('alice'), account('watch-only')], setStep);
+
+  expect(setStep).toHaveBeenCalledWith(DownloadAccountKeysSteps.Failure);
+  expect(setStep).not.toHaveBeenCalledWith(DownloadAccountKeysSteps.Success);
+  expect(mockDownloadFile).not.toHaveBeenCalled();
+});
+
+it('never names the skipped account in the log', async () => {
+  mockCreateKeys.mockImplementation(() => ({ secretKey: null }));
+
+  await runKeysDownload([account('watch-only')], jest.fn());
+
+  expect(JSON.stringify((console.error as jest.Mock).mock.calls)).not.toContain(
+    'watch-only'
+  );
+});

--- a/src/apps/popup/pages/download-account-keys/run-keys-download.ts
+++ b/src/apps/popup/pages/download-account-keys/run-keys-download.ts
@@ -11,6 +11,7 @@ export async function runKeysDownload(
 ): Promise<void> {
   try {
     const zip = new JSZip();
+    let skipped = 0;
 
     for (const account of accounts) {
       const asymmetricKey = createAsymmetricKeys(
@@ -23,7 +24,20 @@ export async function runKeysDownload(
           `${account.name}_secret_key.pem`,
           asymmetricKey.secretKey.toPem()
         );
+      } else {
+        skipped++;
       }
+    }
+
+    if (skipped > 0) {
+      // Count only — an account name is user data, and a partial archive must
+      // never reach Success.
+      console.error(
+        'downloadKeys: selected accounts produced no key file',
+        skipped
+      );
+      setStep(DownloadAccountKeysSteps.Failure);
+      return;
     }
 
     const content = await zip.generateAsync({ type: 'blob' });

--- a/src/apps/popup/pages/password-protection-page/index.tsx
+++ b/src/apps/popup/pages/password-protection-page/index.tsx
@@ -155,6 +155,9 @@ export const PasswordProtectionPage = ({
               // The password is in scope but is deliberately not referenced
               // here — only a static message and the error object are logged.
               console.error('Password confirmation failed:', error);
+              setError('password', {
+                message: t('Something went wrong. Please try again.')
+              });
               setIsSubmitting(false);
             });
         } else {

--- a/src/apps/popup/pages/password-protection-page/index.tsx
+++ b/src/apps/popup/pages/password-protection-page/index.tsx
@@ -17,6 +17,7 @@ import {
 } from '@background/redux/login-retry-count/actions';
 import { selectLoginRetryCount } from '@background/redux/login-retry-count/selectors';
 import { dispatchToMainStore } from '@background/redux/utils';
+import { WorkerResult, isWorkerError } from '@background/workers/types';
 
 import { usePrivateState } from '@hooks/use-private-state';
 
@@ -43,9 +44,9 @@ interface BackupSecretPhrasePasswordPageType {
 }
 
 interface VerifyPasswordMessageEvent extends MessageEvent {
-  data: {
+  data: WorkerResult<{
     isPasswordCorrect: boolean;
-  };
+  }>;
 }
 
 export const PasswordProtectionPage = ({
@@ -109,8 +110,25 @@ export const PasswordProtectionPage = ({
       password
     });
 
+    const handleWorkerFailure = () => {
+      worker.terminate();
+      setError('password', {
+        message: t('Something went wrong. Please try again.')
+      });
+      setIsSubmitting(false);
+    };
+
     worker.onmessage = (event: VerifyPasswordMessageEvent) => {
+      // a worker failure must not be read as a wrong password: that would burn
+      // a login attempt and eventually lock the wallet
+      if (isWorkerError(event.data)) {
+        handleWorkerFailure();
+        return;
+      }
+
       const { isPasswordCorrect } = event.data;
+
+      worker.terminate();
 
       if (!isPasswordCorrect) {
         dispatchToMainStore(loginRetryCountIncremented());
@@ -148,9 +166,11 @@ export const PasswordProtectionPage = ({
       }
     };
 
+    // only reached by a script load failure — a rejection inside the worker
+    // arrives through onmessage instead
     worker.onerror = error => {
       console.error(error);
-      setIsSubmitting(false);
+      handleWorkerFailure();
     };
   };
 

--- a/src/apps/popup/pages/wallet-qr-code/index.tsx
+++ b/src/apps/popup/pages/wallet-qr-code/index.tsx
@@ -9,6 +9,7 @@ import {
   selectVaultDerivedAccounts,
   selectVaultImportedAccounts
 } from '@background/redux/vault/selectors';
+import { WorkerResult, isWorkerError } from '@background/workers/types';
 
 import {
   HeaderPopup,
@@ -17,9 +18,9 @@ import {
 } from '@libs/layout';
 
 interface GenerateWalletQrDataMessageEvent extends MessageEvent {
-  data: {
+  data: WorkerResult<{
     result: string[];
-  };
+  }>;
 }
 
 export const WalletQrCodePage = () => {
@@ -39,8 +40,15 @@ export const WalletQrCodePage = () => {
     setIsPasswordConfirmed(true);
   }, []);
 
-  const generateQRCode = async (password: string) => {
-    if (secretPhrase) {
+  // resolves only once the QR data exists, so a worker failure rejects into the
+  // password page's catch instead of leaving it spinning forever
+  const generateQRCode = (password: string) =>
+    new Promise<void>((resolve, reject) => {
+      if (!secretPhrase) {
+        resolve();
+        return;
+      }
+
       setIsLoading(true);
 
       const worker = new Worker(
@@ -57,19 +65,31 @@ export const WalletQrCodePage = () => {
         importedAccounts
       });
 
+      const fail = (error: unknown) => {
+        worker.terminate();
+        setIsLoading(false);
+        reject(error);
+      };
+
       worker.onmessage = (event: GenerateWalletQrDataMessageEvent) => {
+        if (isWorkerError(event.data)) {
+          fail(new Error('Sync wallet QR generation failed'));
+          return;
+        }
+
         const { result } = event.data;
 
+        worker.terminate();
         setQrStrings(result);
+        setIsLoading(false);
         setPasswordConfirmed();
+        resolve();
       };
 
-      worker.onerror = error => {
-        console.error(error);
-        setIsLoading(false);
-      };
-    }
-  };
+      // only reached by a script load failure — a rejection inside the worker
+      // arrives through onmessage instead
+      worker.onerror = error => fail(error);
+    });
 
   if (!isPasswordConfirmed) {
     return (

--- a/src/background/redux/sagas/vault-sagas.test.ts
+++ b/src/background/redux/sagas/vault-sagas.test.ts
@@ -23,6 +23,7 @@ import * as bip32Module from '@libs/crypto/bip32';
 import * as vaultCryptoModule from '@libs/crypto/vault';
 import { FIXED_ENCRYPTION_KEY_HASH } from '@libs/crypto/__fixtures';
 import { decryptVault, encryptVault } from '@libs/crypto/vault';
+import { Account } from '@libs/types/account';
 
 import { keysUpdated } from '../keys/actions';
 import { lastActivityTimeRefreshed } from '../last-activity-time/actions';
@@ -43,7 +44,10 @@ import { vaultCipherCreated } from '../vault-cipher/actions';
 import { selectVaultCipherDoesExist } from '../vault-cipher/selectors';
 import {
   accountAdded,
+  accountImported,
   accountRenamed,
+  accountsAdded,
+  accountsImported,
   deployPayloadReceived,
   vaultLoaded
 } from '../vault/actions';
@@ -1242,5 +1246,79 @@ describe('saga error channel', () => {
     expect(effects.put).toContainEqual(
       put(sagaError({ source: 'timeoutCounterSaga', message: 'read failed' }))
     );
+  });
+});
+
+const NEW_ACCOUNT: Account = {
+  name: 'imported one',
+  publicKey: '01aa',
+  secretKey: 'c2VjcmV0',
+  hidden: false,
+  derivationIndex: 0
+};
+
+const ACTION_BY_NAME = {
+  accountAdded: accountAdded(NEW_ACCOUNT),
+  accountImported: accountImported({ ...NEW_ACCOUNT, imported: true }),
+  accountsAdded: accountsAdded([NEW_ACCOUNT]),
+  accountsImported: accountsImported([{ ...NEW_ACCOUNT, imported: true }])
+};
+
+describe('account mutations bypass the debounce', () => {
+  // An imported secret key exists nowhere else; losing it to a crash inside the
+  // debounce window is unrecoverable, unlike a rename.
+  it.each([
+    'accountImported',
+    'accountAdded',
+    'accountsImported',
+    'accountsAdded'
+  ])('re-encrypts on %s without waiting out the window', async actionName => {
+    const encryptSpy = jest
+      .spyOn(vaultCryptoModule, 'encryptVault')
+      .mockResolvedValue('cipher-blob');
+
+    await expectSaga(vaultSagas)
+      .provide([
+        [matchers.select.selector(selectEncryptionKeyHash), 'key-hash'],
+        [matchers.select.selector(selectVault), EMPTY_VAULT]
+      ])
+      .dispatch(ACTION_BY_NAME[actionName as keyof typeof ACTION_BY_NAME])
+      .silentRun(VAULT_REENCRYPT_DEBOUNCE_MS - 100);
+
+    expect(encryptSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('still coalesces the debounced actions', async () => {
+    const encryptSpy = jest
+      .spyOn(vaultCryptoModule, 'encryptVault')
+      .mockResolvedValue('cipher-blob');
+
+    await expectSaga(vaultSagas)
+      .provide([
+        [matchers.select.selector(selectEncryptionKeyHash), 'key-hash'],
+        [matchers.select.selector(selectVault), EMPTY_VAULT]
+      ])
+      .dispatch(accountRenamed({ oldName: 'a', newName: 'b' }))
+      .dispatch(accountRenamed({ oldName: 'b', newName: 'c' }))
+      .silentRun(VAULT_REENCRYPT_DEBOUNCE_MS + 200);
+
+    expect(encryptSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes immediately for an import and once more for a coincident rename', async () => {
+    const encryptSpy = jest
+      .spyOn(vaultCryptoModule, 'encryptVault')
+      .mockResolvedValue('cipher-blob');
+
+    await expectSaga(vaultSagas)
+      .provide([
+        [matchers.select.selector(selectEncryptionKeyHash), 'key-hash'],
+        [matchers.select.selector(selectVault), EMPTY_VAULT]
+      ])
+      .dispatch(ACTION_BY_NAME.accountImported)
+      .dispatch(accountRenamed({ oldName: 'a', newName: 'b' }))
+      .silentRun(VAULT_REENCRYPT_DEBOUNCE_MS + 200);
+
+    expect(encryptSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -127,10 +127,10 @@ export function* vaultSagas() {
   );
   // Unlike takeLatest, debounce does not cancel an in-flight run when the next
   // trigger arrives, so two updateVaultCipher runs could overlap and the staler
-  // cipher win — now also possibly a run from the takeEvery above. This relies
-  // on the invariant that a single encryption (~2ms measured, even on a
-  // 50-account vault) stays far below the 500ms debounce window — keep that
-  // true if the vault or crypto grows.
+  // cipher win. The takeEvery above makes overlap materially more likely — any
+  // account mutation now spawns a run immediately — so ordering rests entirely
+  // on a single encryption (~2ms measured) staying far below the 500ms window.
+  // Keep that true if the vault or crypto grows.
   yield debounce(
     VAULT_REENCRYPT_DEBOUNCE_MS,
     [

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -1,4 +1,10 @@
-import { debounce, put, select, takeLatest } from 'redux-saga/effects';
+import {
+  debounce,
+  put,
+  select,
+  takeEvery,
+  takeLatest
+} from 'redux-saga/effects';
 import { storage } from 'webextension-polyfill';
 
 import { getActiveAccountSupports, getUrlOrigin } from '@src/utils';
@@ -106,18 +112,28 @@ export function* vaultSagas() {
     ],
     timeoutCounterSaga
   );
-  // Unlike takeLatest, debounce does not cancel an in-flight run when the next
-  // trigger arrives, so two updateVaultCipher runs could overlap and the staler
-  // cipher win. This relies on the invariant that a single encryption
-  // (~2ms measured, even on a 50-account vault) stays far below the 500ms
-  // debounce window — keep that true if the vault or crypto grows.
-  yield debounce(
-    VAULT_REENCRYPT_DEBOUNCE_MS,
+  // Account mutations persist immediately: an imported secret key exists
+  // nowhere else, so losing it to a crash inside the debounce window is
+  // unrecoverable. The remaining triggers are re-derivable or cosmetic and
+  // keep the coalescing below.
+  yield takeEvery(
     [
       accountAdded.type,
       accountsAdded.type,
       accountImported.type,
-      accountsImported.type,
+      accountsImported.type
+    ],
+    updateVaultCipher
+  );
+  // Unlike takeLatest, debounce does not cancel an in-flight run when the next
+  // trigger arrives, so two updateVaultCipher runs could overlap and the staler
+  // cipher win — now also possibly a run from the takeEvery above. This relies
+  // on the invariant that a single encryption (~2ms measured, even on a
+  // 50-account vault) stays far below the 500ms debounce window — keep that
+  // true if the vault or crypto grows.
+  yield debounce(
+    VAULT_REENCRYPT_DEBOUNCE_MS,
+    [
       accountRemoved.type,
       accountRenamed.type,
       siteConnected.type,

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -128,9 +128,9 @@ export function* vaultSagas() {
   // Unlike takeLatest, debounce does not cancel an in-flight run when the next
   // trigger arrives, so two updateVaultCipher runs could overlap and the staler
   // cipher win. The takeEvery above makes overlap materially more likely — any
-  // account mutation now spawns a run immediately — so ordering rests entirely
-  // on a single encryption (~2ms measured) staying far below the 500ms window.
-  // Keep that true if the vault or crypto grows.
+  // account mutation now spawns a run immediately — so ordering rests on
+  // encryptVault having no `await`: overlapping runs resume strictly FIFO on the
+  // microtask queue. Breaks if encryption becomes async (WebCrypto, or a Worker).
   yield debounce(
     VAULT_REENCRYPT_DEBOUNCE_MS,
     [

--- a/src/background/redux/vault/selectors.test.ts
+++ b/src/background/redux/vault/selectors.test.ts
@@ -1,0 +1,29 @@
+import { RootState } from '@background/redux/store-types';
+
+import { Account, HardwareWalletType } from '@libs/types/account';
+
+import { selectVaultAccountsAvailableForExport } from './selectors';
+
+const accounts: Account[] = [
+  { name: 'alice', publicKey: '01alice', secretKey: 'sk-alice', hidden: false },
+  {
+    name: 'ledger',
+    publicKey: '01ledger',
+    secretKey: 'sk-ledger',
+    hidden: false,
+    hardware: HardwareWalletType.Ledger
+  },
+  {
+    name: 'watch',
+    publicKey: '01watch',
+    secretKey: '',
+    hidden: false,
+    imported: true
+  }
+];
+
+const state = { vault: { accounts } } as unknown as RootState;
+
+it('selectVaultAccountsAvailableForExport excludes hardware accounts and accounts with no secret key', () => {
+  expect(selectVaultAccountsAvailableForExport(state)).toEqual([accounts[0]]);
+});

--- a/src/background/redux/vault/selectors.ts
+++ b/src/background/redux/vault/selectors.ts
@@ -24,9 +24,16 @@ export const selectVaultAccountsPublicKeys = createSelector(
   accounts => accounts.map(account => account.publicKey)
 );
 
-export const selectVaultAccountsExceptLedgersAccounts = createSelector(
+const selectVaultAccountsExceptLedgersAccounts = createSelector(
   selectVaultAccounts,
   accounts => accounts.filter(account => !account.hardware)
+);
+
+// Watch accounts are stored with `secretKey: ''` and no `hardware` flag, so
+// they pass selectVaultAccountsExceptLedgersAccounts but have nothing to export.
+export const selectVaultAccountsAvailableForExport = createSelector(
+  selectVaultAccountsExceptLedgersAccounts,
+  accounts => accounts.filter(account => Boolean(account.secretKey))
 );
 
 export const selectVaultCountsOfAccounts = createSelector(

--- a/src/background/workers/create-password-worker.ts
+++ b/src/background/workers/create-password-worker.ts
@@ -18,22 +18,29 @@ interface CreatePasswordWorkerEvent extends MessageEvent {
 onmessage = async function (event: CreatePasswordWorkerEvent) {
   const { password, vault } = event.data;
 
-  const passwordSaltHash = generateRandomSaltHex();
-  const passwordHash = await encodePassword(password, passwordSaltHash);
-  const keyDerivationSaltHash = generateRandomSaltHex();
-  const newEncryptionKeyBytes = await deriveEncryptionKey(
-    password,
-    keyDerivationSaltHash
-  );
-  const newEncryptionKeyHash = convertBytesToHex(newEncryptionKeyBytes);
+  try {
+    const passwordSaltHash = generateRandomSaltHex();
+    const passwordHash = await encodePassword(password, passwordSaltHash);
+    const keyDerivationSaltHash = generateRandomSaltHex();
+    const newEncryptionKeyBytes = await deriveEncryptionKey(
+      password,
+      keyDerivationSaltHash
+    );
+    const newEncryptionKeyHash = convertBytesToHex(newEncryptionKeyBytes);
 
-  const newVaultCipher = await encryptVault(newEncryptionKeyHash, vault);
+    const newVaultCipher = await encryptVault(newEncryptionKeyHash, vault);
 
-  postMessage({
-    passwordHash,
-    passwordSaltHash,
-    newEncryptionKeyHash,
-    keyDerivationSaltHash,
-    newVaultCipher
-  });
+    postMessage({
+      passwordHash,
+      passwordSaltHash,
+      newEncryptionKeyHash,
+      keyDerivationSaltHash,
+      newVaultCipher
+    });
+  } catch (error) {
+    // a rejection inside an async onmessage raises no error event on the parent
+    // Worker, so the failure has to travel back as a message
+    console.error(error);
+    postMessage({ error: true });
+  }
 };

--- a/src/background/workers/generate-sync-wallet-qr-data-worker.ts
+++ b/src/background/workers/generate-sync-wallet-qr-data-worker.ts
@@ -20,43 +20,50 @@ onmessage = async function (event: GenerateSyncWalletQrDataEvent) {
   const { password, secretPhrase, derivedAccounts, importedAccounts } =
     event.data;
 
-  const salt = randomBytes(16);
-  const iv = randomBytes(16);
+  try {
+    const salt = randomBytes(16);
+    const iv = randomBytes(16);
 
-  const key = await scryptAsync(password, salt, createScryptOptions());
+    const key = await scryptAsync(password, salt, createScryptOptions());
 
-  const qrDataString = JSON.stringify([
-    secretPhrase.join(' '),
-    derivedAccounts.map(da => da.name),
-    [
-      ...importedAccounts.map(acc => ({
-        secretKey: acc.secretKey,
-        label: acc.name,
-        publicKeyTag: PublicKey.fromHex(acc.publicKey).cryptoAlg
-      }))
-    ]
-  ]);
+    const qrDataString = JSON.stringify([
+      secretPhrase.join(' '),
+      derivedAccounts.map(da => da.name),
+      [
+        ...importedAccounts.map(acc => ({
+          secretKey: acc.secretKey,
+          label: acc.name,
+          publicKeyTag: PublicKey.fromHex(acc.publicKey).cryptoAlg
+        }))
+      ]
+    ]);
 
-  const data = Uint8Array.from(Buffer.from(qrDataString));
+    const data = Uint8Array.from(Buffer.from(qrDataString));
 
-  const stream = cbc(key, iv);
-  const cipher = stream.encrypt(data);
+    const stream = cbc(key, iv);
+    const cipher = stream.encrypt(data);
 
-  const qrString = JSON.stringify([
-    convertBytesToBase64(cipher),
-    convertBytesToBase64(salt),
-    convertBytesToBase64(iv)
-  ]);
+    const qrString = JSON.stringify([
+      convertBytesToBase64(cipher),
+      convertBytesToBase64(salt),
+      convertBytesToBase64(iv)
+    ]);
 
-  const qrBytes = Uint8Array.from(Buffer.from(qrString));
-  const qrData = convertBytesToBase64(qrBytes);
-  const qrDataArray = qrData.match(/.{1,200}/g);
+    const qrBytes = Uint8Array.from(Buffer.from(qrString));
+    const qrData = convertBytesToBase64(qrBytes);
+    const qrDataArray = qrData.match(/.{1,200}/g);
 
-  const result = (qrDataArray ?? [qrData]).map(
-    (qr, i, arr) => `${i + 1}$${arr.length}$${qr}`
-  );
+    const result = (qrDataArray ?? [qrData]).map(
+      (qr, i, arr) => `${i + 1}$${arr.length}$${qr}`
+    );
 
-  postMessage({
-    result
-  });
+    postMessage({
+      result
+    });
+  } catch (error) {
+    // a rejection inside an async onmessage raises no error event on the parent
+    // Worker, so the failure has to travel back as a message
+    console.error(error);
+    postMessage({ error: true });
+  }
 };

--- a/src/background/workers/types.ts
+++ b/src/background/workers/types.ts
@@ -1,0 +1,10 @@
+export interface WorkerErrorMessage {
+  error: true;
+}
+
+export type WorkerResult<T> = T | WorkerErrorMessage;
+
+export const isWorkerError = (data: unknown): data is WorkerErrorMessage =>
+  typeof data === 'object' &&
+  data !== null &&
+  (data as WorkerErrorMessage).error === true;

--- a/src/background/workers/unlock-vault-worker.ts
+++ b/src/background/workers/unlock-vault-worker.ts
@@ -24,30 +24,37 @@ interface UnlockVaultMessageEvent extends MessageEvent {
 onmessage = async function (event: UnlockVaultMessageEvent) {
   const { password, keyDerivationSaltHash, vaultCipher } = event.data;
 
-  const encryptionKeyBytes = await deriveEncryptionKey(
-    password,
-    keyDerivationSaltHash
-  );
+  try {
+    const encryptionKeyBytes = await deriveEncryptionKey(
+      password,
+      keyDerivationSaltHash
+    );
 
-  const encryptionKeyHash = convertBytesToHex(encryptionKeyBytes);
-  // decrypt cipher
-  const vault = await decryptVault(encryptionKeyHash, vaultCipher);
+    const encryptionKeyHash = convertBytesToHex(encryptionKeyBytes);
+    // decrypt cipher
+    const vault = await decryptVault(encryptionKeyHash, vaultCipher);
 
-  // derive a new random encryption key
-  const newKeyDerivationSaltHash = generateRandomSaltHex();
-  const newEncryptionKeyBytes = await deriveEncryptionKey(
-    password,
-    newKeyDerivationSaltHash
-  );
-  const newEncryptionKeyHash = convertBytesToHex(newEncryptionKeyBytes);
+    // derive a new random encryption key
+    const newKeyDerivationSaltHash = generateRandomSaltHex();
+    const newEncryptionKeyBytes = await deriveEncryptionKey(
+      password,
+      newKeyDerivationSaltHash
+    );
+    const newEncryptionKeyHash = convertBytesToHex(newEncryptionKeyBytes);
 
-  // encrypt cipher with the new key
-  const newVaultCipher = await encryptVault(newEncryptionKeyHash, vault);
+    // encrypt cipher with the new key
+    const newVaultCipher = await encryptVault(newEncryptionKeyHash, vault);
 
-  postMessage({
-    vault,
-    newVaultCipher,
-    newKeyDerivationSaltHash,
-    newEncryptionKeyHash
-  });
+    postMessage({
+      vault,
+      newVaultCipher,
+      newKeyDerivationSaltHash,
+      newEncryptionKeyHash
+    });
+  } catch (error) {
+    // a rejection inside an async onmessage raises no error event on the parent
+    // Worker, so the failure has to travel back as a message
+    console.error(error);
+    postMessage({ error: true });
+  }
 };

--- a/src/background/workers/verify-password-worker.ts
+++ b/src/background/workers/verify-password-worker.ts
@@ -10,13 +10,21 @@ interface VerifyPasswordEvent extends MessageEvent {
 
 onmessage = async (event: VerifyPasswordEvent) => {
   const { passwordHash, passwordSaltHash, password } = event.data;
-  const isPasswordCorrect = await verifyPasswordAgainstHash(
-    passwordHash,
-    passwordSaltHash,
-    password
-  );
 
-  postMessage({
-    isPasswordCorrect
-  });
+  try {
+    const isPasswordCorrect = await verifyPasswordAgainstHash(
+      passwordHash,
+      passwordSaltHash,
+      password
+    );
+
+    postMessage({
+      isPasswordCorrect
+    });
+  } catch (error) {
+    // a rejection inside an async onmessage raises no error event on the parent
+    // Worker, so the failure has to travel back as a message
+    console.error(error);
+    postMessage({ error: true });
+  }
 };

--- a/src/background/workers/workers.test.ts
+++ b/src/background/workers/workers.test.ts
@@ -4,10 +4,15 @@ jest.mock('@libs/crypto/hashing', () => ({
   generateRandomSaltHex: jest.fn(() => 'salt'),
   encodePassword: jest.fn(async () => 'hash'),
   deriveEncryptionKey: jest.fn(async () => new Uint8Array([1])),
-  verifyPasswordAgainstHash: jest.fn(async () => true)
+  verifyPasswordAgainstHash: jest.fn(async () => true),
+  createScryptOptions: jest.fn(() => ({ N: 2, r: 8, p: 1, dkLen: 32 }))
+}));
+jest.mock('@noble/hashes/scrypt', () => ({
+  scryptAsync: jest.fn(async () => new Uint8Array(32))
 }));
 jest.mock('@libs/crypto/utils', () => ({
-  convertBytesToHex: jest.fn(() => 'key')
+  convertBytesToHex: jest.fn(() => 'key'),
+  convertBytesToBase64: jest.fn(() => 'base64')
 }));
 jest.mock('@libs/crypto/vault', () => ({
   encryptVault: jest.fn(async () => 'cipher'),
@@ -55,6 +60,20 @@ const WORKERS = [
       jest
         .requireMock('@libs/crypto/vault')
         .decryptVault.mockRejectedValueOnce(new Error('bad tag'))
+  },
+  {
+    name: 'generate-sync-wallet-qr-data-worker',
+    path: './generate-sync-wallet-qr-data-worker',
+    data: {
+      password: 'p',
+      secretPhrase: ['word'],
+      derivedAccounts: [],
+      importedAccounts: []
+    },
+    breakIt: () =>
+      jest
+        .requireMock('@noble/hashes/scrypt')
+        .scryptAsync.mockRejectedValueOnce(new Error('boom'))
   },
   {
     name: 'verify-password-worker',

--- a/src/background/workers/workers.test.ts
+++ b/src/background/workers/workers.test.ts
@@ -1,0 +1,109 @@
+import { isWorkerError } from './types';
+
+jest.mock('@libs/crypto/hashing', () => ({
+  generateRandomSaltHex: jest.fn(() => 'salt'),
+  encodePassword: jest.fn(async () => 'hash'),
+  deriveEncryptionKey: jest.fn(async () => new Uint8Array([1])),
+  verifyPasswordAgainstHash: jest.fn(async () => true)
+}));
+jest.mock('@libs/crypto/utils', () => ({
+  convertBytesToHex: jest.fn(() => 'key')
+}));
+jest.mock('@libs/crypto/vault', () => ({
+  encryptVault: jest.fn(async () => 'cipher'),
+  decryptVault: jest.fn(async () => ({ accounts: [] }))
+}));
+
+type WorkerGlobals = {
+  onmessage?: (event: { data: unknown }) => Promise<void>;
+  postMessage?: (message: unknown) => void;
+};
+
+const workerGlobals = globalThis as unknown as WorkerGlobals;
+
+const runWorker = async (modulePath: string, data: unknown) => {
+  const posted: unknown[] = [];
+
+  workerGlobals.onmessage = undefined;
+  workerGlobals.postMessage = message => {
+    posted.push(message);
+  };
+
+  await import(modulePath);
+  await workerGlobals.onmessage!({ data });
+
+  return posted;
+};
+
+const WORKERS = [
+  {
+    name: 'create-password-worker',
+    path: './create-password-worker',
+    data: { password: 'p', vault: { accounts: [] } },
+    breakIt: () =>
+      jest
+        .requireMock('@libs/crypto/hashing')
+        .encodePassword.mockRejectedValueOnce(
+          new Error('encodePassword failed!')
+        )
+  },
+  {
+    name: 'unlock-vault-worker',
+    path: './unlock-vault-worker',
+    data: { password: 'p', keyDerivationSaltHash: 'salt', vaultCipher: 'c' },
+    breakIt: () =>
+      jest
+        .requireMock('@libs/crypto/vault')
+        .decryptVault.mockRejectedValueOnce(new Error('bad tag'))
+  },
+  {
+    name: 'verify-password-worker',
+    path: './verify-password-worker',
+    data: { passwordHash: 'h', passwordSaltHash: 's', password: 'p' },
+    breakIt: () =>
+      jest
+        .requireMock('@libs/crypto/hashing')
+        .verifyPasswordAgainstHash.mockRejectedValueOnce(new Error('boom'))
+  }
+];
+
+describe.each(WORKERS)('$name', ({ path, data, breakIt }) => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('posts a result on success', async () => {
+    const posted = await runWorker(path, data);
+
+    expect(posted).toHaveLength(1);
+    expect(isWorkerError(posted[0])).toBe(false);
+  });
+
+  // a rejection inside an async onmessage raises no error event on the parent
+  // Worker, so the only way the page can learn about it is this message
+  it('posts an error message when the crypto layer rejects', async () => {
+    breakIt();
+
+    const posted = await runWorker(path, data);
+
+    expect(posted).toEqual([{ error: true }]);
+  });
+});
+
+describe('isWorkerError', () => {
+  it.each([
+    [{ error: true }, true],
+    [{ error: false }, false],
+    [{ isPasswordCorrect: true }, false],
+    [null, false],
+    [undefined, false],
+    ['error', false]
+  ])('%p -> %p', (data, expected) => {
+    expect(isWorkerError(data)).toBe(expected);
+  });
+});

--- a/src/libs/crypto/hashing.test.ts
+++ b/src/libs/crypto/hashing.test.ts
@@ -89,6 +89,14 @@ describe('constantTimeEqualHex', () => {
 
   it('does not throw on non-hex garbage input', () => {
     expect(() => constantTimeEqualHex('zzzz', 'zzzz')).not.toThrow();
-    expect(constantTimeEqualHex('zzzz', 'zzzz')).toBe(true);
+    expect(constantTimeEqualHex('zzzz', 'zzzz')).toBe(false);
+  });
+
+  it('rejects inputs that truncate to the same bytes but are not equal hex', () => {
+    expect(constantTimeEqualHex('abzz', 'abyy')).toBe(false);
+  });
+
+  it('rejects odd-length inputs that decode short', () => {
+    expect(constantTimeEqualHex('abc', 'abd')).toBe(false);
   });
 });

--- a/src/libs/crypto/hashing.test.ts
+++ b/src/libs/crypto/hashing.test.ts
@@ -22,6 +22,15 @@ describe('crypto.hashing', () => {
     expect(result).toBeTruthy();
   });
 
+  it('routes through the constant-time comparison, not ===: an upper-case hash still verifies', async () => {
+    const result = await verifyPasswordAgainstHash(
+      FIXED_PASSWORD_HASH.toUpperCase(),
+      FIXED_PASSWORD_SALT,
+      FIXED_PASSWORD_TEXT
+    );
+    expect(result).toBe(true);
+  });
+
   it('should match password text that created it', async () => {
     const passwordHash = await encodePassword(
       FIXED_PASSWORD_TEXT,

--- a/src/libs/crypto/hashing.test.ts
+++ b/src/libs/crypto/hashing.test.ts
@@ -6,6 +6,7 @@ import {
   FIXED_PASSWORD_TEXT
 } from './__fixtures';
 import {
+  constantTimeEqualHex,
   deriveEncryptionKey,
   encodePassword,
   verifyPasswordAgainstHash
@@ -62,5 +63,32 @@ describe('crypto.hashing', () => {
       FIXED_ENCRYPTION_SALT
     );
     expect(Buffer.from(key).toString('hex')).toBe(FIXED_ENCRYPTION_KEY_HASH);
+  });
+});
+
+describe('constantTimeEqualHex', () => {
+  it('accepts identical hex', () => {
+    expect(constantTimeEqualHex(FIXED_PASSWORD_HASH, FIXED_PASSWORD_HASH)).toBe(
+      true
+    );
+  });
+
+  it('rejects a single flipped bit', () => {
+    const flipped =
+      FIXED_PASSWORD_HASH.slice(0, -1) +
+      (FIXED_PASSWORD_HASH.endsWith('0') ? '1' : '0');
+
+    expect(constantTimeEqualHex(FIXED_PASSWORD_HASH, flipped)).toBe(false);
+  });
+
+  it('rejects different lengths without throwing', () => {
+    expect(constantTimeEqualHex(FIXED_PASSWORD_HASH, 'ab')).toBe(false);
+    expect(constantTimeEqualHex('', FIXED_PASSWORD_HASH)).toBe(false);
+    expect(constantTimeEqualHex('', '')).toBe(true);
+  });
+
+  it('does not throw on non-hex garbage input', () => {
+    expect(() => constantTimeEqualHex('zzzz', 'zzzz')).not.toThrow();
+    expect(constantTimeEqualHex('zzzz', 'zzzz')).toBe(true);
   });
 });

--- a/src/libs/crypto/hashing.ts
+++ b/src/libs/crypto/hashing.ts
@@ -39,6 +39,12 @@ export function constantTimeEqualHex(a: string, b: string): boolean {
   const left = convertHexToBytes(a);
   const right = convertHexToBytes(b);
 
+  // Buffer.from(hex) truncates at a dangling nibble or the first non-hex
+  // character, so a short decode means the input was not canonical hex.
+  if (left.length !== a.length / 2 || right.length !== b.length / 2) {
+    return false;
+  }
+
   let diff = 0;
   // must scan every byte — returning early on the first mismatch reintroduces the timing leak
   for (let i = 0; i < left.length; i++) {

--- a/src/libs/crypto/hashing.ts
+++ b/src/libs/crypto/hashing.ts
@@ -31,6 +31,23 @@ export async function encodePassword(
     });
 }
 
+export function constantTimeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  const left = convertHexToBytes(a);
+  const right = convertHexToBytes(b);
+
+  let diff = 0;
+  // must scan every byte — returning early on the first mismatch reintroduces the timing leak
+  for (let i = 0; i < left.length; i++) {
+    diff |= left[i] ^ right[i];
+  }
+
+  return diff === 0;
+}
+
 export async function verifyPasswordAgainstHash(
   passwordHash: string,
   passwordSaltHash: string,
@@ -38,7 +55,7 @@ export async function verifyPasswordAgainstHash(
 ): Promise<boolean> {
   const digest = await encodePassword(password || '', passwordSaltHash);
 
-  return passwordHash === digest;
+  return constantTimeEqualHex(passwordHash, digest);
 }
 
 export async function deriveEncryptionKey(

--- a/src/libs/layout/unlock-vault/index.tsx
+++ b/src/libs/layout/unlock-vault/index.tsx
@@ -194,11 +194,17 @@ export const UnlockVaultPage = ({ popupLayout }: UnlockVaultPageProps) => {
 
     verifyPasswordWorker.onerror = error => {
       console.error(error);
+      setError('password', {
+        message: t('Something went wrong. Please try again.')
+      });
       setIsLoading(false);
     };
 
     unlockVaultWorker.onerror = error => {
       console.error(error);
+      setError('password', {
+        message: t('Something went wrong. Please try again.')
+      });
       setIsLoading(false);
     };
   }

--- a/src/libs/layout/unlock-vault/index.tsx
+++ b/src/libs/layout/unlock-vault/index.tsx
@@ -18,6 +18,7 @@ import { unlockVault } from '@background/redux/sagas/actions';
 import { UnlockVault } from '@background/redux/sagas/types';
 import { dispatchToMainStore } from '@background/redux/utils';
 import { VaultState } from '@background/redux/vault/types';
+import { WorkerResult, isWorkerError } from '@background/workers/types';
 
 import { useLockWalletWhenNoMoreRetries } from '@hooks/use-lock-wallet-when-no-more-retries';
 import { usePrivateState } from '@hooks/use-private-state';
@@ -40,7 +41,7 @@ import { UnlockWalletFormValues } from '@libs/ui/forms/unlock-wallet';
 import { UnlockVaultPageContent } from './content';
 
 interface UnlockMessageEvent extends MessageEvent {
-  data: UnlockVault;
+  data: WorkerResult<UnlockVault>;
 }
 
 interface UnlockVaultPageProps {
@@ -48,9 +49,9 @@ interface UnlockVaultPageProps {
 }
 
 interface VerifyPasswordMessageEvent extends MessageEvent {
-  data: {
+  data: WorkerResult<{
     isPasswordCorrect: boolean;
-  };
+  }>;
 }
 
 export const UnlockVaultPage = ({ popupLayout }: UnlockVaultPageProps) => {
@@ -111,6 +112,19 @@ export const UnlockVaultPage = ({ popupLayout }: UnlockVaultPageProps) => {
       throw Error("Key derivation salt doesn't exist");
     }
 
+    const disposeWorkers = () => {
+      verifyPasswordWorker.terminate();
+      unlockVaultWorker.terminate();
+    };
+
+    const handleWorkerFailure = () => {
+      disposeWorkers();
+      setError('password', {
+        message: t('Something went wrong. Please try again.')
+      });
+      setIsLoading(false);
+    };
+
     verifyPasswordWorker.postMessage({
       passwordHash,
       passwordSaltHash,
@@ -118,16 +132,23 @@ export const UnlockVaultPage = ({ popupLayout }: UnlockVaultPageProps) => {
     });
 
     verifyPasswordWorker.onmessage = (event: VerifyPasswordMessageEvent) => {
+      if (isWorkerError(event.data)) {
+        handleWorkerFailure();
+        return;
+      }
+
       const { isPasswordCorrect } = event.data;
       const errorMessage = getErrorMessageForIncorrectPassword(attemptsLeft);
 
       if (!isPasswordCorrect) {
+        disposeWorkers();
         dispatchToMainStore(loginRetryCountIncremented());
         setError('password', {
           message: t(errorMessage)
         });
         setIsLoading(false);
       } else {
+        verifyPasswordWorker.terminate();
         unlockVaultWorker.postMessage({
           password,
           keyDerivationSaltHash,
@@ -137,12 +158,19 @@ export const UnlockVaultPage = ({ popupLayout }: UnlockVaultPageProps) => {
     };
 
     unlockVaultWorker.onmessage = (event: UnlockMessageEvent) => {
+      if (isWorkerError(event.data)) {
+        handleWorkerFailure();
+        return;
+      }
+
       const {
         vault,
         newKeyDerivationSaltHash,
         newVaultCipher,
         newEncryptionKeyHash
       } = event.data;
+
+      unlockVaultWorker.terminate();
 
       // We should not store checksummed public keys because of possible issues on connect apps
       // that does not migrate to the new casper SDK behavior
@@ -192,20 +220,16 @@ export const UnlockVaultPage = ({ popupLayout }: UnlockVaultPageProps) => {
       }
     };
 
+    // only reached by a script load failure — a rejection inside a worker
+    // arrives through onmessage instead
     verifyPasswordWorker.onerror = error => {
       console.error(error);
-      setError('password', {
-        message: t('Something went wrong. Please try again.')
-      });
-      setIsLoading(false);
+      handleWorkerFailure();
     };
 
     unlockVaultWorker.onerror = error => {
       console.error(error);
-      setError('password', {
-        message: t('Something went wrong. Please try again.')
-      });
-      setIsLoading(false);
+      handleWorkerFailure();
     };
   }
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -173,7 +173,7 @@ describe('getSafariCspContent', () => {
       'script-src': "'self' 'wasm-unsafe-eval'",
       'img-src': 'https: data:',
       'media-src': 'https: data:',
-      'style-src': "'unsafe-inline'",
+      'style-src': "'self' 'unsafe-inline'",
       'connect-src': [
         'https://event-store-api-clarity-testnet.make.services',
         'https://event-store-api-clarity-mainnet.make.services',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -169,7 +169,7 @@ export const getSigningAccount = (
  * changes what Safari enforces.
  */
 export const getSafariCspContent = () =>
-  `${cspConfig.baseDirectives}; style-src 'unsafe-inline'; connect-src ${cspConfig.connectSrc.join(' ')}`;
+  `${cspConfig.baseDirectives}; style-src 'self' 'unsafe-inline'; connect-src ${cspConfig.connectSrc.join(' ')}`;
 
 export const setCSPForSafari = () => {
   if (isSafariBuild) {

--- a/src/webpack-config.test.ts
+++ b/src/webpack-config.test.ts
@@ -215,7 +215,7 @@ describe('webpack.config.js CSP nonce', () => {
           expect(nonceLiteral).toBe('null');
 
           if (csp !== undefined) {
-            expect(csp).toContain("style-src 'unsafe-inline'");
+            expect(csp).toContain("style-src 'self' 'unsafe-inline'");
             expect(csp).not.toContain('nonce-');
           }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,10 +86,10 @@ const getCSP = () => {
   // The latter is unavoidable: React applies every `style={{…}}` prop and lottie-web /
   // react-loading-skeleton / react-tiny-popover mutate element.style at runtime, all of
   // which the CSP treats as "applying inline style" — a nonce cannot cover them. Dev,
-  // Firefox and Safari keep the previous 'unsafe-inline' behaviour.
+  // Firefox and Safari keep 'unsafe-inline' plus 'self' so packaged stylesheets (fonts.css) still load.
   const styleDirectives = CSP_NONCE
     ? `style-src 'self' 'nonce-${CSP_NONCE}'; style-src-attr 'unsafe-inline'`
-    : "style-src 'unsafe-inline'";
+    : "style-src 'self' 'unsafe-inline'";
   // `baseDirectives` (which now also carries img-src/media-src) and `connectSrc`
   // are shared with the Safari runtime <meta> policy in src/utils.ts — see
   // src/csp.json. Only the style arm differs per target, so it stays here.


### PR DESCRIPTION
Closes the six residual P3 defects recorded in WALLET-1364. #1465 — which introduced the
`runKeysDownload` extraction this branch builds on — is merged, so this now sits directly on
`develop`.

Jira: https://make-software.atlassian.net/browse/WALLET-1364

## What each change removes

| #   | Defect                                                        | What the user experienced                                                                                                                                                                                                                                                                                            |
| --- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 10  | Account mutations waited out the re-encrypt debounce          | A browser quit or MV3 worker kill inside the 500 ms window dropped the last vault mutation. When that was an **imported** account, the secret key was gone — it exists nowhere else. The four account-mutating actions now persist immediately via `takeEvery`; everything re-derivable or cosmetic stays debounced. |
| 11  | A failed password change looked exactly like a successful one | `navigate(Home)` sat outside both worker callbacks and ran unconditionally. The user landed on Home believing their password had changed when it had not. Navigation now happens only on a successful worker result; a failure shows a field error and stays put.                                                    |
| 12  | Unlock worker errors said nothing                             | Both error paths stopped the spinner with no message — indistinguishable from a wrong password, which the same screen reports properly a few lines above.                                                                                                                                                            |
| 13  | A partial key archive was presented as success                | Accounts whose `createAsymmetricKeys` returned `secretKey: null` were silently omitted from the zip while Success was shown. Now the export fails loudly, **before** anything is written to disk, and logs a count only.                                                                                             |
| 14  | Password hash compared with `===`                             | Short-circuits at the first differing character. Now a constant-time comparison over the decoded bytes.                                                                                                                                                                                                              |
| 16  | Non-Chrome `style-src` had no `'self'`                        | A source list of only `'unsafe-inline'` matches no external stylesheet, and every app template links `/assets/fonts/fonts.css`. Fixed in `webpack.config.js` and in Safari's hand-maintained runtime CSP in `src/utils.ts`, which had drifted the same way.                                                          |

Item 15 (QR sync uses AES-CBC with no MAC) is **deliberately not fixed** — see below.

## What the review round changed

Three findings, all confirmed against the code before acting on them. The first was the important
one: it meant items 11 and 12 were not actually delivered.

**`onerror` could not fire for the failures it was added to report.** Every worker in this repo is
written `onmessage = async` with no `try`/`catch`, so anything that throws inside — `encodePassword`,
`deriveEncryptionKey`, `decryptVault`'s GCM tag check, `encryptVault`'s missing-vault guard —
becomes a rejected promise, and a rejection inside a worker raises no `error` event on the parent
`Worker`. Only a script *load* failure reaches `onerror`. In `change-password` that was worse than
the bug it replaced: `isSubmitting` was cleared only inside `onerror`, so a rejected worker left the
button disabled on `Loading` forever, with no message and no navigation. Before this PR the user at
least left the page.

Failures now travel as a message. `src/background/workers/types.ts` holds the contract —
`{ error: true }` with no payload (the error object stays in the worker's console rather than
reaching the UI), plus `WorkerResult<T>` and an `isWorkerError` guard. Each worker wraps its body;
each page branches on the guard. `onerror` is kept for the script-load case it does cover.

**The defect was wider than this PR's diff.** `generate-sync-wallet-qr-data-worker.ts` has the same
shape and the same dead `onerror`, and it can throw for real — `scryptAsync`, `PublicKey.fromHex` on
a corrupt imported key. Worse, `generateQRCode` was `async` but resolved as soon as the worker was
constructed, so the `.catch` that `PasswordProtectionPage` already wraps `onClick` in was
unreachable and the page span forever. It now returns a promise that resolves when the QR data
exists and rejects on failure. **The cipher is untouched** — this is delivery of the failure, not the
format; item 15 below still stands.

**`password-protection-page` had to be pulled in.** It consumes the same verify-password worker, and
without handling `{ error: true }` a worker failure would have destructured `isPasswordCorrect:
undefined` and read as a *wrong password* — dispatching `loginRetryCountIncremented()`, burning a
login attempt and eventually locking the wallet. That would have been a new bug, not a leftover. Its
own `onerror` is no longer silent either, which closes a parity gap this description previously left
open.

**The change-password worker outlived its page.** It was never terminated and there was no unmount
cleanup, while the back link stays live throughout — only the submit button is disabled. Pressing
back during the worker's ~1-2 s of scrypt still committed the rotation from a stale closure, so the
user's *next* unlock with the old password would fail. React-router does not stop the `navigate` that
follows either: in the installed 7.18.2, `activeRef.current = true` is set in a layout effect with no
cleanup, so the post-unmount guard passes. The worker is now held in a ref and terminated on unmount,
and both callbacks check a mounted flag. The back link stays enabled — cancelling mid-scrypt now
genuinely cancels. `unlock-vault` was also spawning two workers per submit and terminating neither;
it now disposes them.

**The constant-time comparison was unwireable without turning anything red.** `constantTimeEqualHex`
was tested thoroughly in isolation, but nothing observed that `verifyPasswordAgainstHash` routed
through it — its three tests assert only correct → truthy and wrong → falsy, which plain `===`
satisfies identically. Reverting the call site left the suite green. An upper-case hash is the one
input where the two differ, and that assertion is now in the suite.

## Two things an earlier review found

**A watch account used to break the whole export.** Watch accounts are stored with `secretKey: ''`
and no `hardware` flag, so they passed the export list's `!account.hardware` filter. Item 13's
fail-loudly rule then meant a user with three real accounts and one watch account got **no archive
at all**. That is worse than the bug being fixed, so the export list now excludes accounts with
nothing to export (`selectVaultAccountsAvailableForExport`), and the hard failure is reserved for a
genuinely unexpected null — data corruption, which should still never be shown as success.

**Change-password now waits for the worker, so it needed a submitting state.** Navigation correctly
moved inside the success path, which leaves the page on screen for the worker's two scrypt passes
(N=2¹⁸, roughly 1-2 s). Without a guard, two taps spawn two ~256 MB scrypt workers in the popup.
It now mirrors the `isSubmitting` pattern already used by `password-protection-page`.

## Limitations, stated rather than buried

- **The constant-time property is not test-enforceable here.** Mutating the loop to `break` on the
  first mismatch does not change the output — `|=` is monotonic — only the timing. What the tests now
  prove is that the comparison is _correct_ and that the call site routes through it; the in-code
  comment is still the only thing standing between a future edit and a reintroduced short-circuit.
- **The React paths have no automated coverage.** This project's jest runs
  `testEnvironment: 'node'` with no jsdom, so `change-password`, `unlock-vault`,
  `password-protection-page` and `wallet-qr-code` cannot be unit-tested. Code reading was the only
  verification. Items to click through are listed below. The workers themselves _are_ covered —
  see `src/background/workers/workers.test.ts`, which drives all four through a stubbed
  `globalThis.onmessage`/`postMessage`.
- `change-password` disables the submit button while the worker runs, but unlike its sibling
  `password-protection-page` it does not also guard Enter re-submission or make the field
  read-only. The button guard covers the double-tap vector; the parity gap is noted rather than
  closed here.
- The string `Something went wrong. Please try again.` has no catalogue entry, so the eight
  non-English locales fall back to English. `locale:extract_pot` was deliberately not run — `lang/`
  is hundreds of msgids behind and regenerating it would swamp this diff. A shorter
  `Something went wrong` already exists in four places; consolidating is a reasonable follow-up.

## Why item 15 is not here

`generate-sync-wallet-qr-data-worker.ts` still uses AES-CBC with no MAC. The format is a
**cross-application contract**: `casper-wallet-mobile/src/utils/aes/index.ts` decrypts it with
`aes-256-cbc` and identical scrypt parameters (N = 2¹⁸, r = 8, p = 1, dkLen = 32), and its
`react-native-aes-crypto` exposes CBC only. Changing the extension alone breaks wallet sync until a
matching mobile release ships. The residual risk is also narrow — the ciphertext travels from the
user's own screen to their own camera. If picked up, it needs a versioned envelope landed on mobile
first. The review round touched this worker's *error delivery* only; the ciphertext it produces is
byte-for-byte what it was.

## Please verify before merging

The CSP change needs a real browser, which is the one thing this branch cannot settle itself:

1. `npm run build:firefox`, load `build/firefox` via `about:debugging`, open the popup and the
   onboarding page, and check the console for a blocked-stylesheet violation on `fonts.css` —
   before and after. Same for the Safari build.
2. Change password: confirm it lands on Home only after the worker finishes, and that the button is
   disabled while it runs. Then start a change and press **back** during the scrypt pass — the old
   password must still unlock afterwards.
3. Unlock with a wrong password — the message must still be the wrong-password one, not
   `Something went wrong`.
4. Sync wallet QR — confirm the happy path still produces a scannable code, since its page function
   was promisified.
5. Export keys with a watch account present, using "select all" — the watch account should not be
   offered at all.

`npm run ci-check` is green: 94 suites, 903 tests.
