### PR TITLE
feat(background): route secret-carrying requests over a gated port

### DIFF
--- a/src/apps/popup/pages/change-password/index.tsx
+++ b/src/apps/popup/pages/change-password/index.tsx
@@ -7,7 +7,6 @@ import { PasswordProtectionPage } from '@popup/pages/password-protection-page';
 import { RouterPath, useTypedNavigate } from '@popup/router';
 
 import { CHANGE_PASSWORD_REQUEST_TYPE } from '@background/handlers/privileged-port';
-import { changePassword } from '@background/redux/sagas/actions';
 
 import {
   FooterButtonsContainer,
@@ -18,14 +17,12 @@ import {
 import { requestOverPort } from '@libs/messaging/background-port';
 import { Button, PasswordInputs } from '@libs/ui/components';
 import {
-  clearUiError,
-  reportUiError
-} from '@libs/ui/components/saga-error-banner/ui-error-channel';
-import {
   CreatePasswordFormValues,
   useCreatePasswordForm
 } from '@libs/ui/forms/create-password';
 import { calculateSubmitButtonDisabled } from '@libs/ui/forms/get-submit-button-state-from-validation';
+
+import { submitPasswordChange } from './submit-password-change';
 
 export const ChangePasswordPage = () => {
   const [isPasswordConfirmed, setIsPasswordConfirmed] =
@@ -41,7 +38,7 @@ export const ChangePasswordPage = () => {
   const {
     register,
     handleSubmit,
-    formState: { isDirty, errors },
+    formState: { isDirty, isSubmitting, errors },
     control
   } = useCreatePasswordForm();
 
@@ -58,26 +55,20 @@ export const ChangePasswordPage = () => {
     setCurrentPassword(password);
   }, []);
 
-  const isSubmitButtonDisabled = calculateSubmitButtonDisabled({
-    isDirty
-  });
+  const isSubmitButtonDisabled =
+    calculateSubmitButtonDisabled({ isDirty }) || isSubmitting;
 
-  const onSubmit = (data: CreatePasswordFormValues) => {
+  const onSubmit = async (data: CreatePasswordFormValues) => {
     if (currentPassword == null) return;
 
-    requestOverPort({
-      type: CHANGE_PASSWORD_REQUEST_TYPE,
-      payload: { currentPassword, password: data.password }
-    })
-      .then(() => {
-        clearUiError('dispatch-failed', changePassword.type);
-      })
-      .catch((error: unknown) => {
-        console.error('Password change request failed:', error);
-        reportUiError('dispatch-failed', changePassword.type);
-      });
-
-    navigate(RouterPath.Home);
+    await submitPasswordChange(
+      () =>
+        requestOverPort({
+          type: CHANGE_PASSWORD_REQUEST_TYPE,
+          payload: { currentPassword, password: data.password }
+        }),
+      () => navigate(RouterPath.Home)
+    );
   };
 
   if (!isPasswordConfirmed) {

--- a/src/apps/popup/pages/change-password/index.tsx
+++ b/src/apps/popup/pages/change-password/index.tsx
@@ -6,8 +6,8 @@ import { ChangePasswordPageContent } from '@popup/pages/change-password/content'
 import { PasswordProtectionPage } from '@popup/pages/password-protection-page';
 import { RouterPath, useTypedNavigate } from '@popup/router';
 
+import { CHANGE_PASSWORD_REQUEST_TYPE } from '@background/handlers/privileged-port';
 import { changePassword } from '@background/redux/sagas/actions';
-import { dispatchToMainStore } from '@background/redux/utils';
 
 import {
   FooterButtonsContainer,
@@ -15,7 +15,12 @@ import {
   HeaderSubmenuBarNavLink,
   PopupLayout
 } from '@libs/layout';
+import { requestOverPort } from '@libs/messaging/background-port';
 import { Button, PasswordInputs } from '@libs/ui/components';
+import {
+  clearUiError,
+  reportUiError
+} from '@libs/ui/components/saga-error-banner/ui-error-channel';
 import {
   CreatePasswordFormValues,
   useCreatePasswordForm
@@ -60,9 +65,17 @@ export const ChangePasswordPage = () => {
   const onSubmit = (data: CreatePasswordFormValues) => {
     if (currentPassword == null) return;
 
-    dispatchToMainStore(
-      changePassword({ currentPassword, password: data.password })
-    );
+    requestOverPort({
+      type: CHANGE_PASSWORD_REQUEST_TYPE,
+      payload: { currentPassword, password: data.password }
+    })
+      .then(() => {
+        clearUiError('dispatch-failed', changePassword.type);
+      })
+      .catch((error: unknown) => {
+        console.error('Password change request failed:', error);
+        reportUiError('dispatch-failed', changePassword.type);
+      });
 
     navigate(RouterPath.Home);
   };

--- a/src/apps/popup/pages/change-password/submit-password-change.test.ts
+++ b/src/apps/popup/pages/change-password/submit-password-change.test.ts
@@ -1,0 +1,58 @@
+import { changePassword } from '@background/redux/sagas/actions';
+
+import {
+  clearUiError,
+  reportUiError
+} from '@libs/ui/components/saga-error-banner/ui-error-channel';
+
+import { submitPasswordChange } from './submit-password-change';
+
+jest.mock('@libs/ui/components/saga-error-banner/ui-error-channel', () => ({
+  clearUiError: jest.fn(),
+  reportUiError: jest.fn()
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, 'error').mockImplementation(() => undefined);
+});
+
+it('proceeds only once the background has accepted the change', async () => {
+  const onAccepted = jest.fn();
+
+  await submitPasswordChange(async () => ({ accepted: true }), onAccepted);
+
+  expect(onAccepted).toHaveBeenCalled();
+  expect(clearUiError).toHaveBeenCalledWith(
+    'dispatch-failed',
+    changePassword.type
+  );
+  expect(reportUiError).not.toHaveBeenCalled();
+});
+
+// Navigating regardless left the user on Home believing the password had
+// changed. The old one is still live, and each later unlock attempt counts
+// toward the lockout.
+it('keeps the caller on the page and surfaces the failure when the request fails', async () => {
+  const onAccepted = jest.fn();
+
+  await submitPasswordChange(async () => {
+    throw new Error('Background port timed out');
+  }, onAccepted);
+
+  expect(onAccepted).not.toHaveBeenCalled();
+  expect(reportUiError).toHaveBeenCalledWith(
+    'dispatch-failed',
+    changePassword.type
+  );
+  expect(clearUiError).not.toHaveBeenCalled();
+});
+
+it('never logs the request payload', async () => {
+  await submitPasswordChange(async () => {
+    throw new Error('boom');
+  }, jest.fn());
+
+  const logged = (console.error as jest.Mock).mock.calls.flat().join(' ');
+  expect(logged).not.toContain('password');
+});

--- a/src/apps/popup/pages/change-password/submit-password-change.ts
+++ b/src/apps/popup/pages/change-password/submit-password-change.ts
@@ -1,0 +1,27 @@
+import { changePassword } from '@background/redux/sagas/actions';
+
+import {
+  clearUiError,
+  reportUiError
+} from '@libs/ui/components/saga-error-banner/ui-error-channel';
+
+/**
+ * The port ack is the only signal that a password change reached the background,
+ * and `ui-error-channel` is UI-local — it never reaches the store or a replica.
+ * So the caller must stay on this screen until the ack lands: navigating first
+ * left the user on Home believing the password had changed, while the old one
+ * was still live and every later unlock attempt counted toward the lockout.
+ */
+export async function submitPasswordChange(
+  send: () => Promise<unknown>,
+  onAccepted: () => void
+): Promise<void> {
+  try {
+    await send();
+    clearUiError('dispatch-failed', changePassword.type);
+    onAccepted();
+  } catch (error) {
+    console.error('Password change request failed:', error);
+    reportUiError('dispatch-failed', changePassword.type);
+  }
+}

--- a/src/background/handlers/privileged-port.test.ts
+++ b/src/background/handlers/privileged-port.test.ts
@@ -33,6 +33,14 @@ const WEB_PAGE_SENDER = {
   url: 'https://evil.example/index.html'
 } as Runtime.MessageSender;
 
+// Same id and an allow-listed pathname, foreign origin. Every other fixture is
+// already rejected by `isAllowedPage` on pathname alone, so without this one the
+// `isTrustedUiSender` leg of the guard can be deleted with the suite still green.
+const SPOOFED_ORIGIN_SENDER = {
+  id: 'ext-id',
+  url: 'https://evil.example/popup.html'
+} as Runtime.MessageSender;
+
 const FOREIGN_EXTENSION_SENDER = {
   id: 'some-other-extension-id',
   url: 'chrome-extension://some-other-extension-id/page.html'
@@ -58,6 +66,20 @@ describe('handlePrivilegedRequest — CHANGE_PASSWORD_REQUEST', () => {
     ).resolves.toEqual({ accepted: true });
 
     expect(dispatch).toHaveBeenCalledWith(changePassword(validPayload));
+  });
+
+  it('refuses a sender whose origin is not this extension', async () => {
+    const { store, dispatch } = storeWithDispatch();
+
+    await expect(
+      handlePrivilegedRequest(
+        { type: CHANGE_PASSWORD_REQUEST_TYPE, payload: validPayload },
+        SPOOFED_ORIGIN_SENDER,
+        store
+      )
+    ).resolves.toBeNull();
+
+    expect(dispatch).not.toHaveBeenCalled();
   });
 
   it('refuses a web-page sender', async () => {

--- a/src/background/handlers/privileged-port.test.ts
+++ b/src/background/handlers/privileged-port.test.ts
@@ -1,0 +1,350 @@
+import { Runtime } from 'webextension-polyfill';
+
+import { MainStore } from '@background/redux/get-main-store';
+import { changePassword } from '@background/redux/sagas/actions';
+
+import {
+  ALLOWED_PAGES,
+  CHANGE_PASSWORD_REQUEST_TYPE,
+  attachPrivilegedPort,
+  handlePrivilegedRequest,
+  isAllowedPage
+} from './privileged-port';
+
+jest.mock('webextension-polyfill', () => ({
+  runtime: {
+    id: 'ext-id',
+    getURL: (path: string) => `chrome-extension://ext-id/${path}`
+  }
+}));
+
+const POPUP_SENDER = {
+  id: 'ext-id',
+  url: 'chrome-extension://ext-id/popup.html#/change-password'
+} as Runtime.MessageSender;
+
+const CONNECT_SENDER = {
+  id: 'ext-id',
+  url: 'chrome-extension://ext-id/connect-to-app.html'
+} as Runtime.MessageSender;
+
+const WEB_PAGE_SENDER = {
+  id: 'ext-id',
+  url: 'https://evil.example/index.html'
+} as Runtime.MessageSender;
+
+const FOREIGN_EXTENSION_SENDER = {
+  id: 'some-other-extension-id',
+  url: 'chrome-extension://some-other-extension-id/page.html'
+} as Runtime.MessageSender;
+
+const storeWithDispatch = () => {
+  const dispatch = jest.fn();
+  return { store: { dispatch } as unknown as MainStore, dispatch };
+};
+
+const validPayload = { currentPassword: 'old-one', password: 'new-one' };
+
+describe('handlePrivilegedRequest — CHANGE_PASSWORD_REQUEST', () => {
+  it('dispatches changePassword for the popup page', async () => {
+    const { store, dispatch } = storeWithDispatch();
+
+    await expect(
+      handlePrivilegedRequest(
+        { type: CHANGE_PASSWORD_REQUEST_TYPE, payload: validPayload },
+        POPUP_SENDER,
+        store
+      )
+    ).resolves.toEqual({ accepted: true });
+
+    expect(dispatch).toHaveBeenCalledWith(changePassword(validPayload));
+  });
+
+  it('refuses a web-page sender', async () => {
+    const { store, dispatch } = storeWithDispatch();
+
+    await expect(
+      handlePrivilegedRequest(
+        { type: CHANGE_PASSWORD_REQUEST_TYPE, payload: validPayload },
+        WEB_PAGE_SENDER,
+        store
+      )
+    ).resolves.toBeNull();
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('refuses an extension page that is not on the allowlist', async () => {
+    const { store, dispatch } = storeWithDispatch();
+
+    await expect(
+      handlePrivilegedRequest(
+        { type: CHANGE_PASSWORD_REQUEST_TYPE, payload: validPayload },
+        CONNECT_SENDER,
+        store
+      )
+    ).resolves.toBeNull();
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('refuses an unknown request type', async () => {
+    const { store, dispatch } = storeWithDispatch();
+
+    await expect(
+      handlePrivilegedRequest({ type: 'NOPE' }, POPUP_SENDER, store)
+    ).resolves.toBeNull();
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('never logs the payload', async () => {
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const { store } = storeWithDispatch();
+
+    await handlePrivilegedRequest(
+      { type: CHANGE_PASSWORD_REQUEST_TYPE, payload: validPayload },
+      CONNECT_SENDER,
+      store
+    );
+
+    expect(warn).toHaveBeenCalled();
+    const logged = JSON.stringify(warn.mock.calls);
+    expect(logged).not.toContain('old-one');
+    expect(logged).not.toContain('new-one');
+    warn.mockRestore();
+  });
+
+  it('does not warn for a sender outside this extension', async () => {
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const { store, dispatch } = storeWithDispatch();
+
+    await expect(
+      handlePrivilegedRequest(
+        { type: CHANGE_PASSWORD_REQUEST_TYPE, payload: validPayload },
+        FOREIGN_EXTENSION_SENDER,
+        store
+      )
+    ).resolves.toBeNull();
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('does not dispatch changePassword for a different, allowed request type', async () => {
+    const { store, dispatch } = storeWithDispatch();
+    const OTHER_TYPE = 'OTHER_REQUEST_TYPE';
+    const mutableAllowedPages = ALLOWED_PAGES as Record<
+      string,
+      readonly string[]
+    >;
+    mutableAllowedPages[OTHER_TYPE] = ['/popup.html'];
+
+    try {
+      // Passes the hasOwn check and the sender/page gate — same as a real
+      // sub-handler request — but must not fall through into changePassword.
+      await expect(
+        handlePrivilegedRequest(
+          { type: OTHER_TYPE, payload: validPayload },
+          POPUP_SENDER,
+          store
+        )
+      ).resolves.toBeNull();
+
+      expect(dispatch).not.toHaveBeenCalled();
+    } finally {
+      delete mutableAllowedPages[OTHER_TYPE];
+    }
+  });
+
+  it('refuses a sender with no url', async () => {
+    const { store, dispatch } = storeWithDispatch();
+    const NO_URL_SENDER = { id: 'ext-id' } as Runtime.MessageSender;
+
+    await expect(
+      handlePrivilegedRequest(
+        { type: CHANGE_PASSWORD_REQUEST_TYPE, payload: validPayload },
+        NO_URL_SENDER,
+        store
+      )
+    ).resolves.toBeNull();
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('refuses a malformed payload', async () => {
+    const { store, dispatch } = storeWithDispatch();
+
+    await expect(
+      handlePrivilegedRequest(
+        {
+          type: CHANGE_PASSWORD_REQUEST_TYPE,
+          payload: { currentPassword: 'old-one' }
+        },
+        POPUP_SENDER,
+        store
+      )
+    ).resolves.toBeNull();
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('refuses an empty new password', async () => {
+    const { store, dispatch } = storeWithDispatch();
+
+    await expect(
+      handlePrivilegedRequest(
+        {
+          type: CHANGE_PASSWORD_REQUEST_TYPE,
+          payload: { currentPassword: 'old-one', password: '' }
+        },
+        POPUP_SENDER,
+        store
+      )
+    ).resolves.toBeNull();
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('refuses a request with no payload', async () => {
+    const { store, dispatch } = storeWithDispatch();
+
+    await expect(
+      handlePrivilegedRequest(
+        { type: CHANGE_PASSWORD_REQUEST_TYPE },
+        POPUP_SENDER,
+        store
+      )
+    ).resolves.toBeNull();
+
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('isAllowedPage', () => {
+  it('is false when the sender has no url', () => {
+    const NO_URL_SENDER = { id: 'ext-id' } as Runtime.MessageSender;
+
+    expect(isAllowedPage(CHANGE_PASSWORD_REQUEST_TYPE, NO_URL_SENDER)).toBe(
+      false
+    );
+  });
+});
+
+describe('attachPrivilegedPort', () => {
+  const flush = () => new Promise(resolve => setImmediate(resolve));
+
+  function makePort(sender: Runtime.MessageSender) {
+    const listeners: ((message: unknown) => void)[] = [];
+    return {
+      sender,
+      postMessage: jest.fn(),
+      disconnect: jest.fn(),
+      onMessage: {
+        addListener: (fn: (m: unknown) => void) => listeners.push(fn)
+      },
+      emit: (message: unknown) => listeners.forEach(fn => fn(message)),
+      listenerCount: () => listeners.length
+    } as unknown as Runtime.Port & {
+      emit: (m: unknown) => void;
+      listenerCount: () => number;
+    };
+  }
+
+  it('attaches the message listener synchronously, so a message that arrives before the store is ready is still handled', async () => {
+    const { store, dispatch } = storeWithDispatch();
+    let releaseStore: (value: MainStore) => void = () => undefined;
+    const slowStore = new Promise<MainStore>(resolve => {
+      releaseStore = resolve;
+    });
+
+    const port = makePort(POPUP_SENDER);
+    attachPrivilegedPort(port, () => slowStore);
+
+    // The listener must exist before the store resolves — this is the cold
+    // service-worker-start case that would otherwise hang the UI forever.
+    expect(port.listenerCount()).toBe(1);
+
+    port.emit({ type: CHANGE_PASSWORD_REQUEST_TYPE, payload: validPayload });
+    releaseStore(store);
+    await flush();
+
+    expect(dispatch).toHaveBeenCalledWith(changePassword(validPayload));
+    expect(port.postMessage).toHaveBeenCalledWith({ accepted: true });
+  });
+
+  it('disconnects without answering when the request is refused', async () => {
+    const { store } = storeWithDispatch();
+    const port = makePort(WEB_PAGE_SENDER);
+    attachPrivilegedPort(port, () => Promise.resolve(store));
+
+    port.emit({ type: CHANGE_PASSWORD_REQUEST_TYPE, payload: validPayload });
+    await flush();
+
+    expect(port.postMessage).not.toHaveBeenCalled();
+    expect(port.disconnect).toHaveBeenCalled();
+  });
+
+  it('disconnects when the handler chain throws, and never logs the raw error', async () => {
+    const error = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const thrown = new Error('store init failed') as Error & {
+      action?: unknown;
+    };
+    // Simulate a middleware that attaches the dispatched action (and thus
+    // the payload) to the thrown error, to prove it is never logged as-is.
+    thrown.action = changePassword(validPayload);
+    const port = makePort(POPUP_SENDER);
+    attachPrivilegedPort(port, () => Promise.reject(thrown));
+
+    port.emit({ type: CHANGE_PASSWORD_REQUEST_TYPE, payload: validPayload });
+    await flush();
+
+    expect(port.postMessage).not.toHaveBeenCalled();
+    expect(port.disconnect).toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(
+      'privileged port: handler failed',
+      'store init failed'
+    );
+
+    const logged = JSON.stringify(error.mock.calls);
+    expect(logged).not.toContain('old-one');
+    expect(logged).not.toContain('new-one');
+    error.mockRestore();
+  });
+
+  it('logs "unknown" when the thrown value is not an Error', async () => {
+    const error = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const port = makePort(POPUP_SENDER);
+    attachPrivilegedPort(port, () => Promise.reject('not an Error instance'));
+
+    port.emit({ type: CHANGE_PASSWORD_REQUEST_TYPE, payload: validPayload });
+    await flush();
+
+    expect(error).toHaveBeenCalledWith(
+      'privileged port: handler failed',
+      'unknown'
+    );
+    error.mockRestore();
+  });
+
+  it('treats a missing port.sender as untrusted', async () => {
+    const { store, dispatch } = storeWithDispatch();
+    const port = makePort(undefined as unknown as Runtime.MessageSender);
+    attachPrivilegedPort(port, () => Promise.resolve(store));
+
+    port.emit({ type: CHANGE_PASSWORD_REQUEST_TYPE, payload: validPayload });
+    await flush();
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(port.disconnect).toHaveBeenCalled();
+  });
+});

--- a/src/background/handlers/privileged-port.ts
+++ b/src/background/handlers/privileged-port.ts
@@ -1,0 +1,127 @@
+import { Runtime, runtime } from 'webextension-polyfill';
+
+import { MainStore } from '@background/redux/get-main-store';
+import { changePassword } from '@background/redux/sagas/actions';
+
+import { isTrustedUiSender } from './private-state';
+
+export const CHANGE_PASSWORD_REQUEST_TYPE = 'CHANGE_PASSWORD_REQUEST' as const;
+
+const POPUP_PAGE = '/popup.html';
+
+// isTrustedUiSender proves "an extension page"; it does not prove "a page that
+// needs this". Same shape and same reasoning as vault-secrets.ts.
+export const ALLOWED_PAGES: Record<string, readonly string[]> = {
+  [CHANGE_PASSWORD_REQUEST_TYPE]: [POPUP_PAGE]
+};
+
+export function isAllowedPage(
+  type: string,
+  sender: Runtime.MessageSender
+): boolean {
+  if (sender.url == null) {
+    return false;
+  }
+
+  const pages = ALLOWED_PAGES[type];
+
+  return pages != null && pages.includes(new URL(sender.url).pathname);
+}
+
+function isChangePasswordRequestPayload(
+  payload: unknown
+): payload is { currentPassword: string; password: string } {
+  const p = payload as
+    Partial<{ currentPassword: string; password: string }> | null | undefined;
+
+  if (p == null) {
+    return false;
+  }
+
+  return (
+    typeof p.currentPassword === 'string' &&
+    typeof p.password === 'string' &&
+    p.password.length > 0
+  );
+}
+
+/**
+ * `null` means refused or unknown: the caller disconnects without answering,
+ * matching `vault-secrets.ts`.
+ */
+export async function handlePrivilegedRequest(
+  request: { type: string; payload?: unknown },
+  sender: Runtime.MessageSender,
+  store: MainStore
+): Promise<unknown | null> {
+  if (!Object.hasOwn(ALLOWED_PAGES, request.type)) {
+    return null;
+  }
+
+  if (!isTrustedUiSender(sender) || !isAllowedPage(request.type, sender)) {
+    // Same-extension only, and origin only — a content script or web page can
+    // connect to this port too, and its sender.url can carry a query string.
+    if (sender.id === runtime.id) {
+      // nosemgrep: cw-logging-secrets — logs the sender origin only
+      console.warn(
+        'Background: privileged port request rejected for sender:',
+        sender.url != null ? new URL(sender.url).origin : undefined
+      );
+    }
+    return null;
+  }
+
+  // Explicit type match, not just "the only key in ALLOWED_PAGES today": a
+  // sub-handler for a different type can legitimately return `null` to mean
+  // "refused", and without this check that would fall through into
+  // dispatching changePassword with whatever payload that request carried.
+  if (request.type === CHANGE_PASSWORD_REQUEST_TYPE) {
+    if (!isChangePasswordRequestPayload(request.payload)) {
+      return null;
+    }
+
+    // The ack is "received and dispatched", not "completed" —
+    // `changePasswordSaga` reports its outcome through `sagaError`.
+    store.dispatch(changePassword(request.payload));
+    return { accepted: true };
+  }
+
+  return null;
+}
+
+/**
+ * The message listener MUST be attached synchronously. On a cold service-worker
+ * start the page's already-sent message is delivered only to listeners present
+ * at that moment; awaiting the store first drops it, and because the port is not
+ * disconnected the caller's retry never fires and its promise never settles.
+ */
+export function attachPrivilegedPort(
+  port: Runtime.Port,
+  getStore: () => Promise<MainStore>
+): void {
+  port.onMessage.addListener(message => {
+    void (async () => {
+      const store = await getStore();
+      const result = await handlePrivilegedRequest(
+        message as { type: string; payload?: unknown },
+        port.sender ?? {},
+        store
+      );
+
+      if (result == null) {
+        port.disconnect();
+        return;
+      }
+
+      port.postMessage(result);
+    })().catch((error: unknown) => {
+      // Never the raw error: some middleware paths attach the dispatched
+      // action — and therefore both passwords — to a thrown error object.
+      console.error(
+        'privileged port: handler failed',
+        error instanceof Error ? error.message : 'unknown'
+      );
+      port.disconnect();
+    });
+  });
+}

--- a/src/background/handlers/redux-actions.parity.test.ts
+++ b/src/background/handlers/redux-actions.parity.test.ts
@@ -184,15 +184,19 @@ const EXCLUSIONS: ReadonlySet<string> = new Set(
     // the stored vault cipher with arbitrary bytes via `runtime.sendMessage`.
     // `yield put` only, from vault-sagas (unlock / recover / change-password)
     // and onboarding-sagas — never dispatched from the UI anymore now that
-    // change-password re-encrypts inside `changePasswordSaga` (which IS
-    // forwarded) instead of the page.
+    // change-password re-encrypts inside `changePasswordSaga` (dispatched via
+    // the privileged port, not the forwarding set) instead of the page.
     keysActions.keysUpdated,
     sessionActions.encryptionKeyHashCreated,
     vaultCipherActions.vaultCipherCreated,
     // Background-only since WALLET-1424: `armLockoutSaga` arms the lockout from
     // the background on every increment, so no page dispatches this. Forwarding
     // it would let any extension page set or clear a security control's clock.
-    loginRetryLockoutTimeActions.loginRetryLockoutTimeSet
+    loginRetryLockoutTimeActions.loginRetryLockoutTimeSet,
+    // Background-only since WALLET-1424: it carries two plaintext passwords, so
+    // it travels over the privileged port instead of runtime.sendMessage, which
+    // delivers to every open extension page.
+    sagasActions.changePassword
   ].map(creator => creator.type)
 );
 

--- a/src/background/handlers/redux-actions.parity.test.ts
+++ b/src/background/handlers/redux-actions.parity.test.ts
@@ -243,6 +243,17 @@ describe('FORWARDED_ACTION_TYPES parity', () => {
     expect(sorted(FORWARDED_ACTION_TYPES)).toEqual(sorted(forwardable));
   });
 
+  it('changePassword is NOT forwarded — it travels over the privileged port', () => {
+    // The set-algebra assertions above all stay true when a type moves between
+    // the two sets, so a paired edit — re-adding it here while deleting its
+    // EXCLUSIONS entry — passes every one of them. Membership is what lets the
+    // background accept two plaintext passwords over the fan-out channel from
+    // any trusted-UI page, so it gets its own pin.
+    expect(FORWARDED_ACTION_TYPES.has(sagasActions.changePassword.type)).toBe(
+      false
+    );
+  });
+
   it('windowRequestWindowAttached is NOT blindly forwarded — it has a dedicated branch', () => {
     // The Ledger hook dispatches it from a UI page, so it must reach the
     // background; but it must arrive through `handleReduxAction`'s dedicated

--- a/src/background/handlers/redux-actions.ts
+++ b/src/background/handlers/redux-actions.ts
@@ -86,7 +86,6 @@ import {
   recipientPublicKeyReseted
 } from '../redux/recent-recipient-public-keys/actions';
 import {
-  changePassword,
   createAccount,
   initKeys,
   initVault,
@@ -140,7 +139,6 @@ export const FORWARDED_ACTION_TYPES: ReadonlySet<string> = new Set(
     initVault,
     recoverVault,
     createAccount,
-    changePassword,
     deploysReseted,
     sessionReseted,
     vaultUnlocked,

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -25,6 +25,7 @@ import {
   selectPrivateState,
   warnUntrustedSameExtensionSender
 } from '@background/handlers/private-state';
+import { attachPrivilegedPort } from '@background/handlers/privileged-port';
 import { handleReduxAction } from '@background/handlers/redux-actions';
 import { handleSdkMethod } from '@background/handlers/sdk-methods';
 import { handleSdkResponseToTab } from '@background/handlers/sdk-response-to-tab';
@@ -49,6 +50,8 @@ import {
 
 import { sdkEvent } from '@content/sdk-event';
 import { isSDKMethod } from '@content/sdk-method';
+
+import { BACKGROUND_PORT_NAME } from '@libs/messaging/background-port';
 
 import { activeOriginChanged } from './redux/active-origin/actions';
 import { selectKeysDoesExist } from './redux/keys/selectors';
@@ -307,6 +310,14 @@ runtime.onMessage.addListener(
     });
   }
 );
+
+runtime.onConnect.addListener(port => {
+  if (port.name !== BACKGROUND_PORT_NAME) {
+    return;
+  }
+
+  attachPrivilegedPort(port, getExistingMainStoreSingletonOrInit);
+});
 
 initKeepAlive().catch(error => {
   console.error('Initialization of keep alive error:', error);

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -253,14 +253,15 @@ function isChangePasswordPayload(
 
 // Both halves of the re-key happen here, against the background's own state:
 // the current password is verified, and the new material is derived from a
-// plaintext password exactly as `initKeysSage` does it. This action rides the
-// sender-ungated forwarded path, so a caller that could hand in
-// `newEncryptionKeyHash` would be choosing the key the vault is re-encrypted
-// under — and `fetchPrivateState` hands `vaultCipher` to any extension page,
-// which makes a chosen key an offline decrypt. Verifying page-side only is not
-// enough either: the page-side check reads `passwordHash` from that same
-// handler, so it is replayable, while the plaintext password demanded here is
-// not derivable from anything an extension page can read.
+// plaintext password exactly as `initKeysSage` does it. Since WALLET-1424 this
+// action arrives over the privileged port (`privileged-port.ts`), gated on
+// both sender and page — but a caller that could hand in `newEncryptionKeyHash`
+// would still be choosing the key the vault is re-encrypted under, and
+// `fetchPrivateState` hands `vaultCipher` to any extension page, which makes a
+// chosen key an offline decrypt. Verifying page-side only is not enough
+// either: the page-side check reads `passwordHash` from that same handler, so
+// it is replayable, while the plaintext password demanded here is not
+// derivable from anything an extension page can read.
 // `scryptAsync` yields to the event loop between blocks, so the three
 // derivations do not wedge the worker the way synchronous ones would.
 export function* changePasswordSaga(action: ReturnType<typeof changePassword>) {
@@ -274,11 +275,11 @@ export function* changePasswordSaga(action: ReturnType<typeof changePassword>) {
   const releaseAnchor = anchorServiceWorker('encrypt');
 
   try {
-    // Validated inside the `try`, and destructured only after: this action
-    // rides the sender-ungated forwarded path, so `{ type }` with no payload
-    // reaches `store.dispatch` unchanged, and a destructure above would throw
-    // past every catch here into `rootSaga`'s boundary-less `all([...])`,
-    // cancelling every watcher in the tree — auto-lock included.
+    // Validated inside the `try`, and destructured only after: the privileged
+    // port already validates payload shape before dispatching, but this saga
+    // has no static guarantee of that — a destructure above would throw past
+    // every catch here into `rootSaga`'s boundary-less `all([...])`, cancelling
+    // every watcher in the tree — auto-lock included.
     if (!isChangePasswordPayload(action.payload)) {
       throw Error('Malformed changePassword payload');
     }

--- a/src/background/redux/surfaced-dispatch-actions.test.ts
+++ b/src/background/redux/surfaced-dispatch-actions.test.ts
@@ -1,6 +1,7 @@
 import { dismissSagaError } from './app-events/actions';
 import { ledgerNewWindowIdChanged } from './ledger/actions';
 import {
+  changePassword,
   initKeys,
   initVault,
   lockVault,
@@ -21,6 +22,7 @@ describe('SURFACED_DISPATCH_ACTIONS', () => {
       [
         openExportKeysWindow.type,
         lockVault.type,
+        changePassword.type,
         windowRequestWindowAttached.type,
         ledgerNewWindowIdChanged.type,
         resetVault.type,
@@ -42,6 +44,7 @@ describe('SURFACED_DISPATCH_ACTIONS', () => {
       [
         'OPEN_EXPORT_KEYS_WINDOW_SAGA',
         'LOCK_VAULT_SAGA',
+        'CHANGE_PASSWORD_SAGA',
         'windowManagement/windowRequestWindowAttached',
         'ledger/ledgerNewWindowIdChanged',
         'RESET_VAULT_SAGA',

--- a/src/background/redux/surfaced-dispatch-actions.ts
+++ b/src/background/redux/surfaced-dispatch-actions.ts
@@ -1,6 +1,7 @@
 import { dismissSagaError } from './app-events/actions';
 import { ledgerNewWindowIdChanged } from './ledger/actions';
 import {
+  changePassword,
   initKeys,
   initVault,
   lockVault,
@@ -27,6 +28,12 @@ export const SURFACED_DISPATCH_ACTIONS: ReadonlySet<string> = new Set([
   // The user pressed Lock and the wallet stayed unlocked — a security outcome,
   // not an inconvenience.
   lockVault.type,
+  // Reported by the change-password page directly rather than through
+  // `dispatchToMainStore` — it travels over the privileged port. Listed anyway so
+  // this set describes every `dispatch-failed` banner rather than only the ones
+  // the helper raises: silently, the user is on Home believing the password
+  // changed while the old one still unlocks the vault.
+  changePassword.type,
   // The Ledger permission window never attaches to the request, which then hangs
   // until the dapp's own timeout (see attach-window-to-request.ts).
   windowRequestWindowAttached.type,

--- a/src/libs/messaging/background-port.test.ts
+++ b/src/libs/messaging/background-port.test.ts
@@ -46,11 +46,19 @@ it('resolves with the first message and disconnects', async () => {
   const port = makePort();
   mockConnect.mockReturnValue(port);
 
-  const pending = requestOverPort<{ status: string }>({ type: 'X' });
+  const request = {
+    type: 'X',
+    payload: { currentPassword: 'a', password: 'b' }
+  };
+  const pending = requestOverPort<{ status: string }>(request);
   port.emitMessage({ status: 'ok' });
 
   await expect(pending).resolves.toEqual({ status: 'ok' });
-  expect(port.postMessage).toHaveBeenCalledWith({ type: 'X' });
+  // The background returns early for any other port name *without*
+  // disconnecting, so a wrong name costs the caller the whole backstop.
+  expect(mockConnect).toHaveBeenCalledWith({ name: BACKGROUND_PORT_NAME });
+  // Payload included: the background refuses a request whose payload is missing.
+  expect(port.postMessage).toHaveBeenCalledWith(request);
   expect(port.disconnect).toHaveBeenCalled();
 });
 
@@ -62,7 +70,13 @@ it('retries when the port disconnects before a response', async () => {
   const pending = requestOverPort<{ status: string }>({ type: 'X' });
   first.emitDisconnect();
 
-  await jest.advanceTimersByTimeAsync(250);
+  // Just short of the first delay: a zeroed backoff would already have
+  // reconnected here, and the retry count alone cannot see that.
+  await jest.advanceTimersByTimeAsync(249);
+  expect(mockConnect).toHaveBeenCalledTimes(1);
+
+  await jest.advanceTimersByTimeAsync(1);
+  expect(mockConnect).toHaveBeenCalledTimes(2);
   second.emitMessage({ status: 'ok' });
 
   await expect(pending).resolves.toEqual({ status: 'ok' });
@@ -115,4 +129,25 @@ it('gives up after the configured retries', async () => {
 
   await assertion;
   expect(mockConnect).toHaveBeenCalledTimes(3);
+});
+
+// The one exit that left the timer armed. A synchronous throw rejected with
+// `settled` still false, so the timeout stayed pending for its full duration —
+// holding the executor's closure and, with it, the request's passwords.
+it('clears the timeout when postMessage throws synchronously', async () => {
+  const port = makePort();
+  port.postMessage.mockImplementation(() => {
+    throw new Error('Extension context invalidated');
+  });
+  mockConnect.mockReturnValue(port);
+
+  const pending = requestOverPort({ type: 'X' });
+
+  await expect(pending).rejects.toThrow('Extension context invalidated');
+  expect(port.disconnect).toHaveBeenCalledTimes(1);
+
+  // If the timer were still armed it would fire here and disconnect a second
+  // time.
+  await jest.advanceTimersByTimeAsync(PORT_RESPONSE_TIMEOUT_MS * 2);
+  expect(port.disconnect).toHaveBeenCalledTimes(1);
 });

--- a/src/libs/messaging/background-port.test.ts
+++ b/src/libs/messaging/background-port.test.ts
@@ -1,0 +1,118 @@
+import { runtime } from 'webextension-polyfill';
+
+import {
+  BACKGROUND_PORT_NAME,
+  PORT_RESPONSE_TIMEOUT_MS,
+  requestOverPort
+} from './background-port';
+
+jest.mock('webextension-polyfill', () => ({
+  runtime: { connect: jest.fn() }
+}));
+
+const mockConnect = runtime.connect as jest.Mock;
+
+/** A fake Port whose listeners the test drives directly. */
+function makePort() {
+  const messageListeners: ((message: unknown) => void)[] = [];
+  const disconnectListeners: (() => void)[] = [];
+
+  return {
+    name: BACKGROUND_PORT_NAME,
+    postMessage: jest.fn(),
+    disconnect: jest.fn(),
+    onMessage: {
+      addListener: (fn: (m: unknown) => void) => messageListeners.push(fn)
+    },
+    onDisconnect: {
+      addListener: (fn: () => void) => disconnectListeners.push(fn)
+    },
+    emitMessage: (message: unknown) =>
+      messageListeners.forEach(fn => fn(message)),
+    emitDisconnect: () => disconnectListeners.forEach(fn => fn())
+  };
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockConnect.mockReset();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+it('resolves with the first message and disconnects', async () => {
+  const port = makePort();
+  mockConnect.mockReturnValue(port);
+
+  const pending = requestOverPort<{ status: string }>({ type: 'X' });
+  port.emitMessage({ status: 'ok' });
+
+  await expect(pending).resolves.toEqual({ status: 'ok' });
+  expect(port.postMessage).toHaveBeenCalledWith({ type: 'X' });
+  expect(port.disconnect).toHaveBeenCalled();
+});
+
+it('retries when the port disconnects before a response', async () => {
+  const first = makePort();
+  const second = makePort();
+  mockConnect.mockReturnValueOnce(first).mockReturnValueOnce(second);
+
+  const pending = requestOverPort<{ status: string }>({ type: 'X' });
+  first.emitDisconnect();
+
+  await jest.advanceTimersByTimeAsync(250);
+  second.emitMessage({ status: 'ok' });
+
+  await expect(pending).resolves.toEqual({ status: 'ok' });
+  expect(mockConnect).toHaveBeenCalledTimes(2);
+});
+
+it('does not reconnect when the disconnect follows a response', async () => {
+  const port = makePort();
+  mockConnect.mockReturnValue(port);
+
+  const pending = requestOverPort<{ status: string }>({ type: 'X' });
+  port.emitMessage({ status: 'ok' });
+  port.emitDisconnect();
+
+  await expect(pending).resolves.toEqual({ status: 'ok' });
+  expect(mockConnect).toHaveBeenCalledTimes(1);
+});
+
+it('rejects on the liveness backstop without retrying — a dropped message yields neither a response nor a disconnect', async () => {
+  const port = makePort();
+  mockConnect.mockReturnValue(port);
+
+  const pending = requestOverPort({ type: 'X' });
+  const assertion = expect(pending).rejects.toThrow(
+    'Background port timed out'
+  );
+
+  await jest.advanceTimersByTimeAsync(PORT_RESPONSE_TIMEOUT_MS);
+  await assertion;
+  expect(mockConnect).toHaveBeenCalledTimes(1);
+});
+
+it('gives up after the configured retries', async () => {
+  const ports = [makePort(), makePort(), makePort()];
+  mockConnect
+    .mockReturnValueOnce(ports[0])
+    .mockReturnValueOnce(ports[1])
+    .mockReturnValueOnce(ports[2]);
+
+  const pending = requestOverPort({ type: 'X' });
+  const assertion = expect(pending).rejects.toThrow(
+    'Background port disconnected'
+  );
+
+  ports[0].emitDisconnect();
+  await jest.advanceTimersByTimeAsync(250);
+  ports[1].emitDisconnect();
+  await jest.advanceTimersByTimeAsync(500);
+  ports[2].emitDisconnect();
+
+  await assertion;
+  expect(mockConnect).toHaveBeenCalledTimes(3);
+});

--- a/src/libs/messaging/background-port.ts
+++ b/src/libs/messaging/background-port.ts
@@ -1,0 +1,85 @@
+import { runtime } from 'webextension-polyfill';
+
+/** Only this port name reaches the privileged router; anything else is ignored. */
+export const BACKGROUND_PORT_NAME = 'cw-privileged';
+
+/** A disconnect means the message never produced a result — safe to re-send. */
+const PORT_RETRY_DELAYS_MS = [250, 500];
+
+/**
+ * Liveness backstop. A message delivered before the background attached its
+ * listener produces neither a response nor a disconnect, so retry alone cannot
+ * see it. Generous on purpose: it must never fire during a real scrypt
+ * derivation, which `request-with-retry.ts`'s 5s could not bound.
+ */
+export const PORT_RESPONSE_TIMEOUT_MS = 60_000;
+
+class PortDisconnectedError extends Error {
+  constructor() {
+    super('Background port disconnected');
+    this.name = 'PortDisconnectedError';
+  }
+}
+
+interface PortRequest {
+  type: string;
+  payload?: unknown;
+}
+
+function attempt<Res>(request: PortRequest): Promise<Res> {
+  return new Promise<Res>((resolve, reject) => {
+    let settled = false;
+    const port = runtime.connect({ name: BACKGROUND_PORT_NAME });
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      port.disconnect();
+      reject(new Error('Background port timed out'));
+    }, PORT_RESPONSE_TIMEOUT_MS);
+
+    port.onMessage.addListener(message => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      port.disconnect();
+      resolve(message as Res);
+    });
+
+    port.onDisconnect.addListener(() => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(new PortDisconnectedError());
+    });
+
+    port.postMessage(request);
+  });
+}
+
+/**
+ * One short-lived port per request. Retries only a disconnect-before-response —
+ * a timeout is NOT retried, because the request may have already been acted on.
+ */
+export async function requestOverPort<Res>(request: PortRequest): Promise<Res> {
+  let lastError: unknown;
+
+  for (let i = 0; i <= PORT_RETRY_DELAYS_MS.length; i++) {
+    if (i > 0) {
+      await new Promise(resolve =>
+        setTimeout(resolve, PORT_RETRY_DELAYS_MS[i - 1])
+      );
+    }
+
+    try {
+      return await attempt<Res>(request);
+    } catch (error) {
+      if (!(error instanceof PortDisconnectedError)) {
+        throw error;
+      }
+      lastError = error;
+    }
+  }
+
+  throw lastError;
+}

--- a/src/libs/messaging/background-port.ts
+++ b/src/libs/messaging/background-port.ts
@@ -9,8 +9,14 @@ const PORT_RETRY_DELAYS_MS = [250, 500];
 /**
  * Liveness backstop. A message delivered before the background attached its
  * listener produces neither a response nor a disconnect, so retry alone cannot
- * see it. Generous on purpose: it must never fire during a real scrypt
- * derivation, which `request-with-retry.ts`'s 5s could not bound.
+ * see it.
+ *
+ * Sized for the requests this port is built to carry, not for the one it
+ * carries today. `changePassword` is acked as soon as the handler dispatches,
+ * ahead of any derivation — but the unlock and verify requests answer only
+ * *after* their scrypt, and those derivations are serialised process-wide, so a
+ * queued request waits out every one ahead of it. `request-with-retry.ts`'s 5s
+ * could not bound that, which is why this is a different order of magnitude.
  */
 export const PORT_RESPONSE_TIMEOUT_MS = 60_000;
 
@@ -53,7 +59,19 @@ function attempt<Res>(request: PortRequest): Promise<Res> {
       reject(new PortDisconnectedError());
     });
 
-    port.postMessage(request);
+    try {
+      port.postMessage(request);
+    } catch (error) {
+      // Same shape as the two listeners above: without it this exit leaves the
+      // timeout armed, holding the closure — and the request's passwords — for
+      // its full duration.
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        port.disconnect();
+        reject(error);
+      }
+    }
   });
 }
 


### PR DESCRIPTION
https://make-software.atlassian.net/browse/WALLET-1424

### Why

`runtime.sendMessage` delivers to every open page of this extension, not only the background.
`changePassword` carries two plaintext passwords over it, and the unlock flow (PR 3) is about to carry
more. Those requests move to a point-to-point `runtime.connect` port that only the background sees.

To be precise about the threat: `sendMessage` does **not** reach dapp pages or other extensions. The
exposure is to other pages of this extension — which is exactly the surface the on-demand secret
handlers already guard against.

### Gating

Same shape as the existing secret handlers: `isTrustedUiSender` plus a per-request page allowlist.
Being an extension page proves origin, not need.

### Two subtleties worth a reviewer's attention

**The listener is attached synchronously, before the store is awaited.** On a cold service-worker
start the page's already-sent message reaches only listeners present at that instant. Dropping it
would leave the port _connected_, so the caller's disconnect-retry would never fire and its promise
would never settle.

**Retry policy is asymmetric on purpose.** A disconnect before a response is retried — it proves the
message produced no result. A timeout is _not_ retried — the background may already have acted on it.
A generous liveness backstop covers the case that yields neither.

### Behaviour

No happy-path change. **The error path is new:** `dispatchToMainStore` swallowed a failed
change-password dispatch; failure now surfaces through the existing UI error channel. Please exercise
the failure path, not just the happy one.

`changePasswordSaga` itself is unchanged — only the transport moves — and `changePassword` leaves
`FORWARDED_ACTION_TYPES`.
