### PR TITLE
fix(background): rank tombstone eviction by ordinal, not key order

### DIFF
--- a/src/background/handlers/close-ledger-flow-windows.test.ts
+++ b/src/background/handlers/close-ledger-flow-windows.test.ts
@@ -33,7 +33,8 @@ const openRequest = (windowIds: number[]): Request => ({
   origin: 'https://dapp.example',
   method: 'sign',
   windowIds,
-  awaitingDeviceConfirmation: false
+  awaitingDeviceConfirmation: false,
+  seq: 0
 });
 
 const removedIds = () => removeMock.mock.calls.map(([id]) => id).sort();
@@ -122,7 +123,7 @@ it("closes only the caller's permission window for an internal flow with no requ
 it('closes only the permission window when the response path already collapsed the descriptor', async () => {
   // After close-windows-on-response.ts runs, the descriptor is already
   // { status: 'responded' } (dropping windowIds); this is the normal residue.
-  const { store } = makeStore(20, { r1: { status: 'responded' } });
+  const { store } = makeStore(20, { r1: { status: 'responded', seq: 0 } });
 
   await handleCloseLedgerFlowWindows(store, {
     requestId: 'r1',

--- a/src/background/handlers/close-windows-on-response.test.ts
+++ b/src/background/handlers/close-windows-on-response.test.ts
@@ -147,7 +147,7 @@ describe('markRequestResponded', () => {
     });
     expect(store.getState().windowManagement.requests.r1).toEqual({
       status: 'responded',
-      seq: 0
+      seq: 1
     });
   });
 
@@ -445,7 +445,7 @@ describe('handleSdkResponseToTab (WALLET-1416 wiring)', () => {
     expect(sendMessageMock).toHaveBeenCalled();
     expect(store.getState().windowManagement.requests.r1).toEqual({
       status: 'responded',
-      seq: 0
+      seq: 1
     });
     expect(removeMock).not.toHaveBeenCalled();
   });

--- a/src/background/handlers/close-windows-on-response.test.ts
+++ b/src/background/handlers/close-windows-on-response.test.ts
@@ -146,7 +146,8 @@ describe('markRequestResponded', () => {
       permissionWindowId: 11
     });
     expect(store.getState().windowManagement.requests.r1).toEqual({
-      status: 'responded'
+      status: 'responded',
+      seq: 0
     });
   });
 
@@ -443,7 +444,8 @@ describe('handleSdkResponseToTab (WALLET-1416 wiring)', () => {
 
     expect(sendMessageMock).toHaveBeenCalled();
     expect(store.getState().windowManagement.requests.r1).toEqual({
-      status: 'responded'
+      status: 'responded',
+      seq: 0
     });
     expect(removeMock).not.toHaveBeenCalled();
   });

--- a/src/background/handlers/sdk-response-to-tab.test.ts
+++ b/src/background/handlers/sdk-response-to-tab.test.ts
@@ -75,7 +75,8 @@ const OPEN_REQUEST: Request = {
   origin: DAPP_ORIGIN,
   method: 'sign',
   windowIds: [7],
-  awaitingDeviceConfirmation: false
+  awaitingDeviceConfirmation: false,
+  seq: 0
 };
 
 // Build a fake store whose `requests` map carries the desired request entry
@@ -104,7 +105,7 @@ function makeStatefulStore() {
   const dispatch = jest.fn((action: { payload?: { requestId?: string } }) => {
     const id = action?.payload?.requestId;
     if (id != null) {
-      requests[id] = { status: 'responded' };
+      requests[id] = { status: 'responded', seq: 0 };
     }
   });
   const store = {
@@ -211,7 +212,7 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
   });
 
   it("already 'responded' → drops a duplicate CANCEL with no send and no dispatch", async () => {
-    const { store, dispatch } = makeStore({ status: 'responded' });
+    const { store, dispatch } = makeStore({ status: 'responded', seq: 0 });
 
     const result = await handleSdkResponseToTab(
       makeCancelMessage(),
@@ -255,7 +256,7 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
     });
 
     it('escalates a dropped completed response to error severity', async () => {
-      const { store, dispatch } = makeStore({ status: 'responded' });
+      const { store, dispatch } = makeStore({ status: 'responded', seq: 0 });
 
       await handleSdkResponseToTab(makeMessage(), UI_SENDER, store);
 
@@ -277,7 +278,7 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
     });
 
     it('only warns about a duplicate cancel, and does not bother the user', async () => {
-      const { store, dispatch } = makeStore({ status: 'responded' });
+      const { store, dispatch } = makeStore({ status: 'responded', seq: 0 });
 
       await handleSdkResponseToTab(makeCancelMessage(), UI_SENDER, store);
 
@@ -294,7 +295,7 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
       // plain boolean, so a branch on `payload.cancelled` does not generalise
       // across the union. `false` is what `buildCancelResponse` and the reject
       // buttons send — nothing is lost by dropping it.
-      const { store } = makeStore({ status: 'responded' });
+      const { store } = makeStore({ status: 'responded', seq: 0 });
 
       await handleSdkResponseToTab(
         {
@@ -317,7 +318,7 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
       // the wallet listing the site as connected while the dapp was told the
       // user rejected. Classifying it as a cancel logs the exact opposite of
       // what happened.
-      const { store } = makeStore({ status: 'responded' });
+      const { store } = makeStore({ status: 'responded', seq: 0 });
 
       await handleSdkResponseToTab(
         {

--- a/src/background/open-window.test.ts
+++ b/src/background/open-window.test.ts
@@ -68,7 +68,8 @@ const awaitingDeviceIn = (windowIds: number[]): Record<string, Request> => ({
     origin: 'https://dapp.example',
     method: 'sign',
     windowIds,
-    awaitingDeviceConfirmation: true
+    awaitingDeviceConfirmation: true,
+    seq: 0
   }
 });
 

--- a/src/background/redux/sagas/vault-sagas.test.ts
+++ b/src/background/redux/sagas/vault-sagas.test.ts
@@ -718,7 +718,8 @@ describe('reconcileStalePayloadsSaga', () => {
     origin: 'https://dapp.example',
     method: 'sign',
     windowIds: [1],
-    awaitingDeviceConfirmation: false
+    awaitingDeviceConfirmation: false,
+    seq: 0
   } as const;
 
   const combinedReducer = () =>

--- a/src/background/redux/windowManagement/reducer.test.ts
+++ b/src/background/redux/windowManagement/reducer.test.ts
@@ -84,10 +84,10 @@ describe('windowManagement reducer', () => {
   it('marks a request as responded, and is idempotent on a second respond', () => {
     let state = reducer(empty, opened('r1'));
     state = reducer(state, windowRequestResponded({ requestId: 'r1' }));
-    expect(state.requests.r1).toEqual({ status: 'responded' });
+    expect(state.requests.r1).toEqual({ status: 'responded', seq: 0 });
 
     state = reducer(state, windowRequestResponded({ requestId: 'r1' }));
-    expect(state.requests.r1).toEqual({ status: 'responded' });
+    expect(state.requests.r1).toEqual({ status: 'responded', seq: 0 });
   });
 
   it('leaves a still-open sibling untouched when one request is answered', () => {
@@ -108,12 +108,13 @@ describe('windowManagement reducer', () => {
       origin: 'https://other.example',
       method: 'signMessage',
       windowIds: [],
-      awaitingDeviceConfirmation: false
+      awaitingDeviceConfirmation: false,
+      seq: 1
     });
 
     // Responding twice must not throw or resurrect the dropped descriptor.
     state = reducer(state, windowRequestResponded({ requestId: 'r1' }));
-    expect(state.requests.r1).toEqual({ status: 'responded' });
+    expect(state.requests.r1).toEqual({ status: 'responded', seq: 0 });
   });
 });
 
@@ -127,7 +128,8 @@ describe('windowManagement requests', () => {
       origin: 'https://dapp',
       method: 'sign',
       windowIds: [],
-      awaitingDeviceConfirmation: false
+      awaitingDeviceConfirmation: false,
+      seq: 0
     });
   });
 
@@ -150,7 +152,8 @@ describe('windowManagement requests', () => {
       origin: 'https://dapp.example',
       method: 'sign',
       windowIds: [],
-      awaitingDeviceConfirmation: false
+      awaitingDeviceConfirmation: false,
+      seq: 0
     });
   });
 
@@ -177,7 +180,8 @@ describe('windowManagement requests', () => {
       origin: 'https://dapp.example',
       method: 'sign',
       windowIds: [],
-      awaitingDeviceConfirmation: false
+      awaitingDeviceConfirmation: false,
+      seq: 0
     });
   });
 
@@ -275,7 +279,7 @@ describe('windowManagement requests', () => {
     let state = reducer(empty, opened('r1'));
     state = reducer(state, windowRequestResponded({ requestId: 'r1' }));
 
-    expect(state.requests.r1).toEqual({ status: 'responded' });
+    expect(state.requests.r1).toEqual({ status: 'responded', seq: 0 });
   });
 
   it('a reused requestId does not resurrect a tombstone', () => {
@@ -284,7 +288,7 @@ describe('windowManagement requests', () => {
     const next = reducer(state, opened('r1'));
 
     expect(next).toBe(state);
-    expect(next.requests.r1).toEqual({ status: 'responded' });
+    expect(next.requests.r1).toEqual({ status: 'responded', seq: 0 });
   });
 
   it('a reused requestId does not clobber a still-open descriptor', () => {
@@ -379,7 +383,7 @@ describe('windowManagement requests', () => {
         windowRequestResponded({ requestId: 'r1' })
       );
 
-      expect(next.requests.r1).toEqual({ status: 'responded' });
+      expect(next.requests.r1).toEqual({ status: 'responded', seq: 0 });
       expect(Object.keys(next.requests)).toContain('ghost');
     });
   });
@@ -432,8 +436,60 @@ describe('windowManagement requests', () => {
       // for a request that was answered recently.
       expect(state.requests.r0).toBeUndefined();
       expect(state.requests[`r${MAX_RESPONDED_TOMBSTONES + 9}`]).toEqual({
-        status: 'responded'
+        status: 'responded',
+        seq: MAX_RESPONDED_TOMBSTONES + 9
       });
+    });
+
+    // Eviction ranked on `Object.keys`, whose order is not registration order:
+    // an integer-like dapp-chosen key is enumerated ahead of every string key
+    // however recently it was written, so `"42"` was always evicted first.
+    it('does not evict an integer-like key ahead of older string-keyed tombstones', () => {
+      let state = empty;
+      for (let i = 0; i < MAX_RESPONDED_TOMBSTONES; i++) {
+        state = reducer(state, opened(`r${i}`));
+        state = reducer(state, windowRequestResponded({ requestId: `r${i}` }));
+      }
+
+      state = reducer(state, opened('42'));
+      state = reducer(state, windowRequestResponded({ requestId: '42' }));
+
+      expect(Object.keys(state.requests)).toHaveLength(
+        MAX_RESPONDED_TOMBSTONES
+      );
+      expect(state.requests['42']).toEqual({
+        status: 'responded',
+        seq: MAX_RESPONDED_TOMBSTONES
+      });
+      expect(state.requests.r0).toBeUndefined();
+    });
+
+    it('stamps the first request of an empty map with the first ordinal', () => {
+      expect(reducer(empty, opened('r1')).requests.r1).toMatchObject({
+        seq: 0
+      });
+    });
+
+    // Re-stamping would let a page promote its own tombstone past older ones
+    // by re-sending an id it already used.
+    it('does not re-stamp the ordinal of an id that is re-sent', () => {
+      let state = reducer(empty, opened('r1'));
+      state = reducer(state, opened('r2'));
+      state = reducer(state, opened('r1'));
+
+      expect(state.requests.r1).toMatchObject({ seq: 0 });
+      expect(state.requests.r2).toMatchObject({ seq: 1 });
+    });
+
+    // The sequence names only ids the map actually holds, so a refused write
+    // cannot leak a slot of its own.
+    it('consumes no ordinal for a refused write', () => {
+      let state = reducer(empty, opened('r1'));
+      state = reducer(state, opened('__proto__'));
+      state = reducer(state, opened('r1'));
+      state = reducer(state, opened('r2'));
+
+      expect(state.requests.r2).toMatchObject({ seq: 1 });
     });
 
     it('never evicts an open request to make room', () => {

--- a/src/background/redux/windowManagement/reducer.test.ts
+++ b/src/background/redux/windowManagement/reducer.test.ts
@@ -84,10 +84,10 @@ describe('windowManagement reducer', () => {
   it('marks a request as responded, and is idempotent on a second respond', () => {
     let state = reducer(empty, opened('r1'));
     state = reducer(state, windowRequestResponded({ requestId: 'r1' }));
-    expect(state.requests.r1).toEqual({ status: 'responded', seq: 0 });
+    expect(state.requests.r1).toEqual({ status: 'responded', seq: 1 });
 
     state = reducer(state, windowRequestResponded({ requestId: 'r1' }));
-    expect(state.requests.r1).toEqual({ status: 'responded', seq: 0 });
+    expect(state.requests.r1).toEqual({ status: 'responded', seq: 1 });
   });
 
   it('leaves a still-open sibling untouched when one request is answered', () => {
@@ -114,7 +114,7 @@ describe('windowManagement reducer', () => {
 
     // Responding twice must not throw or resurrect the dropped descriptor.
     state = reducer(state, windowRequestResponded({ requestId: 'r1' }));
-    expect(state.requests.r1).toEqual({ status: 'responded', seq: 0 });
+    expect(state.requests.r1).toEqual({ status: 'responded', seq: 2 });
   });
 });
 
@@ -279,7 +279,7 @@ describe('windowManagement requests', () => {
     let state = reducer(empty, opened('r1'));
     state = reducer(state, windowRequestResponded({ requestId: 'r1' }));
 
-    expect(state.requests.r1).toEqual({ status: 'responded', seq: 0 });
+    expect(state.requests.r1).toEqual({ status: 'responded', seq: 1 });
   });
 
   it('a reused requestId does not resurrect a tombstone', () => {
@@ -288,7 +288,7 @@ describe('windowManagement requests', () => {
     const next = reducer(state, opened('r1'));
 
     expect(next).toBe(state);
-    expect(next.requests.r1).toEqual({ status: 'responded', seq: 0 });
+    expect(next.requests.r1).toEqual({ status: 'responded', seq: 1 });
   });
 
   it('a reused requestId does not clobber a still-open descriptor', () => {
@@ -383,7 +383,7 @@ describe('windowManagement requests', () => {
         windowRequestResponded({ requestId: 'r1' })
       );
 
-      expect(next.requests.r1).toEqual({ status: 'responded', seq: 0 });
+      expect(next.requests.r1).toEqual({ status: 'responded', seq: 1 });
       expect(Object.keys(next.requests)).toContain('ghost');
     });
   });
@@ -435,9 +435,11 @@ describe('windowManagement requests', () => {
       // Oldest evicted, newest kept: a late duplicate is most likely to arrive
       // for a request that was answered recently.
       expect(state.requests.r0).toBeUndefined();
+      // Each iteration consumes two ordinals (open, then the respond restamp),
+      // so the last of MAX_RESPONDED_TOMBSTONES + 10 iterations lands here.
       expect(state.requests[`r${MAX_RESPONDED_TOMBSTONES + 9}`]).toEqual({
         status: 'responded',
-        seq: MAX_RESPONDED_TOMBSTONES + 9
+        seq: 2 * MAX_RESPONDED_TOMBSTONES + 19
       });
     });
 
@@ -459,9 +461,37 @@ describe('windowManagement requests', () => {
       );
       expect(state.requests['42']).toEqual({
         status: 'responded',
-        seq: MAX_RESPONDED_TOMBSTONES
+        seq: 2 * MAX_RESPONDED_TOMBSTONES + 1
       });
       expect(state.requests.r0).toBeUndefined();
+    });
+
+    // Eviction is oldest-ANSWERED-first, not oldest-REGISTERED-first: a
+    // request that registered before every other one but is answered last
+    // must get the highest seq and outlive tombstones for requests that
+    // registered later but were answered sooner. Restamping the tombstone at
+    // respond time (rather than keeping the registration seq) is what makes
+    // this hold — otherwise `first` would answer with its own registration
+    // seq of 0, making it the lowest-seq (oldest) tombstone and evicting
+    // itself in the very dispatch that created it.
+    it('a request registered first but answered last survives eviction over an earlier-answered tombstone', () => {
+      let state = reducer(empty, opened('first'));
+
+      for (let i = 0; i < MAX_RESPONDED_TOMBSTONES; i++) {
+        state = reducer(state, opened(`r${i}`));
+        state = reducer(state, windowRequestResponded({ requestId: `r${i}` }));
+      }
+
+      state = reducer(state, windowRequestResponded({ requestId: 'first' }));
+
+      expect(Object.keys(state.requests)).toHaveLength(
+        MAX_RESPONDED_TOMBSTONES
+      );
+      expect(state.requests.r0).toBeUndefined();
+      expect(state.requests.first).toEqual({
+        status: 'responded',
+        seq: 2 * MAX_RESPONDED_TOMBSTONES + 1
+      });
     });
 
     it('stamps the first request of an empty map with the first ordinal', () => {

--- a/src/background/redux/windowManagement/reducer.ts
+++ b/src/background/redux/windowManagement/reducer.ts
@@ -9,6 +9,17 @@ import { CancellableMethod, WindowManagementState } from './types';
 // background page never restarts.
 export const MAX_RESPONDED_TOMBSTONES = 50;
 
+// Derived from the map rather than kept in a counter field: a counter is state
+// the session record does not carry, so after a service-worker restart it would
+// resume at zero and re-issue ordinals the restored map still holds.
+const nextSeq = (requests: WindowManagementState['requests']): number => {
+  const stamped = Object.values(requests).flatMap(request =>
+    request == null ? [] : [request.seq]
+  );
+
+  return stamped.length === 0 ? 0 : Math.max(...stamped) + 1;
+};
+
 const initialState: WindowManagementState = {
   windowId: null,
   exportKeysWindowId: null,
@@ -68,7 +79,8 @@ const slice = createSlice({
             origin: action.payload.origin,
             method: action.payload.method,
             windowIds: [],
-            awaitingDeviceConfirmation: false
+            awaitingDeviceConfirmation: false,
+            seq: nextSeq(state.requests)
           }
         }
       };
@@ -179,22 +191,26 @@ const slice = createSlice({
       // id the store no longer holds (an MV3 restart between registration and
       // the response) wrote an orphan tombstone that consumed a slot in the cap
       // below and made the SDK entry guard reject that id as a duplicate.
-      if (
-        getRequest(state.requests, action.payload.requestId)?.status !== 'open'
-      ) {
+      const request = getRequest(state.requests, action.payload.requestId);
+
+      if (request?.status !== 'open') {
         return state;
       }
 
       const requests: WindowManagementState['requests'] = {
         ...state.requests,
-        [action.payload.requestId]: { status: 'responded' }
+        [action.payload.requestId]: { status: 'responded', seq: request.seq }
       };
 
-      // Insertion order = the order requests were first registered, since
-      // re-writing an existing key keeps its original position.
-      const respondedIds = Object.keys(requests).filter(
-        requestId => getRequest(requests, requestId)?.status === 'responded'
-      );
+      // Oldest first by stamped ordinal, not by key order: enumeration hoists
+      // an integer-like dapp-chosen key ahead of every string key, so `"42"`
+      // would be evicted first however recently it was registered.
+      const respondedIds = Object.entries(requests)
+        .flatMap(([requestId, entry]) =>
+          entry?.status === 'responded' ? [[requestId, entry.seq] as const] : []
+        )
+        .sort(([, a], [, b]) => a - b)
+        .map(([requestId]) => requestId);
 
       const overflow = respondedIds.length - MAX_RESPONDED_TOMBSTONES;
       if (overflow > 0) {

--- a/src/background/redux/windowManagement/reducer.ts
+++ b/src/background/redux/windowManagement/reducer.ts
@@ -197,14 +197,21 @@ const slice = createSlice({
         return state;
       }
 
+      // The tombstone is restamped with a fresh ordinal rather than keeping
+      // the registration `seq`: eviction below is oldest-ANSWERED-first, so
+      // reusing the registration ordinal could make answering the
+      // oldest-registered request write a tombstone this same dispatch evicts.
       const requests: WindowManagementState['requests'] = {
         ...state.requests,
-        [action.payload.requestId]: { status: 'responded', seq: request.seq }
+        [action.payload.requestId]: {
+          status: 'responded',
+          seq: nextSeq(state.requests)
+        }
       };
 
-      // Oldest first by stamped ordinal, not by key order: enumeration hoists
-      // an integer-like dapp-chosen key ahead of every string key, so `"42"`
-      // would be evicted first however recently it was registered.
+      // Oldest-ANSWERED first by stamped ordinal, not by key order: enumeration
+      // hoists an integer-like dapp-chosen key ahead of every string key, so
+      // `"42"` would be evicted first however recently it was answered.
       const respondedIds = Object.entries(requests)
         .flatMap(([requestId, entry]) =>
           entry?.status === 'responded' ? [[requestId, entry.seq] as const] : []

--- a/src/background/redux/windowManagement/selectors.test.ts
+++ b/src/background/redux/windowManagement/selectors.test.ts
@@ -20,10 +20,11 @@ const requests: Record<string, Request> = {
     origin: 'o',
     method: 'sign',
     windowIds: [7],
-    awaitingDeviceConfirmation: false
+    awaitingDeviceConfirmation: false,
+    seq: 0
   },
-  b: { status: 'responded' },
-  c: { status: 'responded' }
+  b: { status: 'responded', seq: 1 },
+  c: { status: 'responded', seq: 2 }
 };
 
 const state = {
@@ -48,7 +49,8 @@ it('selectOpenRequests joins open status with its descriptor, including windowId
       origin: 'o',
       method: 'sign',
       windowIds: [7],
-      awaitingDeviceConfirmation: false
+      awaitingDeviceConfirmation: false,
+      seq: 0
     }
   ]);
 });
@@ -61,7 +63,8 @@ it('selectOpenRequest returns the open descriptor with its id', () => {
     origin: 'o',
     method: 'sign',
     windowIds: [7],
-    awaitingDeviceConfirmation: false
+    awaitingDeviceConfirmation: false,
+    seq: 0
   });
 });
 
@@ -90,7 +93,8 @@ describe('selectIsWindowBusyWithDevice', () => {
     origin: 'https://dapp.example',
     method: 'sign',
     windowIds,
-    awaitingDeviceConfirmation: true
+    awaitingDeviceConfirmation: true,
+    seq: 0
   });
 
   it('reports the window that displays the awaiting request', () => {

--- a/src/background/redux/windowManagement/types.ts
+++ b/src/background/redux/windowManagement/types.ts
@@ -45,8 +45,16 @@ export type Request =
       // entry, and a detach shrinks `windowIds`, which is the other half of the
       // question. WALLET-1394.
       readonly awaitingDeviceConfirmation: boolean;
+      // Registration order, stamped once. Key order cannot stand in for it: an
+      // integer-like dapp-chosen id such as `"42"` enumerates ahead of every
+      // string key whatever its age.
+      readonly seq: number;
     }
-  | { readonly status: 'responded' };
+  | {
+      readonly status: 'responded';
+      // Outlives the descriptor because eviction ranks tombstones by age.
+      readonly seq: number;
+    };
 
 // Not exported: with `selectOpenRequests` narrowing on the discriminant rather
 // than asserting a predicate, nothing outside this file needs the bare


### PR DESCRIPTION
## Description

`windowRequestResponded` evicted the oldest tombstones by filtering `Object.keys(requests)`, on the stated assumption that *"Insertion order = the order requests were first registered"*.

That is false for the keys this map actually holds. `requestId` is page-generated (`generateRequestId`, `src/content/sdk.ts`), so an integer-like id such as `"42"` is one the wallet accepts — and integer-like keys enumerate ahead of every string key in ascending numeric order, however recently they were written. A dapp numbering its requests could therefore have its **newest** tombstone evicted first while genuinely older ones survived, and `MAX_RESPONDED_TOMBSTONES` stopped bounding what it was meant to bound. Losing a tombstone early means the response dedup no longer drops a late duplicate for that id.

### What changed

- Both arms of `Request` carry a `seq`. The open row is stamped at registration; the tombstone is **restamped at response time** (`nextSeq` over the pre-update map), because the cap's stated policy is eviction by when a request was *answered* — inheriting the registration ordinal would let answering the oldest-registered request evict its own just-written tombstone (review finding, pinned by a dedicated test).
- Eviction ranks on `seq` ascending instead of on key order.
- The ordinal is **derived from the map** (`max + 1`) rather than held in a counter field. A counter would be state that survives nothing: after an MV3 service-worker restart it would resume at zero and re-issue ordinals the map still holds.

### Why not reuse the vault's helpers verbatim

`vault/reducer.ts` solved the same problem for its payload map (WALLET-1418), but its `orderOldestFirst` additionally handles rows written *before* the field existed, ranking unstamped hoisted keys newest. Nothing here can be unstamped — every row is stamped by this reducer at birth — so those branches are not ported. On a file held to 100% coverage they would be unreachable code demanding tests.

The helpers were also deliberately **not** moved into `request-map.ts`: `collectCoverageFrom` matches `src/background/redux/**/reducer.ts` but not `request-map.ts`, so relocating them would silently drop covered code out of the enforced universe for both slices.

### Verification

- `npx jest src/background/redux/windowManagement/ src/background/handlers/ src/background/open-window.test.ts src/background/redux/sagas/vault-sagas.test.ts` — 22 suites, 394 tests pass.
- `npx tsc --noEmit` — clean.
- `windowManagement/reducer.ts` coverage: 100% statements / branches / functions / lines.
- The regression test was proven to fail against the old ranking: with `Object.keys` restored, `"42"` is evicted while the genuinely older `r0` survives.

### Context

This is a prerequisite for the rest of WALLET-1419. The planned fix mirrors `windowManagement`'s request state into `chrome.storage.session` so it survives a service-worker restart; that mirror round-trips through a JSON-shaped structure, which re-applies the same key hoisting, and its write-side row cap needs an age order to drop by. The ordinal has to exist first.

The eviction bug is live on `develop` independently of that work, so this stands on its own.

## Linked tickets

[WALLET-1419](https://make-software.atlassian.net/browse/WALLET-1419)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [x] If the PR adds any new text to the UI, make sure they are localized — no UI text added

- [x] Include a screenshot or recording if implementing significant UI or user flow change — background-only, no UI change

- [ ] When this PR affects architecture changes wait for review from Dmytro before merging


[WALLET-1419]: https://make-software.atlassian.net/browse/WALLET-1419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
