### PR TITLE
fix: WALLET-1394 — keep the approval window out of reuse during a Ledger confirmation

### DIFF
--- a/src/background/handlers/close-ledger-flow-windows.test.ts
+++ b/src/background/handlers/close-ledger-flow-windows.test.ts
@@ -32,7 +32,8 @@ const openRequest = (windowIds: number[]): Request => ({
   tabId: 1,
   origin: 'https://dapp.example',
   method: 'sign',
-  windowIds
+  windowIds,
+  awaitingDeviceConfirmation: false
 });
 
 const removedIds = () => removeMock.mock.calls.map(([id]) => id).sort();

--- a/src/background/handlers/redux-actions.parity.test.ts
+++ b/src/background/handlers/redux-actions.parity.test.ts
@@ -142,6 +142,12 @@ const EXCLUSIONS: ReadonlySet<string> = new Set(
     // request whose set can never shrink to the window that went away is a
     // request nothing can ever cancel.
     windowManagementActions.windowRequestWindowAttached,
+    // UI-dispatched (use-ledger, around the device call), but intercepted by its
+    // own branch in handleReduxAction — deliberately not in the forwarding set,
+    // which checks no sender at all. It decides whether the shared approval
+    // window may be reused, so a page must only be able to set it on the request
+    // its own URL names.
+    windowManagementActions.windowRequestDeviceConfirmationChanged,
     // UI-dispatched (use-ledger, when a Ledger flow ends), but intercepted by
     // the dedicated `closeLedgerFlowWindows` branch in handleReduxAction —
     // deliberately not in the forwarding set. It has no reducer case at all, so

--- a/src/background/handlers/redux-actions.test.ts
+++ b/src/background/handlers/redux-actions.test.ts
@@ -7,7 +7,10 @@ import { MainStore } from '@background/redux/get-main-store';
 import { closeLedgerFlowWindows } from '@background/redux/ledger/actions';
 import { lockVault, resetVault } from '@background/redux/sagas/actions';
 import { accountRenamed } from '@background/redux/vault/actions';
-import { windowRequestWindowAttached } from '@background/redux/windowManagement/actions';
+import {
+  windowRequestDeviceConfirmationChanged,
+  windowRequestWindowAttached
+} from '@background/redux/windowManagement/actions';
 
 import { handleCloseLedgerFlowWindows } from './close-ledger-flow-windows';
 import { handleReduxAction } from './redux-actions';
@@ -368,5 +371,73 @@ describe('handleReduxAction forwarding gate (fail-closed)', () => {
       error
     );
     consoleError.mockRestore();
+  });
+
+  describe('windowRequestDeviceConfirmationChanged', () => {
+    // It decides whether the shared approval window may be reused, so it is
+    // gated like its two siblings rather than left in the forwarding set, which
+    // checks no sender at all.
+    it('reaches the store when the page names the request it displays', async () => {
+      const { store, dispatch } = makeStore();
+      const action = windowRequestDeviceConfirmationChanged({
+        requestId: 'r1',
+        awaiting: true
+      });
+
+      const result = await handleReduxAction(action, trustedSenderForR1, store);
+
+      expect(dispatch).toHaveBeenCalledWith(action);
+      expect(result).toEqual({ handled: true, response: undefined });
+    });
+
+    it('is dropped from an untrusted sender', async () => {
+      const { store, dispatch } = makeStore();
+
+      const result = await handleReduxAction(
+        windowRequestDeviceConfirmationChanged({
+          requestId: 'r1',
+          awaiting: true
+        }),
+        {
+          id: 'other-ext',
+          url: 'https://evil.example'
+        } as Runtime.MessageSender,
+        store
+      );
+
+      expect(dispatch).not.toHaveBeenCalled();
+      expect(result).toEqual({ handled: true });
+    });
+
+    // Holding the flag on someone else's request withholds THAT request's
+    // window from reuse for as long as it stays open.
+    it('is dropped when the page names a request it does not display', async () => {
+      const { store, dispatch } = makeStore();
+
+      const result = await handleReduxAction(
+        windowRequestDeviceConfirmationChanged({
+          requestId: 'r1',
+          awaiting: true
+        }),
+        trustedSender,
+        store
+      );
+
+      expect(dispatch).not.toHaveBeenCalled();
+      expect(result).toEqual({ handled: true });
+    });
+
+    it('drops a payload-less message instead of throwing on it', async () => {
+      const { store, dispatch } = makeStore();
+
+      const result = await handleReduxAction(
+        { type: windowRequestDeviceConfirmationChanged.type },
+        trustedSenderForR1,
+        store
+      );
+
+      expect(dispatch).not.toHaveBeenCalled();
+      expect(result).toEqual({ handled: true });
+    });
   });
 });

--- a/src/background/handlers/redux-actions.ts
+++ b/src/background/handlers/redux-actions.ts
@@ -70,6 +70,7 @@ import {
   onboardingAppInit,
   popupWindowInit,
   signWindowInit,
+  windowRequestDeviceConfirmationChanged,
   windowRequestWindowAttached
 } from '@background/redux/windowManagement/actions';
 
@@ -242,6 +243,38 @@ export async function handleReduxAction(
       payload.requestId as string,
       payload.windowId as number
     );
+    return { handled: true, response: undefined };
+  }
+
+  // Intercepted rather than forwarded even though it HAS a reducer case: it
+  // decides whether the shared approval window may be reused while a Ledger
+  // call runs in it, and `FORWARDED_ACTION_TYPES` checks no sender at all. Held
+  // on a foreign request the flag withholds that request's window from reuse for
+  // as long as it stays open, so the same two gates as the branches around it.
+  if (windowRequestDeviceConfirmationChanged.match(action)) {
+    if (!isTrustedUiSender(sender)) {
+      return { handled: true };
+    }
+
+    // `.match` says nothing about the payload, and this crosses
+    // `runtime.sendMessage`.
+    const payload: Partial<{ requestId: string; awaiting: boolean }> =
+      action.payload ?? {};
+
+    // Bound to the sender's own URL exactly as `closeLedgerFlowWindows` is: the
+    // page that runs the device call is the page the request opened, so it
+    // carries the id in its query string. Unlike that one there is no
+    // internal-flow case to admit — `runWithDeviceConfirmationReported` sends
+    // nothing without a requestId.
+    if (
+      typeof payload.awaiting !== 'boolean' ||
+      typeof payload.requestId !== 'string' ||
+      payload.requestId !== recoverRequestId(sender.url)
+    ) {
+      return { handled: true };
+    }
+
+    store.dispatch(action as unknown as ReduxAction);
     return { handled: true, response: undefined };
   }
 

--- a/src/background/handlers/sdk-response-to-tab.test.ts
+++ b/src/background/handlers/sdk-response-to-tab.test.ts
@@ -72,7 +72,8 @@ const OPEN_REQUEST: Request = {
   tabId: TAB_ID,
   origin: DAPP_ORIGIN,
   method: 'sign',
-  windowIds: [7]
+  windowIds: [7],
+  awaitingDeviceConfirmation: false
 };
 
 // Build a fake store whose `requests` map carries the desired request entry

--- a/src/background/open-window.test.ts
+++ b/src/background/open-window.test.ts
@@ -7,6 +7,7 @@ import {
   windowIdCleared,
   windowRequestWindowAttached
 } from '@background/redux/windowManagement/actions';
+import { Request } from '@background/redux/windowManagement/types';
 
 import {
   cancelRequestsDisplacedBy,
@@ -48,14 +49,28 @@ const createOpenWindowMock = createOpenWindow as jest.MockedFunction<
 
 const flush = () => new Promise(resolve => setImmediate(resolve));
 
-function makeStore(windowId: number | null) {
+function makeStore(
+  windowId: number | null,
+  requests: Record<string, Request> = {}
+) {
   const dispatch = jest.fn();
   const store = {
-    getState: () => ({ windowManagement: { windowId, requests: {} } }),
+    getState: () => ({ windowManagement: { windowId, requests } }),
     dispatch
   } as unknown as MainStore;
   return { store, dispatch };
 }
+
+const awaitingDeviceIn = (windowIds: number[]): Record<string, Request> => ({
+  ledger: {
+    status: 'open',
+    tabId: 1,
+    origin: 'https://dapp.example',
+    method: 'sign',
+    windowIds,
+    awaitingDeviceConfirmation: true
+  }
+});
 
 describe('openWindow (background store routing)', () => {
   beforeEach(() => {
@@ -79,6 +94,41 @@ describe('openWindow (background store routing)', () => {
     openWindow(store, { windowApp: WindowApp.ConnectToApp, requestId: 'r0' });
 
     expect(createOpenWindowMock).toHaveBeenCalledTimes(1);
+    const config = createOpenWindowMock.mock.calls[0][0]!;
+    expect(config.windowId).toBe(42);
+  });
+
+  // WALLET-1394. Not the permission-window flow, which #1427/#1462 already
+  // cover: there the device call runs in a SECOND window and the request
+  // survives a reuse by still being displayed in it.
+  it('withholds the tracked window while a device confirmation runs in it', () => {
+    const { store } = makeStore(42, awaitingDeviceIn([42]));
+
+    openWindow(store, { windowApp: WindowApp.ConnectToApp, requestId: 'r0' });
+
+    const config = createOpenWindowMock.mock.calls[0][0]!;
+    expect(config.windowId).toBeNull();
+  });
+
+  it('still offers a tracked window whose device confirmation ended', () => {
+    const { store } = makeStore(42, {
+      ledger: {
+        ...awaitingDeviceIn([42]).ledger,
+        awaitingDeviceConfirmation: false
+      }
+    } as Record<string, Request>);
+
+    openWindow(store, { windowApp: WindowApp.ConnectToApp, requestId: 'r0' });
+
+    const config = createOpenWindowMock.mock.calls[0][0]!;
+    expect(config.windowId).toBe(42);
+  });
+
+  it('offers the tracked window when the device confirmation is in another one', () => {
+    const { store } = makeStore(42, awaitingDeviceIn([77]));
+
+    openWindow(store, { windowApp: WindowApp.ConnectToApp, requestId: 'r0' });
+
     const config = createOpenWindowMock.mock.calls[0][0]!;
     expect(config.windowId).toBe(42);
   });

--- a/src/background/open-window.ts
+++ b/src/background/open-window.ts
@@ -13,7 +13,10 @@ import {
   windowIdChanged,
   windowIdCleared
 } from '@background/redux/windowManagement/actions';
-import { selectWindowId } from '@background/redux/windowManagement/selectors';
+import {
+  selectIsWindowBusyWithDevice,
+  selectWindowId
+} from '@background/redux/windowManagement/selectors';
 
 export interface OpenApprovalWindowProps extends OpenWindowProps {
   /**
@@ -52,8 +55,21 @@ export function openWindow(
     );
   };
 
+  // Withheld while a Ledger confirmation is in flight in it — reuse navigates
+  // that window's tab out from under the device call (see
+  // `awaitingDeviceConfirmation` in windowManagement/types). `null` REDIRECTS
+  // the reuse rather than suppressing it: the new-window branch still runs
+  // `setWindowId`, so the slot retracks and only the protected window leaves
+  // the rotation. WALLET-1394.
+  const trackedWindowId = selectWindowId(store.getState());
+  const reusableWindowId =
+    trackedWindowId != null &&
+    selectIsWindowBusyWithDevice(store.getState(), trackedWindowId)
+      ? null
+      : trackedWindowId;
+
   const chain = createOpenWindow({
-    windowId: selectWindowId(store.getState()),
+    windowId: reusableWindowId,
     setWindowId: (id: number) => store.dispatch(windowIdChanged(id)),
     clearWindowId: () => store.dispatch(windowIdCleared())
   })(openWindowProps).then(

--- a/src/background/redux/sagas/vault-sagas.test.ts
+++ b/src/background/redux/sagas/vault-sagas.test.ts
@@ -606,7 +606,8 @@ describe('reconcileStalePayloadsSaga', () => {
     tabId: 7,
     origin: 'https://dapp.example',
     method: 'sign',
-    windowIds: [1]
+    windowIds: [1],
+    awaitingDeviceConfirmation: false
   } as const;
 
   const combinedReducer = () =>

--- a/src/background/redux/windowManagement/actions.ts
+++ b/src/background/redux/windowManagement/actions.ts
@@ -9,6 +9,7 @@ export {
   windowDetachedFromRequests,
   windowIdChanged,
   windowIdCleared,
+  windowRequestDeviceConfirmationChanged,
   windowRequestOpened,
   windowRequestResponded,
   windowRequestWindowAttached

--- a/src/background/redux/windowManagement/reducer.test.ts
+++ b/src/background/redux/windowManagement/reducer.test.ts
@@ -9,6 +9,7 @@ import {
   windowDetachedFromRequests,
   windowIdChanged,
   windowIdCleared,
+  windowRequestDeviceConfirmationChanged,
   windowRequestOpened,
   windowRequestResponded,
   windowRequestWindowAttached
@@ -106,7 +107,8 @@ describe('windowManagement reducer', () => {
       tabId: 9,
       origin: 'https://other.example',
       method: 'signMessage',
-      windowIds: []
+      windowIds: [],
+      awaitingDeviceConfirmation: false
     });
 
     // Responding twice must not throw or resurrect the dropped descriptor.
@@ -124,7 +126,8 @@ describe('windowManagement requests', () => {
       tabId: 3,
       origin: 'https://dapp',
       method: 'sign',
-      windowIds: []
+      windowIds: [],
+      awaitingDeviceConfirmation: false
     });
   });
 
@@ -378,5 +381,108 @@ describe('windowManagement requests', () => {
 
       expect(state.requests['still-open']).toMatchObject({ status: 'open' });
     });
+  });
+});
+
+describe('windowManagement device confirmation', () => {
+  it('opens a request that is not awaiting the device', () => {
+    const state = reducer(empty, opened('r1'));
+
+    expect(state.requests.r1).toMatchObject({
+      awaitingDeviceConfirmation: false
+    });
+  });
+
+  it('marks an open request as awaiting the device', () => {
+    let state = reducer(empty, opened('r1'));
+
+    state = reducer(
+      state,
+      windowRequestDeviceConfirmationChanged({
+        requestId: 'r1',
+        awaiting: true
+      })
+    );
+
+    expect(state.requests.r1).toMatchObject({
+      awaitingDeviceConfirmation: true
+    });
+  });
+
+  it('clears the flag when the confirmation ends', () => {
+    let state = reducer(empty, opened('r1'));
+    state = reducer(
+      state,
+      windowRequestDeviceConfirmationChanged({
+        requestId: 'r1',
+        awaiting: true
+      })
+    );
+
+    state = reducer(
+      state,
+      windowRequestDeviceConfirmationChanged({
+        requestId: 'r1',
+        awaiting: false
+      })
+    );
+
+    expect(state.requests.r1).toMatchObject({
+      awaitingDeviceConfirmation: false
+    });
+  });
+
+  // The tombstone carries no descriptor to flag, and resurrecting one would
+  // hand `selectIsWindowBusyWithDevice` an answered request to protect.
+  it('leaves a tombstone alone', () => {
+    let state = reducer(empty, opened('r1'));
+    state = reducer(state, windowRequestResponded({ requestId: 'r1' }));
+
+    const next = reducer(
+      state,
+      windowRequestDeviceConfirmationChanged({
+        requestId: 'r1',
+        awaiting: true
+      })
+    );
+
+    expect(next).toBe(state);
+  });
+
+  it('ignores a request the store never registered', () => {
+    const next = reducer(
+      empty,
+      windowRequestDeviceConfirmationChanged({
+        requestId: 'ghost',
+        awaiting: true
+      })
+    );
+
+    expect(next).toBe(empty);
+  });
+
+  // Identity, not just equality. The store subscriber does no state-change
+  // comparison, so every new object is a popupState broadcast to every replica
+  // plus a full storage.local rewrite — the same cost `windowDetachedFromRequests`
+  // gates its dispatch on. A repeated report must not pay it.
+  it('returns the same state when the flag already holds that value', () => {
+    let state = reducer(empty, opened('r1'));
+    state = reducer(
+      state,
+      windowRequestDeviceConfirmationChanged({
+        requestId: 'r1',
+        awaiting: true
+      })
+    );
+
+    const next = reducer(
+      state,
+      windowRequestDeviceConfirmationChanged({
+        requestId: 'r1',
+        awaiting: true
+      })
+    );
+
+    expect(next).toBe(state);
   });
 });

--- a/src/background/redux/windowManagement/reducer.ts
+++ b/src/background/redux/windowManagement/reducer.ts
@@ -65,7 +65,36 @@ const slice = createSlice({
             tabId: action.payload.tabId,
             origin: action.payload.origin,
             method: action.payload.method,
-            windowIds: []
+            windowIds: [],
+            awaitingDeviceConfirmation: false
+          }
+        }
+      };
+    },
+    // A Ledger confirmation started or finished for this request. Guarded like
+    // its siblings: only a live 'open' descriptor can carry the flag, so a
+    // message that arrives after the request was answered cannot resurrect one.
+    windowRequestDeviceConfirmationChanged: (
+      state,
+      action: PayloadAction<{ requestId: string; awaiting: boolean }>
+    ) => {
+      const request = getRequest(state.requests, action.payload.requestId);
+
+      if (
+        request == null ||
+        request.status !== 'open' ||
+        request.awaitingDeviceConfirmation === action.payload.awaiting
+      ) {
+        return state;
+      }
+
+      return {
+        ...state,
+        requests: {
+          ...state.requests,
+          [action.payload.requestId]: {
+            ...request,
+            awaitingDeviceConfirmation: action.payload.awaiting
           }
         }
       };
@@ -188,6 +217,7 @@ export const {
   windowDetachedFromRequests,
   windowIdChanged,
   windowIdCleared,
+  windowRequestDeviceConfirmationChanged,
   windowRequestOpened,
   windowRequestResponded,
   windowRequestWindowAttached

--- a/src/background/redux/windowManagement/selectors.test.ts
+++ b/src/background/redux/windowManagement/selectors.test.ts
@@ -1,6 +1,10 @@
 import { RootState } from '@background/redux/store-types';
 
-import { selectOpenRequests, selectRequestStatus } from './selectors';
+import {
+  selectIsWindowBusyWithDevice,
+  selectOpenRequests,
+  selectRequestStatus
+} from './selectors';
 import { Request } from './types';
 
 // Typed as `Record<string, Request>` (not `any`) so a future shape change to
@@ -9,7 +13,14 @@ import { Request } from './types';
 // drifted from the flat `{ [id]: status }` + `pendingRequests` shape to this
 // discriminated union.
 const requests: Record<string, Request> = {
-  a: { status: 'open', tabId: 1, origin: 'o', method: 'sign', windowIds: [7] },
+  a: {
+    status: 'open',
+    tabId: 1,
+    origin: 'o',
+    method: 'sign',
+    windowIds: [7],
+    awaitingDeviceConfirmation: false
+  },
   b: { status: 'responded' },
   c: { status: 'responded' }
 };
@@ -35,7 +46,56 @@ it('selectOpenRequests joins open status with its descriptor, including windowId
       tabId: 1,
       origin: 'o',
       method: 'sign',
-      windowIds: [7]
+      windowIds: [7],
+      awaitingDeviceConfirmation: false
     }
   ]);
+});
+
+describe('selectIsWindowBusyWithDevice', () => {
+  const stateWith = (...entries: [string, Request][]) =>
+    ({
+      windowManagement: {
+        windowId: null,
+        exportKeysWindowId: null,
+        requests: Object.fromEntries(entries)
+      }
+    }) as unknown as RootState;
+
+  const awaiting = (windowIds: number[]): Request => ({
+    status: 'open',
+    tabId: 1,
+    origin: 'https://dapp.example',
+    method: 'sign',
+    windowIds,
+    awaitingDeviceConfirmation: true
+  });
+
+  it('reports the window that displays the awaiting request', () => {
+    expect(
+      selectIsWindowBusyWithDevice(stateWith(['a', awaiting([7])]), 7)
+    ).toBe(true);
+  });
+
+  it('leaves an unrelated window free', () => {
+    expect(
+      selectIsWindowBusyWithDevice(stateWith(['a', awaiting([7])]), 9)
+    ).toBe(false);
+  });
+
+  // The flag is per request, so the answer must come from `windowIds` and not
+  // from "some request somewhere is on the device".
+  it('is false while no request awaits the device', () => {
+    expect(selectIsWindowBusyWithDevice(state, 7)).toBe(false);
+  });
+
+  // A request the permission window still displays has two windows; the shared
+  // approval window among them is not the one hosting the device call, but it
+  // is still the one a reuse would navigate out from under the flow.
+  it('reports every window the awaiting request displays in', () => {
+    const busy = stateWith(['a', awaiting([7, 9])]);
+
+    expect(selectIsWindowBusyWithDevice(busy, 7)).toBe(true);
+    expect(selectIsWindowBusyWithDevice(busy, 9)).toBe(true);
+  });
 });

--- a/src/background/redux/windowManagement/selectors.ts
+++ b/src/background/redux/windowManagement/selectors.ts
@@ -37,3 +37,15 @@ export const selectOpenRequests = createSelector(
       request?.status === 'open' ? [{ requestId, ...request }] : []
     )
 );
+
+// Is a Ledger confirmation in flight in this window? Composed from the request
+// side rather than stored per window — see `awaitingDeviceConfirmation` in
+// ./types for why. Read by `openWindow` before it reuses the shared slot.
+export const selectIsWindowBusyWithDevice = (
+  state: RootState,
+  windowId: number
+): boolean =>
+  selectOpenRequests(state).some(
+    request =>
+      request.awaitingDeviceConfirmation && request.windowIds.includes(windowId)
+  );

--- a/src/background/redux/windowManagement/types.ts
+++ b/src/background/redux/windowManagement/types.ts
@@ -29,6 +29,15 @@ export type Request =
       readonly origin: string;
       readonly method: CancellableMethod;
       readonly windowIds: readonly number[];
+      // A Ledger confirmation is in flight for this request. The device call
+      // runs in the page that displays it, so reusing that page's window
+      // navigates the document away and takes the HID session and the pending
+      // signature with it — `openWindow` reads this to leave such a window
+      // alone. Lives on the descriptor rather than in a slice-level set so it
+      // cannot outlive what it describes: the tombstone replaces the whole
+      // entry, and a detach shrinks `windowIds`, which is the other half of the
+      // question. WALLET-1394.
+      readonly awaitingDeviceConfirmation: boolean;
     }
   | { readonly status: 'responded' };
 

--- a/src/hooks/ledger-device-confirmation.test.ts
+++ b/src/hooks/ledger-device-confirmation.test.ts
@@ -81,3 +81,83 @@ it('treats an empty requestId as absent', async () => {
 
   expect(dispatchMock).not.toHaveBeenCalled();
 });
+
+// Two brackets can overlap in one document: the submit control is not disabled
+// while a call is in flight, and the page state that hides it is only flipped
+// after `getPreferredTransport()` and `beforeLedgerActionCb()` have resolved
+// (use-ledger.ts). The second call fails fast — the transport is busy, so it
+// throws TransportRaceCondition — and a bare release would then unprotect the
+// window while the first call is still on the device.
+describe('concurrent brackets', () => {
+  it('does not release the window until the last bracket settles', async () => {
+    let releaseFirst: () => void = () => {};
+    const first = runWithDeviceConfirmationReported(
+      'r1',
+      () =>
+        new Promise<void>(resolve => {
+          releaseFirst = resolve;
+        })
+    );
+
+    await runWithDeviceConfirmationReported('r1', async () => {
+      throw new Error('transport busy');
+    });
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenLastCalledWith(
+      windowRequestDeviceConfirmationChanged({
+        requestId: 'r1',
+        awaiting: true
+      })
+    );
+
+    releaseFirst();
+    await first;
+
+    expect(dispatchMock).toHaveBeenLastCalledWith(
+      windowRequestDeviceConfirmationChanged({
+        requestId: 'r1',
+        awaiting: false
+      })
+    );
+  });
+
+  it('counts each request separately', async () => {
+    let releaseOther: () => void = () => {};
+    const other = runWithDeviceConfirmationReported(
+      'r2',
+      () =>
+        new Promise<void>(resolve => {
+          releaseOther = resolve;
+        })
+    );
+
+    await runWithDeviceConfirmationReported('r1', async () => {});
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      windowRequestDeviceConfirmationChanged({
+        requestId: 'r1',
+        awaiting: false
+      })
+    );
+
+    releaseOther();
+    await other;
+  });
+
+  // A leaked counter would make every later call for that id a silent no-op,
+  // which is the failure this guard must not introduce.
+  it('releases the count so a later call reports again', async () => {
+    await runWithDeviceConfirmationReported('r1', async () => {});
+    dispatchMock.mockClear();
+
+    await runWithDeviceConfirmationReported('r1', async () => {});
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      windowRequestDeviceConfirmationChanged({
+        requestId: 'r1',
+        awaiting: true
+      })
+    );
+  });
+});

--- a/src/hooks/ledger-device-confirmation.test.ts
+++ b/src/hooks/ledger-device-confirmation.test.ts
@@ -1,0 +1,83 @@
+import { dispatchToMainStore } from '@background/redux/utils';
+import { windowRequestDeviceConfirmationChanged } from '@background/redux/windowManagement/actions';
+
+import { runWithDeviceConfirmationReported } from './ledger-device-confirmation';
+
+jest.mock('@background/redux/utils', () => ({
+  dispatchToMainStore: jest.fn()
+}));
+
+const dispatchMock = dispatchToMainStore as jest.Mock;
+
+let consoleError: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => consoleError.mockRestore());
+
+it('brackets the device call with a start and an end', async () => {
+  await runWithDeviceConfirmationReported('r1', async () => {
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenLastCalledWith(
+      windowRequestDeviceConfirmationChanged({
+        requestId: 'r1',
+        awaiting: true
+      })
+    );
+  });
+
+  expect(dispatchMock).toHaveBeenLastCalledWith(
+    windowRequestDeviceConfirmationChanged({
+      requestId: 'r1',
+      awaiting: false
+    })
+  );
+});
+
+// The flag withholds the shared approval window from every later request, so a
+// device call that throws must still release it — otherwise one failed signing
+// attempt makes every subsequent dapp request open a window of its own.
+it('releases the window when the device call fails', async () => {
+  await runWithDeviceConfirmationReported('r1', async () => {
+    throw new Error('device says no');
+  });
+
+  expect(dispatchMock).toHaveBeenLastCalledWith(
+    windowRequestDeviceConfirmationChanged({
+      requestId: 'r1',
+      awaiting: false
+    })
+  );
+});
+
+it('surfaces a failed device call instead of swallowing it', async () => {
+  await runWithDeviceConfirmationReported('r1', async () => {
+    throw new Error('device says no');
+  });
+
+  expect(consoleError).toHaveBeenCalledWith(
+    'useLedger: the device action failed',
+    { errorName: 'Error' }
+  );
+});
+
+// `import-account-from-ledger`, transfer and staking run the same hook with no
+// dapp request behind them: there is no descriptor to flag and no approval
+// window to protect.
+it('still runs the device call for an internal flow, reporting nothing', async () => {
+  const run = jest.fn().mockResolvedValue(undefined);
+
+  await runWithDeviceConfirmationReported(undefined, run);
+
+  expect(run).toHaveBeenCalledTimes(1);
+  expect(dispatchMock).not.toHaveBeenCalled();
+});
+
+it('treats an empty requestId as absent', async () => {
+  await runWithDeviceConfirmationReported('', async () => {});
+
+  expect(dispatchMock).not.toHaveBeenCalled();
+});

--- a/src/hooks/ledger-device-confirmation.ts
+++ b/src/hooks/ledger-device-confirmation.ts
@@ -2,6 +2,47 @@ import { dispatchToMainStore } from '@background/redux/utils';
 import { windowRequestDeviceConfirmationChanged } from '@background/redux/windowManagement/actions';
 
 /**
+ * How many brackets currently hold each request, so overlapping ones report the
+ * flag once between them rather than each releasing it for the others.
+ *
+ * They do overlap: neither signing page disables its submit control while a
+ * call is in flight, and the page state that hides it is only flipped after
+ * `getPreferredTransport()` and `beforeLedgerActionCb()` resolve — so a second
+ * click lands, fails fast on the busy transport (`TransportRaceCondition`) and
+ * would otherwise unprotect the window while the first call is still on the
+ * device.
+ *
+ * Module scope is the right scope: a transport is per document, so brackets can
+ * only overlap within one, and the reducer's equality guard already absorbs a
+ * repeated `true` from anywhere else.
+ */
+const heldByRequest = new Map<string, number>();
+
+/** @returns whether this is the first holder, i.e. whether to report the start. */
+function acquire(requestId: string): boolean {
+  const held = (heldByRequest.get(requestId) ?? 0) + 1;
+  heldByRequest.set(requestId, held);
+
+  return held === 1;
+}
+
+/** @returns whether this was the last holder, i.e. whether to report the end. */
+function release(requestId: string): boolean {
+  const held = (heldByRequest.get(requestId) ?? 1) - 1;
+
+  if (held > 0) {
+    heldByRequest.set(requestId, held);
+    return false;
+  }
+
+  // Deleted rather than left at zero: `requestId` is dapp-controlled, and a page
+  // that signs repeatedly would otherwise grow this map for its whole life.
+  heldByRequest.delete(requestId);
+
+  return true;
+}
+
+/**
  * Runs a Ledger device call with the background told, for its whole duration,
  * that this request is on the device — which is what keeps the window it runs
  * in out of the reuse rotation (`awaitingDeviceConfirmation` in
@@ -25,6 +66,10 @@ export async function runWithDeviceConfirmationReported(
   // dapp request behind them, so there is no descriptor to flag.
   const report = (awaiting: boolean) => {
     if (requestId == null || requestId === '') {
+      return;
+    }
+
+    if (!(awaiting ? acquire(requestId) : release(requestId))) {
       return;
     }
 

--- a/src/hooks/ledger-device-confirmation.ts
+++ b/src/hooks/ledger-device-confirmation.ts
@@ -1,0 +1,50 @@
+import { dispatchToMainStore } from '@background/redux/utils';
+import { windowRequestDeviceConfirmationChanged } from '@background/redux/windowManagement/actions';
+
+/**
+ * Runs a Ledger device call with the background told, for its whole duration,
+ * that this request is on the device — which is what keeps the window it runs
+ * in out of the reuse rotation (`awaitingDeviceConfirmation` in
+ * windowManagement/types).
+ *
+ * The bracket lives here rather than as two calls in `useLedger` for the reason
+ * `register-ledger-permission-window.ts` exists: the repo has no React-hook
+ * harness, so inside the hook the pairing would be two lines that can drift
+ * apart — and a start without its end withholds the shared window from every
+ * later request for the rest of that request's life.
+ *
+ * Never rejects. `run` is invoked fire-and-forget by the hook, exactly as the
+ * bare `ledgerAction()` it replaces was; a rejection propagated from here would
+ * be the unhandled rejection that call site already produced.
+ */
+export async function runWithDeviceConfirmationReported(
+  requestId: string | undefined,
+  run: () => Promise<void>
+): Promise<void> {
+  // The internal flows (transfer, staking, `import-account-from-ledger`) have no
+  // dapp request behind them, so there is no descriptor to flag.
+  const report = (awaiting: boolean) => {
+    if (requestId == null || requestId === '') {
+      return;
+    }
+
+    dispatchToMainStore(
+      windowRequestDeviceConfirmationChanged({ requestId, awaiting })
+    );
+  };
+
+  report(true);
+
+  try {
+    await run();
+  } catch (error) {
+    // Name only: a Ledger error carries the public key and transaction hash it
+    // failed on, and this line is a diagnostic, not the user-facing surface —
+    // the same failure already reaches the screen through the event subject.
+    console.error('useLedger: the device action failed', {
+      errorName: (error as Error)?.name
+    });
+  } finally {
+    report(false);
+  }
+}

--- a/src/hooks/use-ledger.ts
+++ b/src/hooks/use-ledger.ts
@@ -16,6 +16,7 @@ import {
 } from '@background/redux/ledger/selectors';
 import { dispatchToMainStore } from '@background/redux/utils';
 
+import { runWithDeviceConfirmationReported } from '@hooks/ledger-device-confirmation';
 import { createLedgerWindowCloseTracker } from '@hooks/ledger-window-close-listener';
 import { resolveOwnPermissionWindowId } from '@hooks/ledger-window-ownership';
 import { registerLedgerPermissionWindow } from '@hooks/register-ledger-permission-window';
@@ -131,7 +132,13 @@ export const useLedger = ({
     await beforeLedgerActionCb();
 
     if (isLedgerConnected) {
-      ledgerAction();
+      // Fire-and-forget as before — the status below must render while the
+      // device is being read — but bracketed so the background knows this
+      // request is on the device and leaves the window it runs in alone.
+      void runWithDeviceConfirmationReported(
+        askPermissionUrlData.params?.requestId,
+        ledgerAction
+      );
 
       if (shouldLoadAccountList) {
         setLedgerEventStatusToRender({


### PR DESCRIPTION
Fixes [WALLET-1394](https://make-software.atlassian.net/browse/WALLET-1394).

## The bug

An **already-permitted** Ledger device opens no permission window, so the device call runs in the page inside the **shared approval window**. When the next dapp request arrives, that window is reused — and reuse runs `tabs.update(tab.id, { url })` on its tab (`create-open-window.ts:100-110`), a full navigation. `ledger` is a **per-document** singleton (`libs/services/ledger/ledger.ts`), so the navigation destroys the document, the HID session and the pending `signTransaction` promise together.

Confirmed on hardware, 3 runs. The ticket describes a second mechanism — the signature reaching `sdk-response-to-tab` and being dropped by the supersede tombstone — and that one is real too, but it happened in only 1 of 3 runs. **Which one wins is a race** with how fast the replacement page commits its navigation (bundle cache, disk, load). Both end in `signResponse({ cancelled: true })` to the first dapp.

This matters for the fix: nothing on the tombstone side can help, including WALLET-1364 P2 #10 — in the dominant case there is no longer anything to deliver. Only preventing the reuse works.

PR #1427 / #1462 covered only the _other_ path, where a separate permission window gives the request a second display and the reuse leaves it alive.

## The fix

- `awaitingDeviceConfirmation` on the **open** `Request` descriptor. Deliberately not a slice-level set: the tombstone replaces the whole entry and `windowDetachedFromRequests` shrinks `windowIds`, so the flag cannot outlive what it describes and nothing has to remember to clear it.
- `selectIsWindowBusyWithDevice(state, windowId)` composes the answer from the request side.
- `openWindow` withholds the tracked window while it is busy. Passing `null` **redirects** the reuse rather than suppressing it: the new-window branch still runs `setWindowId` (`create-open-window.ts:154`), so the shared slot retracks to the newcomer and only the protected window leaves the rotation.
- UI half: `runWithDeviceConfirmationReported(requestId, run)` brackets the device call. The bracket lives in its own module for the reason `register-ledger-permission-window.ts` does — there is no React-hook harness in this repo, and a start without its end would withhold the shared window for the rest of that request's life. It also gives the previously un-awaited `ledgerAction()` a `catch`.
- The action is **intercepted** in `handleReduxAction`, not added to `FORWARDED_ACTION_TYPES` (which checks no sender at all). Gates: `isTrustedUiSender` plus `payload.requestId === recoverRequestId(sender.url)` — the same pair `closeLedgerFlowWindows` uses, so a page can only speak for the request its own URL names.

## Reviewer notes

**Deliberate behaviour change in the permission-window flow.** During the device call the request's `windowIds` is `[shared, permission]`, so both now read as busy and a second request opens a third window instead of reusing the shared one. Previously the reuse navigated the shared window and the request merely _survived_ it. Strictly safer — the waiting screen is no longer navigated away — but it is a change, and it is pinned by a selector test.

**Residual race, knowingly left open.** The flag is dispatched from the page and reduced in the background one `runtime.sendMessage` hop later. A second dapp request processed inside that hop (single-digit ms) still reuses the window. Previously the exposure was the entire device confirmation — seconds to minutes.

It was **not** closed by awaiting the dispatch ack, though the ack does mean the flag is in the store (`background/index.ts:216` responds only when the result carries a `response` key, and the branch dispatches synchronously before returning). The drop paths return `{ handled: true }` with **no** `response` key, so their promise never resolves — awaiting it before the device call would mean that any future tightening of the gate silently stops Ledger signing altogether. Bad trade against a millisecond window. Closing it properly means moving "this request is Ledger-signed" into the background, which it could derive from `signingPublicKeyHex` plus the vault at window-open time; that is a wider behaviour change and belongs in its own ticket.

**A burst opens one window per request while the device is busy.** The slot is only rewritten in the `windows.create` callback, so several requests arriving during a Ledger confirmation all see "tracked but busy" and each opens its own window. This is not new machinery — the same thing happens on base whenever no window is tracked yet (`selectWindowId` is `null` at cold start, so concurrent calls all take the create branch and each calls `setWindowId`); what changes is the condition that triggers it. Base collapsed such a burst into one window only by cancelling each previous request in turn, which for a Ledger confirmation is the exact P0 this PR exists to stop. Bounded near `MAX_STORED_PAYLOADS` for `sign`; `signMessage` has no equivalent cap, which is a pre-existing gap of its own.

**One line is covered only by the manual test:** the wiring at `use-ledger.ts:135`. Reverting it to a bare `ledgerAction()` leaves the whole suite green — same gap `registerLedgerPermissionWindow` lives with, for the same reason.

## Testing

`tsc`, `lint`, `format:check`, `knip` clean; 1047 unit tests pass; the coverage gate passes (`windowManagement` 100%, `handlers` above its floor).

Manual, on a real Ledger with the HID permission already granted (so no permission window appears — that is the precondition for this bug):

1. Dapp A → `sign` from a Ledger account, stop at "Confirm on device".
2. Dapp B (second tab) → `signMessage`.
3. **Before:** A's window is repainted with B's request; A's dapp receives `cancelled: true` ~250 ms later; pressing Approve on the device does nothing. **After:** A's window is untouched, B opens its own window, A signs through, then B signs through.

## Found while testing — not fixed here

Two Ledger flows can now be live at once, which was unreachable before this change because the second request used to consume the first one's window. If the user leaves A waiting on the device and presses **Sign with Ledger** in B, B's document opens the device and sends its own APDUs while A's prompt is up. The Casper app has no queue: it tears down A's prompt and answers B with `0x6985`, so B shows "You rejected to sign the deploy" (which the user did not do) and A can no longer be completed — the window has to be closed and the flow restarted.

This is contention over one physical device, not window management, and it is **not** made worse by this PR: previously A was lost _unconditionally and silently_, whereas now it is lost only if the user deliberately starts a second signing flow, and the failure is visible. Note that `LedgerEventStatus.WaitingToSignPrevDeploy` already exists with exactly the right copy for this situation — B just never gets to it.

It cannot be arbitrated inside a page (the `ledger` singleton is per document); the only shared authority is the background store, which is where this PR's flag already lives. It also affects the internal flows (transfer, staking, import-from-ledger), which carry no `requestId` and so are not covered by that flag.

Investigated and filed as **[WALLET-1429](https://make-software.atlassian.net/browse/WALLET-1429)**. Two findings from it are worth knowing while reviewing this PR:

- **Request A hangs rather than fails.** There is no timeout anywhere on the signing path — `TransportWebHID` never consults `exchangeTimeout`, and `exchangeAtomicImpl`'s 15 s `unresponsiveTimeout` only emits an event. So `runWithDeviceConfirmationReported`'s `finally` never runs and `awaitingDeviceConfirmation` stays set. The blast radius is still what this PR describes — the slot retracks to the newcomer's window and later requests reuse that normally, so it costs exactly one held window until A's window is closed, not one per request.
- **`LedgerEventStatus.WaitingToSignPrevDeploy` is unreachable**, and not only because of ordering: its trigger `returnCode === 65535` (`ledger.ts:135`) cannot fire for a busy device, since Zondax's `processErrorResponse` returns the real status code whenever the error carries one and `0xffff` only as the fallback for errors without one. Any future fix leaning on that copy must trigger it from a wallet-held fact.


[WALLET-1394]: https://make-software.atlassian.net/browse/WALLET-1394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WALLET-1429]: https://make-software.atlassian.net/browse/WALLET-1429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ