### PR TITLE
build(deps): stop proposing @types/node majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,10 @@ updates:
     # Add reviewers
     reviewers:
       - "Comp0te"
+    ignore:
+      # @types/node must track the Node runtime we build and run on, which is 22
+      # everywhere (.nvmrc, engines.node, CI node-version). Bump it with the Node
+      # upgrade, not ahead of it — otherwise code typechecks against APIs that are
+      # not there at runtime.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Dependabot keeps re-proposing `@types/node` majors. `@dependabot ignore this major version` only silences the one major the comment was filed on: #1479 silenced 26.x, and a day later #1485 arrived with 25.9.5. A config rule covers every future major instead.

`@types/node` has to track the Node runtime we build and run on, which is 22 everywhere — `.nvmrc` pins v22.23.1, `package.json` has `engines.node >=22`, and every CI workflow uses `node-version: 22.x`. Typing against a newer Node while running 22 means code that typechecks against APIs that are not there at runtime. Minors and patches still come through; only majors are held back, to be taken together with the Node upgrade.