### PR TITLE
fix(background): gate the redux router's re-dispatch branches on a trusted UI sender

### DIFF
--- a/src/background/handlers/private-state.test.ts
+++ b/src/background/handlers/private-state.test.ts
@@ -7,7 +7,8 @@ import {
   fetchPrivateState,
   isPrivateStateRequest,
   isTrustedUiSender,
-  selectPrivateState
+  selectPrivateState,
+  warnUntrustedSameExtensionSender
 } from './private-state';
 
 // `webextension-polyfill` throws outside an extension. Stub the identity +
@@ -111,6 +112,69 @@ describe('selectPrivateState', () => {
       keyDerivationSaltHash: null,
       vaultCipher: null
     });
+  });
+});
+
+describe('warnUntrustedSameExtensionSender', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('foreign extension id → silent (another extension probing is not our diagnostic)', () => {
+    const sender = {
+      id: 'other-ext',
+      url: 'chrome-extension://other-ext/page.html'
+    } as Runtime.MessageSender;
+
+    warnUntrustedSameExtensionSender(sender, 'private-state request');
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('same extension id → warns with the context and the ORIGIN, never the query string', () => {
+    // A content script of this extension carries our id and the host page URL,
+    // which is exactly why the full URL must not be logged.
+    const sender = {
+      id: 'ext-id',
+      url: 'https://dapp.example/page?session=secret'
+    } as Runtime.MessageSender;
+
+    warnUntrustedSameExtensionSender(sender, 'private-state request');
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Background: private-state request from same-extension sender rejected by URL check:',
+      'https://dapp.example'
+    );
+  });
+
+  it('unparseable url → warns with undefined instead of throwing out of the router', () => {
+    const sender = { id: 'ext-id', url: 'not a url' } as Runtime.MessageSender;
+
+    expect(() =>
+      warnUntrustedSameExtensionSender(sender, 'redux action LOCK_VAULT')
+    ).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Background: redux action LOCK_VAULT from same-extension sender rejected by URL check:',
+      undefined
+    );
+  });
+
+  it('absent url → warns with undefined', () => {
+    const sender = { id: 'ext-id', url: undefined } as Runtime.MessageSender;
+
+    warnUntrustedSameExtensionSender(sender, 'private-state request');
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Background: private-state request from same-extension sender rejected by URL check:',
+      undefined
+    );
   });
 });
 

--- a/src/background/handlers/private-state.ts
+++ b/src/background/handlers/private-state.ts
@@ -39,6 +39,33 @@ export function isTrustedUiSender(sender: Runtime.MessageSender): boolean {
   );
 }
 
+/**
+ * Why a rejected sender is worth a line: a same-extension id means either an
+ * unrecognized UI origin (packaging variant, sandboxed frame) or a content
+ * script relaying what it should not. Origin only — a content-script sender's
+ * page URL can carry tokens in its query string.
+ */
+export function warnUntrustedSameExtensionSender(
+  sender: Runtime.MessageSender,
+  context: string
+): void {
+  if (sender.id !== runtime.id) {
+    return;
+  }
+
+  let senderOrigin: string | undefined;
+  try {
+    senderOrigin = sender.url != null ? new URL(sender.url).origin : undefined;
+  } catch {
+    senderOrigin = undefined;
+  }
+
+  console.warn(
+    `Background: ${context} from same-extension sender rejected by URL check:`,
+    senderOrigin
+  );
+}
+
 export function selectPrivateState(state: RootState): PrivateState {
   return {
     passwordHash: state.keys.passwordHash,

--- a/src/background/handlers/redux-actions.parity.test.ts
+++ b/src/background/handlers/redux-actions.parity.test.ts
@@ -32,12 +32,12 @@ jest.mock('webextension-polyfill', () => ({ windows: { get: jest.fn() } }));
 /**
  * Parity guard for `FORWARDED_ACTION_TYPES`.
  *
- * `handleReduxAction` (redux-actions.ts) only re-dispatches a UI-originated
- * Redux action into the background store when its `.type` is present in the
- * hand-maintained `FORWARDED_ACTION_TYPES` set. The set is fail-closed (an
- * unknown type is dropped and `{ handled: false }` is returned), so forgetting
- * to append a newly-added UI action produces NO compile-time signal — the
- * action is just silently dropped at runtime.
+ * `handleReduxAction` (redux-actions.ts) only re-dispatches via the generic
+ * forwarding path when the sender passes `isTrustedUiSender` AND the action's
+ * `.type` is present in the hand-maintained `FORWARDED_ACTION_TYPES` set. The
+ * set is fail-closed (an unknown type is dropped and `{ handled: false }` is
+ * returned), so forgetting to append a newly-added UI action produces NO
+ * compile-time signal — the action is just silently dropped at runtime.
  *
  * This test reconstructs the "creator universe" from the exact same action
  * modules `redux-actions.ts` imports and asserts BOTH directions of drift:

--- a/src/background/handlers/redux-actions.test.ts
+++ b/src/background/handlers/redux-actions.test.ts
@@ -10,7 +10,7 @@ import { accountRenamed } from '@background/redux/vault/actions';
 import { windowRequestWindowAttached } from '@background/redux/windowManagement/actions';
 
 import { handleCloseLedgerFlowWindows } from './close-ledger-flow-windows';
-import { handleReduxAction } from './redux-actions';
+import { FORWARDED_ACTION_TYPES, handleReduxAction } from './redux-actions';
 
 // enableOnboardingFlow touches webextension-polyfill; stub it and assert it runs.
 jest.mock('@background/open-onboarding-flow', () => ({
@@ -30,6 +30,13 @@ jest.mock('webextension-polyfill', () => ({
 const trustedSender = {
   id: 'ext-id',
   url: 'chrome-extension://ext-id/popup.html'
+} as Runtime.MessageSender;
+
+// A content script of this extension: our id, but a page URL — it fails the URL
+// half of the gate, which is the half that makes the gate meaningful.
+const untrustedSender = {
+  id: 'ext-id',
+  url: 'https://dapp.example/page'
 } as Runtime.MessageSender;
 
 // The same, displaying request `r1` — every window a dapp flow opens carries the
@@ -368,5 +375,104 @@ describe('handleReduxAction forwarding gate (fail-closed)', () => {
       error
     );
     consoleError.mockRestore();
+  });
+});
+
+describe('handleReduxAction sender-trust gate', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('resetVault from an untrusted sender never reaches the store', async () => {
+    // resetVaultSaga calls storage.local.clear() — this branch can wipe the wallet.
+    const { store, dispatch } = makeStore();
+
+    const result = await handleReduxAction(
+      { type: resetVault.type },
+      untrustedSender,
+      store
+    );
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(enableOnboardingFlowMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ handled: true });
+    expect(result).not.toHaveProperty('response');
+  });
+
+  it('a forwarded action from an untrusted sender never reaches the store', async () => {
+    const { store, dispatch } = makeStore();
+
+    const result = await handleReduxAction(lockVault(), untrustedSender, store);
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(result).toEqual({ handled: true });
+    // `toEqual` ignores undefined-valued keys, so the contract `respond()` reads
+    // (`index.ts:215` branches on `'response' in result`) needs its own assertion.
+    expect(result).not.toHaveProperty('response');
+  });
+
+  it('EVERY member of FORWARDED_ACTION_TYPES is gated, so a future addition is covered too', async () => {
+    // The point of iterating the live set rather than sampling it: there is no
+    // second list to keep in sync when a type is appended.
+    for (const type of FORWARDED_ACTION_TYPES) {
+      const { store, dispatch } = makeStore();
+
+      const result = await handleReduxAction({ type }, untrustedSender, store);
+
+      expect(dispatch).not.toHaveBeenCalled();
+      expect(result).toEqual({ handled: true });
+      expect(result).not.toHaveProperty('response');
+    }
+  });
+
+  it('warns once, with the origin only, when the rejected sender carries this extension id', async () => {
+    const { store } = makeStore();
+
+    await handleReduxAction(lockVault(), untrustedSender, store);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      `Background: redux action ${lockVault.type} from same-extension sender rejected by URL check:`,
+      'https://dapp.example'
+    );
+  });
+
+  it('a foreign extension id is dropped without a log', async () => {
+    const { store, dispatch } = makeStore();
+
+    const result = await handleReduxAction(
+      lockVault(),
+      {
+        id: 'other-ext',
+        url: 'chrome-extension://other-ext/page.html'
+      } as Runtime.MessageSender,
+      store
+    );
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({ handled: true });
+  });
+
+  it('an unlisted type from an untrusted sender still falls through — handleBringWeb3 depends on it', async () => {
+    // GET_ACTIVE_PUBLIC_KEY arrives from bring.ts, i.e. from a content script.
+    // If the gate were ever widened past the two re-dispatch types this would
+    // come back { handled: true } and the Bring integration would go dark.
+    const { store, dispatch } = makeStore();
+
+    const result = await handleReduxAction(
+      { type: 'GET_ACTIVE_PUBLIC_KEY' },
+      untrustedSender,
+      store
+    );
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(result).toEqual({ handled: false });
   });
 });

--- a/src/background/handlers/redux-actions.ts
+++ b/src/background/handlers/redux-actions.ts
@@ -111,7 +111,10 @@ import {
 import { vaultCipherReseted } from '../redux/vault-cipher/actions';
 import { attachWindowToRequest } from './attach-window-to-request';
 import { handleCloseLedgerFlowWindows } from './close-ledger-flow-windows';
-import { isTrustedUiSender } from './private-state';
+import {
+  isTrustedUiSender,
+  warnUntrustedSameExtensionSender
+} from './private-state';
 import { HandlerResult } from './types';
 
 // The request a sender page is displaying, read off its own URL — the same
@@ -293,6 +296,27 @@ export async function handleReduxAction(
     );
 
     return { handled: true, response: undefined };
+  }
+
+  // Both branches below re-dispatch into the real store: the set carries
+  // `unlockVault`, `initVault` and `keysReseted`, and `resetVault` reaches
+  // `storage.local.clear()`. Gated like the two branches above, and for the same
+  // reason — so this does not rest on the content script's request allowlist
+  // staying right. Scoped to those two branches on purpose: an unlisted type must
+  // keep falling through as `{ handled: false }`, which is how `handleBringWeb3`
+  // sees its content-script messages at all.
+  if (
+    action.type === resetVault.type ||
+    FORWARDED_ACTION_TYPES.has(action.type)
+  ) {
+    // Silently drop (no response), matching the sibling gates. Interpolating
+    // `action.type` into the warning is safe only because this branch is
+    // reached for a fixed vocabulary (resetVault plus FORWARDED_ACTION_TYPES) —
+    // widen the branch and it becomes attacker-chosen console text.
+    if (!isTrustedUiSender(sender)) {
+      warnUntrustedSameExtensionSender(sender, `redux action ${action.type}`);
+      return { handled: true };
+    }
   }
 
   if (action.type === resetVault.type) {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -22,7 +22,8 @@ import { handleLegacyImport } from '@background/handlers/legacy-import';
 import {
   isPrivateStateRequest,
   isTrustedUiSender,
-  selectPrivateState
+  selectPrivateState,
+  warnUntrustedSameExtensionSender
 } from '@background/handlers/private-state';
 import { handleReduxAction } from '@background/handlers/redux-actions';
 import { handleSdkMethod } from '@background/handlers/sdk-methods';
@@ -235,19 +236,7 @@ runtime.onMessage.addListener(
         // and has to be captured (and rejected) by the SDK branch first
         if (isPrivateStateRequest(action)) {
           if (!isTrustedUiSender(sender)) {
-            if (sender.id === runtime.id) {
-              // Same-extension sender rejected by the URL-prefix check —
-              // distinguishes a legitimate-but-unrecognized UI origin
-              // (packaging variant, sandboxed frame) from a probing sender.
-              // Origin only: a content-script sender's full page URL could
-              // carry tokens in query strings
-              const senderOrigin =
-                sender.url != null ? new URL(sender.url).origin : undefined;
-              console.warn(
-                'Background: private-state request from same-extension sender rejected by URL check:',
-                senderOrigin
-              );
-            }
+            warnUntrustedSameExtensionSender(sender, 'private-state request');
             // No data (and no error detail) for untrusted senders
             return;
           }


### PR DESCRIPTION
Closes [WALLET-1423](https://make-software.atlassian.net/browse/WALLET-1423).

## Problem

`handleReduxAction` (`src/background/handlers/redux-actions.ts`) re-dispatched messages into the background Redux store through two branches that never consulted the message `sender`:

- the `resetVault` branch, which runs `resetVaultSaga` → `storage.local.clear()`
- the `FORWARDED_ACTION_TYPES` branch — 73 action types, including `unlockVault`, `initVault`, `recoverVault`, `changePassword`, `keysReseted` and the `loginRetry*` lockout counters

Every sibling branch in the same router is gated on `isTrustedUiSender(sender)` — `windowRequestWindowAttached` and `closeLedgerFlowWindows` in this same file, plus the private-state request in `background/index.ts`, `handleSdkResponseToTab` and `handleLegacyImport`. These two were not, and the omission reads as oversight rather than decision: the parity test's own doc comment already described the set as re-dispatching "a UI-originated Redux action" — an invariant the code stated but did not enforce.

## Impact

**Latent, not live.** Verified on this tree: no `externally_connectable` and no `sandbox` key in any of the three manifests, no `onMessageExternal` anywhere, and the content script relays only the 12 `SDK_REQUEST_TYPES` (`src/content/index.ts`), which the earlier `isSDKMethod` branch consumes before the redux router runs.

So reachability rested entirely on that content-script allow-list — precisely the dependency the gated siblings state in their own comments that they refuse to rely on. If the relay regressed, or the content-script world were compromised, an attacker-chosen vault could be pushed through `unlockVault`, or the wallet wiped through `resetVault`.

## Change

1. **`refactor(background)`** — the "rejected same-extension sender" log was inline in the private-state branch of `background/index.ts`. It moves to `warnUntrustedSameExtensionSender` next to `isTrustedUiSender` in `handlers/private-state.ts`, so the redux router can reuse it. The URL parse is now wrapped in `try/catch`: an unparseable `sender.url` threw out of the router before. Origin only is logged, never the full URL — a content-script sender's page URL can carry query-string tokens.

2. **`fix(background)`** — the gate itself, covering both re-dispatch branches, dropping untrusted senders silently as `{ handled: true }` with no `response` key, exactly as the four sibling gates do.

**The gate is deliberately scoped to those two branches rather than applied to the whole handler.** An unlisted type must keep falling through as `{ handled: false }`, because that fall-through is the only route by which `handleBringWeb3` receives its three content-script message types. A blanket sender check would take the Bring integration down. A regression test pins this.

## Notes for review

- **The ticket's example actions are stale.** It names `encryptionKeyHashCreated`, `vaultCipherCreated` and `keysUpdated`; those left the forwarded set in WALLET-1385 and now sit in the parity test's EXCLUSIONS as background-only. The argument holds via the actions listed under "Problem" above, which are genuinely in the set. The ticket's "75 action types" is likewise stale — the set has 73.
- **No legitimate non-UI sender was found.** All ~100 `dispatchToMainStore` call sites live in `src/apps/*`, `src/libs/*` and `src/hooks/*`, i.e. extension pages. Content scripts send only the 12 SDK types plus the 3 Bring types; workers use `postMessage`; there are no offscreen documents, and no extension HTML page is web-accessible.
- **Why the `console.warn`.** A silent drop leaves no trace, and `dispatchToMainStore` never rejects — so a misfiring gate would present as a promise that never settles. The warn fires only for a sender carrying this extension's own id (which includes our own content script, whose `sender.url` is the host page).

## Testing

- New: 4 unit tests for the helper, 6 for the gate — including one that iterates **every** member of `FORWARDED_ACTION_TYPES`, so a type appended to the set in future is covered with no second list to maintain.
- Full suite green: 106 suites / 1035 tests, coverage thresholds enforced. `tsc --noEmit`, eslint and prettier clean.
- **Manual check still worth doing before merge:** the gate widened from 2 lifecycle actions to 74, so exercise lock/unlock, account rename, network switch, theme toggle, contacts and onboarding, and confirm the service-worker console shows no `rejected by URL check` warnings.


[WALLET-1423]: https://make-software.atlassian.net/browse/WALLET-1423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ