### PR TITLE
fix(background): keep request descriptors across a worker restart

### DIFF
--- a/.github/workflows/e2e-request-lifecycle-tests.yml
+++ b/.github/workflows/e2e-request-lifecycle-tests.yml
@@ -1,0 +1,55 @@
+name: E2E request lifecycle tests
+
+# Its own job rather than a directory added to the onboarding one: both suites
+# build into ./build/chrome, so running them in the same job would have the
+# second build race the first suite's browser.
+on:
+  push:
+    branches: [ master, develop, release/** ]
+  pull_request:
+    branches: [ master, develop, release/** ]
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-request-lifecycle-tests:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.56.1-jammy
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Run approved dependency install scripts (.npmrc sets ignore-scripts=true)
+      # and fail the build if a dependency ships an install script not in the
+      # `lavamoat.allowScripts` allowlist — same supply-chain gate as ci-check.
+      - name: Allow approved install scripts
+        run: npm run allow-scripts
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Chrome tests
+        run: npm run e2e:chrome:headless:request-lifecycle
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: test-results
+          path: test-results/
+          retention-days: 30

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -60,20 +60,40 @@ rules:
       - pattern: storage.session.get(...)
       - pattern: storage.session.set(...)
       - pattern: storage.session.remove(...)
-      - pattern: storage.session.setAccessLevel(...)
       - pattern: browser.storage.session.get(...)
       - pattern: browser.storage.session.set(...)
       - pattern: browser.storage.session.remove(...)
-      - pattern: browser.storage.session.setAccessLevel(...)
       - pattern: chrome.storage.session.get(...)
       - pattern: chrome.storage.session.set(...)
       - pattern: chrome.storage.session.remove(...)
-      - pattern: chrome.storage.session.setAccessLevel(...)
     paths:
       exclude:
         - 'src/background/**'
         - '**/*.test.ts'
         - '**/*.test.tsx'
+
+  # ============================================================================
+  # `setAccessLevel` widens who can read `storage.session` — TRUSTED_AND_UNTRUSTED
+  # would hand every dapp content script the pending-request origins the mirror
+  # holds. A SEPARATE rule, not folded into cw-storage-local-outside-background:
+  # that rule's `paths.exclude` drops src/background/** (the only place session
+  # code legitimately lives), so a background-side `setAccessLevel` call — the
+  # one that matters — would never be flagged there. This one has no `paths`
+  # block: forbidden everywhere, always.
+  # ============================================================================
+  - id: cw-storage-session-access-level
+    message: >
+      storage.session.setAccessLevel() must never be called. The area's
+      default access level (TRUSTED_CONTEXTS) is what keeps the pending
+      request-lifecycle mirror — dapp origins, tab ids, live request ids —
+      out of reach of every content script; TRUSTED_AND_UNTRUSTED would hand
+      it to any dapp.
+    severity: ERROR
+    languages: [typescript, javascript]
+    pattern-either:
+      - pattern: storage.session.setAccessLevel(...)
+      - pattern: browser.storage.session.setAccessLevel(...)
+      - pattern: chrome.storage.session.setAccessLevel(...)
 
   # ============================================================================
   # Async side effects use Redux-Saga (src/background/redux/sagas/), not

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -33,15 +33,17 @@ rules:
 
   # ============================================================================
   # Same invariant, storage layer: state persistence via browser.storage.local
-  # is owned by the background script (get-main-store.ts). Frontend apps must
+  # and browser.storage.session is owned by the background script
+  # (get-main-store.ts, windowManagement/session-store.ts). Frontend apps must
   # not read or write extension storage directly.
   # ============================================================================
   - id: cw-storage-local-outside-background
     message: >
       Direct browser storage access outside src/background/. State persistence
-      (encrypted vault, keys, settings) is owned by the background script;
-      frontend apps must consume state replicas instead. If this usage is
-      intentional and does not touch persisted state, add a
+      (encrypted vault, keys, settings, the request-lifecycle session mirror)
+      is owned by the background script; frontend apps must consume state
+      replicas instead. If this usage is intentional and does not touch
+      persisted state, add a
       // nosemgrep: cw-storage-local-outside-background comment with justification.
     severity: WARNING
     languages: [typescript, javascript]
@@ -55,6 +57,18 @@ rules:
       - pattern: chrome.storage.local.get(...)
       - pattern: chrome.storage.local.set(...)
       - pattern: chrome.storage.local.remove(...)
+      - pattern: storage.session.get(...)
+      - pattern: storage.session.set(...)
+      - pattern: storage.session.remove(...)
+      - pattern: storage.session.setAccessLevel(...)
+      - pattern: browser.storage.session.get(...)
+      - pattern: browser.storage.session.set(...)
+      - pattern: browser.storage.session.remove(...)
+      - pattern: browser.storage.session.setAccessLevel(...)
+      - pattern: chrome.storage.session.get(...)
+      - pattern: chrome.storage.session.set(...)
+      - pattern: chrome.storage.session.remove(...)
+      - pattern: chrome.storage.session.setAccessLevel(...)
     paths:
       exclude:
         - 'src/background/**'

--- a/.semgrep/rule-tests/cw-storage-local-outside-background.ts
+++ b/.semgrep/rule-tests/cw-storage-local-outside-background.ts
@@ -35,27 +35,17 @@ export async function sessionArea() {
   // ruleid: cw-storage-local-outside-background
   await storage.session.remove('a');
   // ruleid: cw-storage-local-outside-background
-  await storage.session.setAccessLevel({ accessLevel: 'TRUSTED_CONTEXTS' });
-  // ruleid: cw-storage-local-outside-background
   await browser.storage.session.get('a');
   // ruleid: cw-storage-local-outside-background
   await browser.storage.session.set({ a: 1 });
   // ruleid: cw-storage-local-outside-background
   await browser.storage.session.remove('a');
   // ruleid: cw-storage-local-outside-background
-  await browser.storage.session.setAccessLevel({
-    accessLevel: 'TRUSTED_CONTEXTS'
-  });
-  // ruleid: cw-storage-local-outside-background
   await chrome.storage.session.get('a');
   // ruleid: cw-storage-local-outside-background
   await chrome.storage.session.set({ a: 1 });
   // ruleid: cw-storage-local-outside-background
   await chrome.storage.session.remove('a');
-  // ruleid: cw-storage-local-outside-background
-  await chrome.storage.session.setAccessLevel({
-    accessLevel: 'TRUSTED_CONTEXTS'
-  });
 }
 
 export async function safeAlternatives() {

--- a/.semgrep/rule-tests/cw-storage-local-outside-background.ts
+++ b/.semgrep/rule-tests/cw-storage-local-outside-background.ts
@@ -27,9 +27,38 @@ export async function insideCallback() {
   }, 0);
 }
 
-export async function safeAlternatives() {
-  // ok: cw-storage-local-outside-background
+export async function sessionArea() {
+  // ruleid: cw-storage-local-outside-background
+  await storage.session.get('a');
+  // ruleid: cw-storage-local-outside-background
+  await storage.session.set({ a: 1 });
+  // ruleid: cw-storage-local-outside-background
+  await storage.session.remove('a');
+  // ruleid: cw-storage-local-outside-background
+  await storage.session.setAccessLevel({ accessLevel: 'TRUSTED_CONTEXTS' });
+  // ruleid: cw-storage-local-outside-background
   await browser.storage.session.get('a');
+  // ruleid: cw-storage-local-outside-background
+  await browser.storage.session.set({ a: 1 });
+  // ruleid: cw-storage-local-outside-background
+  await browser.storage.session.remove('a');
+  // ruleid: cw-storage-local-outside-background
+  await browser.storage.session.setAccessLevel({
+    accessLevel: 'TRUSTED_CONTEXTS'
+  });
+  // ruleid: cw-storage-local-outside-background
+  await chrome.storage.session.get('a');
+  // ruleid: cw-storage-local-outside-background
+  await chrome.storage.session.set({ a: 1 });
+  // ruleid: cw-storage-local-outside-background
+  await chrome.storage.session.remove('a');
+  // ruleid: cw-storage-local-outside-background
+  await chrome.storage.session.setAccessLevel({
+    accessLevel: 'TRUSTED_CONTEXTS'
+  });
+}
+
+export async function safeAlternatives() {
   // ok: cw-storage-local-outside-background
   await storage.sync.get('a');
   // ok: cw-storage-local-outside-background

--- a/.semgrep/rule-tests/cw-storage-session-access-level.ts
+++ b/.semgrep/rule-tests/cw-storage-session-access-level.ts
@@ -1,0 +1,39 @@
+// @ts-nocheck — semgrep pattern fixture, not type-checked code.
+// Test fixture for cw-storage-session-access-level.
+// No `paths` block on this rule — forbidden everywhere, background included.
+
+export async function bare() {
+  // ruleid: cw-storage-session-access-level
+  await storage.session.setAccessLevel({ accessLevel: 'TRUSTED_CONTEXTS' });
+}
+
+export async function namespaced() {
+  // ruleid: cw-storage-session-access-level
+  await browser.storage.session.setAccessLevel({
+    accessLevel: 'TRUSTED_CONTEXTS'
+  });
+  // ruleid: cw-storage-session-access-level
+  await chrome.storage.session.setAccessLevel({
+    accessLevel: 'TRUSTED_CONTEXTS'
+  });
+}
+
+export async function widenedAccessLevelIsAlsoCaught() {
+  // The dangerous call is the target regardless of which value is passed —
+  // the rule flags the call, not the argument.
+  // ruleid: cw-storage-session-access-level
+  await storage.session.setAccessLevel({
+    accessLevel: 'TRUSTED_AND_UNTRUSTED_CONTEXTS'
+  });
+}
+
+export async function safeAlternatives() {
+  // Deliberately NOT `storage.session.get`/`set` here — those are also
+  // matched by cw-storage-local-outside-background's patterns, and an
+  // un-annotated cross-rule match on the same line confuses semgrep's
+  // --test rule resolution for the whole file (observed empirically).
+  // ok: cw-storage-session-access-level
+  await storage.sync.get('a');
+  // ok: cw-storage-session-access-level
+  await storage.local.setAccessLevel({ accessLevel: 'TRUSTED_CONTEXTS' });
+}

--- a/docs/architecture/storage-keys.md
+++ b/docs/architecture/storage-keys.md
@@ -54,6 +54,39 @@ exist.
 | `LOGIN_RETRY_LOCKOUT_DEADLINE_KEY` | `q9Tf3Lm4pRxVne` | Absolute timestamp (`Date.now() + remaining`, ms) when the login-retry lockout ends | No      | Yes                |
 | `AUTO_LOCK_DEADLINE_KEY`           | `r3Wj7Nc8vBhQyD` | Absolute timestamp (`Date.now() + remaining`, ms) when auto-lock inactivity fires   | No      | Yes                |
 
+## The session area — not part of the inventory above
+
+Everything above is `storage.local`. One key lives in **`storage.session`**
+instead, and it deliberately obeys none of the rules in this document:
+
+| Constant              | Obfuscated key  | Stores                                                                                                                                      | Secret?                                                                | Plaintext at rest?                   |
+| --------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------ |
+| `REQUEST_SESSION_KEY` | `q7Rk2vHs4nTbX` | `{ requests, windowId }` from the `windowManagement` slice — every in-flight/recently answered request's dapp origin, tab id and window ids | **Sensitive** — dapp origins and live request ids, never dapp-readable | Never at rest: the area is in-memory |
+
+Defined in
+[`src/background/redux/windowManagement/session-store.ts`](../../src/background/redux/windowManagement/session-store.ts)
+and hydrated by the `get-main-store.ts` preload (WALLET-1419). It exists
+because `windowManagement.requests` lives only in the MV3 service worker's
+memory: a worker restart destroyed every request descriptor while the approval
+windows they describe were still on screen and still signable, which broke
+cancel-on-close, response dedup and supersede. It is written only on
+ephemeral-background builds (`isEphemeralBackgroundBuild`, i.e. Chrome/Edge);
+Firefox and Safari have persistent background pages and lose nothing.
+
+Three properties that follow from the area, not from the rules above:
+
+- **No purge is needed.** `storage.session` is in-memory and is cleared when
+  the browser closes and when the extension is reloaded or updated. No
+  `runtime.onStartup` purge, no session marker, no TTL — and nothing reaches
+  disk, so the plaintext-at-rest question does not arise.
+- **The key name is _not_ immutable.** Because no data crosses a version
+  boundary, renaming it would strand nothing. It follows the obfuscated
+  convention for consistency only.
+- **The area must stay at Chrome's default `TRUSTED_CONTEXTS`.** Nothing calls
+  `storage.session.setAccessLevel` and nothing should: raising it to
+  `TRUSTED_AND_UNTRUSTED_CONTEXTS` would expose every pending request's origin
+  and tab id to content scripts, i.e. to the dapps themselves.
+
 ## Immutability
 
 Once a key string ships, it is permanent. Two failure modes if that rule is

--- a/e2e-tests/request-lifecycle/close-as-wake.spec.ts
+++ b/e2e-tests/request-lifecycle/close-as-wake.spec.ts
@@ -1,0 +1,131 @@
+import { PLAYGROUND_URL, twentyFourWordsSecretPhrase } from '../constants';
+import { onboarding, onboardingExpect } from '../fixtures';
+import {
+  markServiceWorker,
+  readServiceWorkerMark,
+  stopServiceWorker
+} from '../service-worker';
+
+const SETTLEMENT_KEY = '__casperConnectSettlement';
+
+type Settlement = { accepted: boolean } | { error: string };
+
+// The one ordering that matters, and the only one an in-memory `requests` map
+// cannot survive: the worker is already dead and the event that WAKES it is the
+// approval window closing. A saga cannot rebuild the descriptor from the open
+// windows here — the window is gone from `windows.getAll` by the time anything
+// runs — so the mirror in `storage.session`, hydrated in the store preload, is
+// the only thing that can still tell the dapp its request was cancelled.
+//
+// Two things make this test real, and both are easy to void:
+//   - It must NOT run against a MOCK_STATE build. `get-main-store.ts`
+//     short-circuits the session READ under that flag, so the mirror never
+//     hydrates and the result says nothing about the fix. Hence the wallet is
+//     set up through onboarding, and this directory has its own npm script.
+//   - Nothing may touch the approval page. `useUserActivityTracker` is still
+//     mounted with its pre-kill listeners, and one mouse move over that page
+//     wakes the worker before the close — which is why the window is closed
+//     programmatically rather than through its title-bar X.
+onboarding.describe('Request lifecycle: service worker restart', () => {
+  onboarding(
+    'should cancel a connect request when its window closes while the worker is dead',
+    async ({ page, context, extensionId, createOnboardingPassword }) => {
+      onboarding.setTimeout(180000);
+
+      await createOnboardingPassword();
+
+      await page
+        .getByRole('button', {
+          name: 'Import an existing secret recovery phrase'
+        })
+        .click();
+
+      await page
+        .getByPlaceholder('e.g. Bobcat Lemon Blanket…')
+        .fill(twentyFourWordsSecretPhrase);
+
+      await page.getByRole('button', { name: 'Next' }).click();
+
+      await onboardingExpect(
+        page.getByText('Select accounts to recover')
+      ).toBeVisible();
+
+      await page.getByTestId('select-account-0').click();
+      await page
+        .getByRole('button', { name: 'Recover selected accounts' })
+        .click();
+
+      // `closeActiveTab` is inert under Playwright, so the recover screen has no
+      // success state to wait on. An unlocked popup is the signal instead.
+      await page.goto(`chrome-extension://${extensionId}/popup.html`);
+      await onboardingExpect(page.getByTestId('menu-open-icon')).toBeVisible();
+
+      await page.goto(PLAYGROUND_URL);
+      await page.waitForLoadState('networkidle');
+      await page.waitForFunction(
+        () => typeof (window as any).CasperWalletProvider !== 'undefined',
+        null,
+        { timeout: 10000 }
+      );
+
+      // Driven from the page rather than from a playground button so the test
+      // holds the promise itself: the assertion is about it SETTLING, and a
+      // button click leaves it somewhere unreachable.
+      const [approvalPage] = await Promise.all([
+        context.waitForEvent('page', { timeout: 15000 }),
+        page.evaluate(key => {
+          const scope = window as any;
+
+          scope[key] = undefined;
+          scope
+            .CasperWalletProvider()
+            .requestConnection()
+            .then(
+              (accepted: boolean) => {
+                scope[key] = { accepted };
+              },
+              (error: unknown) => {
+                scope[key] = { error: String(error) };
+              }
+            );
+        }, SETTLEMENT_KEY)
+      ]);
+
+      // Rendering this screen took a background round trip, so the descriptor is
+      // registered and the mirror written well before the kill.
+      await onboardingExpect(
+        approvalPage.getByRole('button', { name: 'Next' })
+      ).toBeVisible();
+
+      onboardingExpect(
+        await page.evaluate(key => (window as any)[key], SETTLEMENT_KEY)
+      ).toBeUndefined();
+
+      const generation = await markServiceWorker(context);
+
+      await stopServiceWorker(context, page);
+      await approvalPage.close();
+
+      // Short on purpose. Without the mirror this never settles at all — the
+      // dapp waits out the SDK's own 30 minute timeout.
+      await page.waitForFunction(
+        key => (window as any)[key] !== undefined,
+        SETTLEMENT_KEY,
+        { timeout: 15000 }
+      );
+
+      const settlement = (await page.evaluate(
+        key => (window as any)[key],
+        SETTLEMENT_KEY
+      )) as Settlement;
+
+      onboardingExpect(settlement).toEqual({ accepted: false });
+
+      // The cancel came from a worker that had lost its memory: nothing between
+      // the stop and the close could have kept `requests` alive in it.
+      onboardingExpect(await readServiceWorkerMark(context)).not.toBe(
+        generation
+      );
+    }
+  );
+});

--- a/e2e-tests/service-worker.ts
+++ b/e2e-tests/service-worker.ts
@@ -1,0 +1,97 @@
+import { BrowserContext, Page } from '@playwright/test';
+
+const GENERATION_KEY = '__casperWorkerGeneration';
+
+const STOP_TIMEOUT_MS = 15000;
+
+function currentWorker(context: BrowserContext) {
+  const worker = context.serviceWorkers()[0];
+
+  if (!worker) {
+    throw new Error('No extension service worker is registered.');
+  }
+
+  return worker;
+}
+
+/**
+ * Stamps a token on the running worker's global scope. It dies with the worker,
+ * so a later read that no longer returns it is proof the worker really restarted
+ * — which `context.serviceWorkers()` cannot give: the list keeps its entry
+ * across a stop, and `Worker.evaluate` keeps answering because the evaluate
+ * itself starts a fresh worker.
+ */
+export async function markServiceWorker(
+  context: BrowserContext
+): Promise<string> {
+  const token = `gen-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+  await currentWorker(context).evaluate(
+    ([key, value]) => {
+      (self as unknown as Record<string, string>)[key] = value;
+    },
+    [GENERATION_KEY, token]
+  );
+
+  return token;
+}
+
+/** The token from `markServiceWorker`, or undefined once the worker restarted. */
+export async function readServiceWorkerMark(
+  context: BrowserContext
+): Promise<string | undefined> {
+  try {
+    return await currentWorker(context).evaluate(
+      key => (self as unknown as Record<string, string | undefined>)[key],
+      GENERATION_KEY
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Terminates the extension's MV3 service worker. There is no Playwright API for
+ * it — `Worker` has no `close()` — so it goes over CDP; `stopAllWorkers` is
+ * global despite being sent on a page session, so the page it is sent from does
+ * not matter.
+ *
+ * Resolution waits for the worker's own `stopped` transition rather than
+ * polling it. Polling would be self-defeating: every probe that touches the
+ * worker starts it again, and a caller that needs it to STAY dead would be the
+ * one waking it.
+ */
+export async function stopServiceWorker(
+  context: BrowserContext,
+  page: Page
+): Promise<void> {
+  const scriptUrl = currentWorker(context).url();
+  const client = await context.newCDPSession(page);
+
+  const stopped = new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error('Service worker did not report a stop.'));
+    }, STOP_TIMEOUT_MS);
+
+    client.on('ServiceWorker.workerVersionUpdated', ({ versions }) => {
+      const isStopped = versions.some(
+        version =>
+          version.scriptURL === scriptUrl && version.runningStatus === 'stopped'
+      );
+
+      if (isStopped) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+  });
+
+  await client.send('ServiceWorker.enable');
+  await client.send('ServiceWorker.stopAllWorkers');
+
+  try {
+    await stopped;
+  } finally {
+    await client.detach();
+  }
+}

--- a/e2e-tests/service-worker.ts
+++ b/e2e-tests/service-worker.ts
@@ -5,7 +5,12 @@ const GENERATION_KEY = '__casperWorkerGeneration';
 const STOP_TIMEOUT_MS = 15000;
 
 function currentWorker(context: BrowserContext) {
-  const worker = context.serviceWorkers()[0];
+  // Index 0 is not necessarily the extension: other registered workers (a
+  // Playwright-loaded page's own service worker, another extension) can share
+  // the context, and their position in the list is not guaranteed.
+  const worker = context
+    .serviceWorkers()
+    .find(w => w.url().startsWith('chrome-extension://'));
 
   if (!worker) {
     throw new Error('No extension service worker is registered.');

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "dependency:orphans": "npx madge --ts-config=tsconfig.json --orphans src/**/*",
     "e2e:chrome:headless:onboarding": "TEST_ENV=true npm run build:chrome && PLAYWRIGHT_BROWSER=chromium npx playwright test e2e-tests/onboarding-flow --project chromium",
     "e2e:chrome:ui:onboarding": "TEST_ENV=true npm run build:chrome && PLAYWRIGHT_BROWSER=chromium npx playwright test e2e-tests/onboarding-flow --ui --project chromium",
+    "e2e:chrome:headless:request-lifecycle": "TEST_ENV=true npm run build:chrome && PLAYWRIGHT_BROWSER=chromium npx playwright test e2e-tests/request-lifecycle --project chromium",
+    "e2e:chrome:ui:request-lifecycle": "TEST_ENV=true npm run build:chrome && PLAYWRIGHT_BROWSER=chromium npx playwright test e2e-tests/request-lifecycle --ui --project chromium",
     "e2e:chrome:headless:popup": "TEST_ENV=true MOCK_STATE=true npm run build:chrome && PLAYWRIGHT_BROWSER=chromium npx playwright test e2e-tests/popup --project chromium",
     "e2e:chrome:ui:popup": "TEST_ENV=true MOCK_STATE=true npm run build:chrome && PLAYWRIGHT_BROWSER=chromium npx playwright test e2e-tests/popup --ui --project chromium",
     "e2e:firefox:headless:smoke": "TEST_ENV=true npm run build:firefox && npx playwright test --config playwright.firefox.config.ts",

--- a/src/background/handlers/sdk-methods.test.ts
+++ b/src/background/handlers/sdk-methods.test.ts
@@ -266,6 +266,27 @@ describe('a requestId that is not storable', () => {
 
     expect(openWindowMock).toHaveBeenCalledTimes(1);
   });
+
+  it('refuses an oversized requestId before anything registers', async () => {
+    // Unbounded, a multi-MB dapp-supplied id could register here and later
+    // overflow the `storage.session` mirror's write quota (session-store.ts).
+    const { store, dispatch } = makeStore();
+    const oversizedRequestId = 'x'.repeat(257);
+
+    await expect(
+      handleSdkMethod(
+        sdkMethod.connectRequest(
+          { title: 't' },
+          { requestId: oversizedRequestId }
+        ),
+        SENDER,
+        store
+      )
+    ).rejects.toThrow('Invalid requestId');
+
+    expect(openWindowMock).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
 });
 
 describe('connectRequest', () => {

--- a/src/background/redux/get-main-store.test.ts
+++ b/src/background/redux/get-main-store.test.ts
@@ -1,18 +1,23 @@
 import type { KeysState } from '@background/redux/keys/types';
 import {
+  exportKeysWindowIdCleared,
   windowIdChanged,
   windowRequestOpened
 } from '@background/redux/windowManagement/actions';
+import { REQUEST_SESSION_KEY } from '@background/redux/windowManagement/session-store';
 
 // --- storage / runtime mock -------------------------------------------------
 // storage.local.get returns the per-test snapshot; set/remove/sendMessage are
 // no-op spies that absorb the subscribe-persist write and the saga deadline
 // clears armed by startBackground (no real timers are scheduled for a
 // keys-only snapshot). This is the same mock style as the handler/saga tests.
+// `storage.session` is here to exercise hydration, not to avoid a throw.
 const storageGet = jest.fn<Promise<Record<string, unknown>>, [unknown]>();
 const storageSet = jest.fn().mockResolvedValue(undefined);
 const storageRemove = jest.fn().mockResolvedValue(undefined);
 const runtimeSendMessage = jest.fn().mockResolvedValue(undefined);
+const sessionGet = jest.fn<Promise<Record<string, unknown>>, [unknown]>();
+const sessionSet = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('webextension-polyfill', () => ({
   storage: {
@@ -20,12 +25,24 @@ jest.mock('webextension-polyfill', () => ({
       get: (...args: unknown[]) => storageGet(...(args as [unknown])),
       set: (...args: unknown[]) => storageSet(...args),
       remove: (...args: unknown[]) => storageRemove(...args)
+    },
+    session: {
+      get: (...args: unknown[]) => sessionGet(...(args as [unknown])),
+      set: (...args: unknown[]) => sessionSet(...args),
+      remove: jest.fn().mockResolvedValue(undefined)
     }
   },
   runtime: {
     sendMessage: (...args: unknown[]) => runtimeSendMessage(...args)
   },
   tabs: { query: jest.fn().mockResolvedValue([]) }
+}));
+
+// The mirror is gated on a build-time flag that is FALSE under jest, so without
+// this the hydration cases would exercise the disabled path.
+jest.mock('@src/utils', () => ({
+  ...jest.requireActual('@src/utils'),
+  isEphemeralBackgroundBuild: true
 }));
 
 // Drive the REAL preload of getExistingMainStoreSingletonOrInit with a fresh
@@ -51,6 +68,8 @@ async function initWithKeysSnapshot(keys: KeysState | undefined) {
 describe('getExistingMainStoreSingletonOrInit — keysDoesExist preload derivation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    sessionGet.mockResolvedValue({});
+    sessionSet.mockResolvedValue(undefined);
     storageSet.mockResolvedValue(undefined);
     storageRemove.mockResolvedValue(undefined);
     runtimeSendMessage.mockResolvedValue(undefined);
@@ -124,6 +143,8 @@ function lastPopupStateBroadcast(): Record<string, unknown> | undefined {
 describe('selectPopupState broadcast — replica privacy narrowing', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    sessionGet.mockResolvedValue({});
+    sessionSet.mockResolvedValue(undefined);
     storageSet.mockResolvedValue(undefined);
     storageRemove.mockResolvedValue(undefined);
     runtimeSendMessage.mockResolvedValue(undefined);
@@ -172,11 +193,143 @@ describe('selectPopupState broadcast — replica privacy narrowing', () => {
   });
 });
 
+describe('preload hydration — the session mirror', () => {
+  const mirroredRequest = {
+    status: 'open',
+    tabId: 7,
+    origin: 'https://dapp.example',
+    method: 'sign',
+    windowIds: [11],
+    awaitingDeviceConfirmation: false,
+    seq: 0
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionGet.mockResolvedValue({});
+    sessionSet.mockResolvedValue(undefined);
+    storageSet.mockResolvedValue(undefined);
+    storageRemove.mockResolvedValue(undefined);
+    runtimeSendMessage.mockResolvedValue(undefined);
+  });
+
+  it('puts a mirrored request map and windowId into the store before any handler can run', async () => {
+    sessionGet.mockResolvedValue({
+      [REQUEST_SESSION_KEY]: {
+        requests: { 'req-1': mirroredRequest },
+        windowId: 3
+      }
+    });
+
+    const store = await initWithKeysSnapshot(undefined);
+
+    expect(store.getState().windowManagement).toEqual({
+      windowId: 3,
+      exportKeysWindowId: null,
+      requests: { 'req-1': mirroredRequest }
+    });
+  });
+
+  it('drops a malformed record without throwing, leaving the empty slice', async () => {
+    sessionGet.mockResolvedValue({
+      [REQUEST_SESSION_KEY]: {
+        requests: { 'req-1': { status: 'open', tabId: '7' } },
+        windowId: 'not a window'
+      }
+    });
+
+    const store = await initWithKeysSnapshot(undefined);
+
+    expect(store.getState().windowManagement).toEqual({
+      windowId: null,
+      exportKeysWindowId: null,
+      requests: {}
+    });
+  });
+
+  it('survives a rejected session read', async () => {
+    sessionGet.mockRejectedValue('context invalidated');
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const store = await initWithKeysSnapshot(undefined);
+
+    expect(store.getState().windowManagement.requests).toEqual({});
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('keeps a hydrated request out of the replica broadcast', async () => {
+    sessionGet.mockResolvedValue({
+      [REQUEST_SESSION_KEY]: {
+        requests: { 'req-1': mirroredRequest },
+        windowId: 3
+      }
+    });
+
+    const store = await initWithKeysSnapshot(undefined);
+    store.dispatch(windowIdChanged(11));
+
+    expect(JSON.stringify(lastPopupStateBroadcast())).not.toContain(
+      'dapp.example'
+    );
+  });
+
+  it('mirrors a request the store registers after hydration', async () => {
+    const store = await initWithKeysSnapshot(undefined);
+
+    store.dispatch(
+      windowRequestOpened({
+        requestId: 'req-1',
+        tabId: 7,
+        origin: 'https://dapp.example',
+        method: 'sign'
+      })
+    );
+    await new Promise(resolve => setImmediate(resolve as () => void));
+
+    expect(sessionSet).toHaveBeenCalledWith({
+      [REQUEST_SESSION_KEY]: {
+        // No window has attached yet at registration time.
+        requests: { 'req-1': { ...mirroredRequest, windowIds: [] } },
+        windowId: null
+      }
+    });
+  });
+
+  it('does not write the mirror for a change that leaves the pair identical', async () => {
+    const store = await initWithKeysSnapshot(undefined);
+    sessionSet.mockClear();
+
+    // No no-op path: the reducer returns a fresh slice for a value-equal write.
+    store.dispatch(exportKeysWindowIdCleared());
+    await new Promise(resolve => setImmediate(resolve as () => void));
+
+    expect(sessionSet).not.toHaveBeenCalled();
+  });
+
+  it('yields ONE store for two interleaved first callers', async () => {
+    await jest.isolateModulesAsync(async () => {
+      const mod = await import('@background/redux/get-main-store');
+      storageGet.mockResolvedValue({});
+
+      const [first, second] = await Promise.all([
+        mod.getExistingMainStoreSingletonOrInit(),
+        mod.getExistingMainStoreSingletonOrInit()
+      ]);
+
+      expect(first).toBe(second);
+    });
+  });
+});
+
 describe('replica broadcast — rejection handling', () => {
   let consoleErrorSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    sessionGet.mockResolvedValue({});
+    sessionSet.mockResolvedValue(undefined);
     storageSet.mockResolvedValue(undefined);
     storageRemove.mockResolvedValue(undefined);
     runtimeSendMessage.mockResolvedValue(undefined);

--- a/src/background/redux/get-main-store.ts
+++ b/src/background/redux/get-main-store.ts
@@ -1,5 +1,6 @@
 import { storage } from 'webextension-polyfill';
 
+import { redactUrlQuery } from '@background/redact-url-query';
 import { AppEventsState } from '@background/redux/app-events/types';
 import { broadcastPopupState } from '@background/redux/broadcast-popup-state';
 import { ContactsState } from '@background/redux/contacts/types';
@@ -14,6 +15,11 @@ import { RecentRecipientPublicKeysState } from '@background/redux/recent-recipie
 import { startBackground } from '@background/redux/sagas/actions';
 import { SettingsState } from '@background/redux/settings/types';
 import { TrustedWasmState } from '@background/redux/trusted-wasm/types';
+import {
+  SessionRecord,
+  readRequestSession,
+  writeRequestSession
+} from '@background/redux/windowManagement/session-store';
 
 // `storage.local` key names below are immutable and append-only: renaming or
 // repurposing one strands/drops the persisted data under the old name on
@@ -56,33 +62,44 @@ const isMockStateEnable = Boolean(process.env.MOCK_STATE);
 export async function getExistingMainStoreSingletonOrInit() {
   try {
     // load selected state
-    const {
-      [VAULT_CIPHER_KEY]: vaultCipher,
-      [KEYS_KEY]: keys,
-      [LOGIN_RETRY_KEY]: loginRetryCount,
-      [LOGIN_RETRY_LOCKOUT_KEY]: loginRetryLockoutTime,
-      [LAST_ACTIVITY_TIME]: lastActivityTime,
-      [VAULT_SETTINGS]: settings,
-      [RECENT_RECIPIENT_PUBLIC_KEYS]: recentRecipientPublicKeys,
-      [CONTACTS_KEY]: contacts,
-      [RATE_APP]: rateApp,
-      [APP_EVENTS]: appEvents,
-      [TRUSTED_WASM]: trustedWasm,
-      [CSPR_NAME_EXPIRATIONS]: csprNameExpirations
-    } = (await storage.local.get([
-      VAULT_CIPHER_KEY,
-      KEYS_KEY,
-      LOGIN_RETRY_KEY,
-      LOGIN_RETRY_LOCKOUT_KEY,
-      LAST_ACTIVITY_TIME,
-      VAULT_SETTINGS,
-      RECENT_RECIPIENT_PUBLIC_KEYS,
-      CONTACTS_KEY,
-      RATE_APP,
-      APP_EVENTS,
-      TRUSTED_WASM,
-      CSPR_NAME_EXPIRATIONS
-    ])) as StorageState;
+    // In parallel, never sequentially: both reads run on EVERY invocation, i.e.
+    // on every `runtime.onMessage`, to serve data consumed only when the
+    // singleton is null.
+    const [
+      {
+        [VAULT_CIPHER_KEY]: vaultCipher,
+        [KEYS_KEY]: keys,
+        [LOGIN_RETRY_KEY]: loginRetryCount,
+        [LOGIN_RETRY_LOCKOUT_KEY]: loginRetryLockoutTime,
+        [LAST_ACTIVITY_TIME]: lastActivityTime,
+        [VAULT_SETTINGS]: settings,
+        [RECENT_RECIPIENT_PUBLIC_KEYS]: recentRecipientPublicKeys,
+        [CONTACTS_KEY]: contacts,
+        [RATE_APP]: rateApp,
+        [APP_EVENTS]: appEvents,
+        [TRUSTED_WASM]: trustedWasm,
+        [CSPR_NAME_EXPIRATIONS]: csprNameExpirations
+      },
+      requestSession
+    ] = await Promise.all([
+      storage.local.get([
+        VAULT_CIPHER_KEY,
+        KEYS_KEY,
+        LOGIN_RETRY_KEY,
+        LOGIN_RETRY_LOCKOUT_KEY,
+        LAST_ACTIVITY_TIME,
+        VAULT_SETTINGS,
+        RECENT_RECIPIENT_PUBLIC_KEYS,
+        CONTACTS_KEY,
+        RATE_APP,
+        APP_EVENTS,
+        TRUSTED_WASM,
+        CSPR_NAME_EXPIRATIONS
+      ]) as Promise<StorageState>,
+      isMockStateEnable
+        ? Promise.resolve<SessionRecord>({ requests: {}, windowId: null })
+        : readRequestSession()
+    ]);
 
     if (storeSingleton == null) {
       if (isMockStateEnable) {
@@ -114,11 +131,25 @@ export async function getExistingMainStoreSingletonOrInit() {
               }
             : undefined,
           trustedWasm,
-          csprNameExpirations
+          csprNameExpirations,
+          // Present before any handler can run: `windowManagement.requests`
+          // lives only in the worker's memory, and an MV3 restart destroys it
+          // while the approval windows it describes are still on screen.
+          windowManagement: {
+            windowId: requestSession.windowId,
+            exportKeysWindowId: null,
+            requests: requestSession.requests
+          }
         });
       }
       // send start action
       storeSingleton.dispatch(startBackground());
+      // The PAIR, not the slice reference: the four window-id case reducers
+      // return a fresh slice for a value-equal write. Baselined from the
+      // hydrated pair, so a sanitizer-trimmed record is not written back until
+      // the first genuine change — deliberate, not a missing write-on-init.
+      let { requests: previousRequests, windowId: previousRequestWindowId } =
+        storeSingleton.getState().windowManagement;
       // on updates propagate new state to replicas and also persist encrypted vault
       storeSingleton.subscribe(() => {
         const state = storeSingleton.getState();
@@ -160,6 +191,20 @@ export async function getExistingMainStoreSingletonOrInit() {
             // nosemgrep: cw-logging-secrets — static message + error object, no key material
             console.error('Persist encrypted vault failed: ', e);
           });
+
+        // A separate call to a separate area with its own catch: a dapp-chosen
+        // oversized `requestId` must never be able to fail the vault write.
+        const { requests, windowId } = state.windowManagement;
+        if (
+          requests !== previousRequests ||
+          windowId !== previousRequestWindowId
+        ) {
+          previousRequests = requests;
+          previousRequestWindowId = windowId;
+          writeRequestSession({ requests, windowId }).catch(e => {
+            console.error('Persist request mirror failed: ', redactUrlQuery(e));
+          });
+        }
       });
     }
   } catch (e) {

--- a/src/background/redux/windowManagement/request-map.ts
+++ b/src/background/redux/windowManagement/request-map.ts
@@ -1,5 +1,11 @@
 import { Request, WindowManagementState } from './types';
 
+// `requestId` is page-generated and page-controlled (`generateRequestId`,
+// src/content/sdk.ts) — an oversized id must be refused here, at the SDK
+// entry, before it can register and later overflow the `storage.session`
+// mirror's write quota (session-store.ts).
+export const MAX_REQUEST_ID_LENGTH = 256;
+
 /**
  * The only sanctioned way to read the `requests` map.
  *
@@ -34,7 +40,11 @@ export function getRequest(
  * descriptor would then be inherited by every later lookup in the map. The
  * other four (`toString`, `constructor`, `valueOf`, `hasOwnProperty`) store as
  * ordinary own properties once reads go through `getRequest`.
+ *
+ * Also bounds length: unchecked here, a multi-MB dapp-supplied id could
+ * register, then overflow the `storage.session` mirror's write quota, and the
+ * mirror's remove-on-reject wipes the whole thing.
  */
 export function isStorableRequestId(requestId: string): boolean {
-  return requestId !== '__proto__';
+  return requestId !== '__proto__' && requestId.length <= MAX_REQUEST_ID_LENGTH;
 }

--- a/src/background/redux/windowManagement/request-map.ts
+++ b/src/background/redux/windowManagement/request-map.ts
@@ -4,7 +4,7 @@ import { Request, WindowManagementState } from './types';
 // src/content/sdk.ts) — an oversized id must be refused here, at the SDK
 // entry, before it can register and later overflow the `storage.session`
 // mirror's write quota (session-store.ts).
-export const MAX_REQUEST_ID_LENGTH = 256;
+const MAX_REQUEST_ID_LENGTH = 256;
 
 /**
  * The only sanctioned way to read the `requests` map.

--- a/src/background/redux/windowManagement/session-store.test.ts
+++ b/src/background/redux/windowManagement/session-store.test.ts
@@ -166,6 +166,21 @@ describe('session-store — read path', () => {
     });
   });
 
+  it('drops an array of otherwise-valid rows to {}, not index-keyed entries', async () => {
+    // Every element here individually passes `sanitizeRequest`, so this is
+    // blind to the `Array.isArray` guard specifically: without it,
+    // `Object.entries` on an array hydrates as `{'0': …, '1': …}` instead of
+    // `{}`.
+    sessionGet.mockResolvedValue(
+      storedRecord({ requests: [openRow(), openRow()], windowId: null })
+    );
+
+    await expect(readRequestSession()).resolves.toEqual({
+      requests: {},
+      windowId: null
+    });
+  });
+
   it.each([
     ['a non-integer', 1.5],
     ['a string', '4'],
@@ -283,7 +298,12 @@ describe('session-store — the sanitizer drops only the row it cannot vouch for
       'a truthy non-boolean awaitingDeviceConfirmation',
       openRow({ awaitingDeviceConfirmation: 1 })
     ],
-    ['a non-object row', 'nope' as unknown as Record<string, unknown>]
+    ['a non-object row', 'nope' as unknown as Record<string, unknown>],
+    // `typeof null === 'object'`, so this exercises the `raw == null` half of
+    // the guard specifically — the `typeof raw !== 'object'` half alone would
+    // let a null row through as "an object".
+    ['a null row', null as unknown as Record<string, unknown>],
+    ['an undefined row', undefined as unknown as Record<string, unknown>]
   ];
 
   it.each(cases)('drops a row with %s', async (_label, row) => {
@@ -317,6 +337,10 @@ describe('session-store — the sanitizer drops only the row it cannot vouch for
 
     expect(requests).toEqual({ good: survivingRow });
     expect(Object.keys(requests)).toEqual(['good']);
+    // `__proto__` must be dropped as a KEY, not assigned — assigning it inside
+    // the sanitizer's output builder would set the object's PROTOTYPE instead,
+    // silently making every later lookup on this map inherit `openRow()`.
+    expect(Object.getPrototypeOf(requests)).toBe(Object.prototype);
   });
 
   it('keeps awaitingDeviceConfirmation: true and an empty windowIds', async () => {
@@ -326,6 +350,42 @@ describe('session-store — the sanitizer drops only the row it cannot vouch for
     );
 
     expect((await readRequestSession()).requests).toEqual({ 'req-1': row });
+  });
+});
+
+describe('session-store — sanitizer completeness pin', () => {
+  type OpenRow = Extract<Request, { status: 'open' }>;
+
+  // `sanitizeRequest`'s open-row return literal is checked against `Request`,
+  // but TS does not require an OPTIONAL field to appear in an object literal
+  // typed as a union member — `frameId` proved exactly this can go unnoticed
+  // for a while. This record must list every key of `OpenRow`; a field added
+  // there without a matching key here is a compile error, forcing the
+  // sanitizer's return literal in session-store.ts to be revisited too.
+  const OPEN_ROW_KEYS = {
+    status: true,
+    tabId: true,
+    frameId: true,
+    origin: true,
+    method: true,
+    windowIds: true,
+    awaitingDeviceConfirmation: true,
+    seq: true
+  } satisfies Record<keyof OpenRow, true>;
+
+  it('lists every OpenRow field', () => {
+    expect(Object.keys(OPEN_ROW_KEYS).sort()).toEqual(
+      [
+        'status',
+        'tabId',
+        'frameId',
+        'origin',
+        'method',
+        'windowIds',
+        'awaitingDeviceConfirmation',
+        'seq'
+      ].sort()
+    );
   });
 });
 
@@ -405,6 +465,33 @@ describe('session-store — write path', () => {
     await writeRequestSession({ requests: {}, windowId: 2 });
 
     expect(sessionSet).toHaveBeenCalledTimes(1);
+    expect(lastWrittenRecord().windowId).toBe(2);
+  });
+
+  it('does not start a queued flush until the in-flight one settles', async () => {
+    let resolveA: (() => void) | undefined;
+    sessionSet.mockImplementationOnce(
+      () =>
+        new Promise<void>(resolve => {
+          resolveA = resolve;
+        })
+    );
+
+    const writeA = writeRequestSession({ requests: {}, windowId: 1 });
+    // Let flush() run up to its `await area.set(...)` — this is what resets
+    // `flushQueued` before A's write has actually landed.
+    await Promise.resolve();
+
+    const writeB = writeRequestSession({ requests: {}, windowId: 2 });
+    // The reset queue only lets B's flush get CHAINED after A's — A's `set`
+    // promise is still pending, so B's flush cannot have started yet.
+    expect(sessionSet).toHaveBeenCalledTimes(1);
+
+    resolveA?.();
+    await writeA;
+    await writeB;
+
+    expect(sessionSet).toHaveBeenCalledTimes(2);
     expect(lastWrittenRecord().windowId).toBe(2);
   });
 

--- a/src/background/redux/windowManagement/session-store.test.ts
+++ b/src/background/redux/windowManagement/session-store.test.ts
@@ -190,6 +190,66 @@ describe('session-store — read path', () => {
   });
 });
 
+describe('session-store — frameId', () => {
+  it('keeps frameId 0 (top frame) verbatim through hydration', async () => {
+    sessionGet.mockResolvedValue(
+      storedRecord({
+        requests: { 'req-1': openRow({ frameId: 0 }) },
+        windowId: null
+      })
+    );
+
+    expect((await readRequestSession()).requests).toEqual({
+      'req-1': openRow({ frameId: 0 })
+    });
+  });
+
+  it('keeps a positive frameId verbatim through hydration', async () => {
+    sessionGet.mockResolvedValue(
+      storedRecord({
+        requests: { 'req-1': openRow({ frameId: 4 }) },
+        windowId: null
+      })
+    );
+
+    expect((await readRequestSession()).requests).toEqual({
+      'req-1': openRow({ frameId: 4 })
+    });
+  });
+
+  it('leaves frameId absent when the stored row has none', async () => {
+    sessionGet.mockResolvedValue(
+      storedRecord({ requests: { 'req-1': openRow() }, windowId: null })
+    );
+
+    const { requests } = await readRequestSession();
+
+    expect(requests).toEqual({ 'req-1': openRow() });
+    expect('frameId' in (requests['req-1'] as object)).toBe(false);
+  });
+
+  it.each([
+    ['a stringified frameId', '1'],
+    ['a fractional frameId', 1.5],
+    ['null', null]
+  ])(
+    'drops the frameId field but keeps the row for %s',
+    async (_label, frameId) => {
+      sessionGet.mockResolvedValue(
+        storedRecord({
+          requests: { 'req-1': openRow({ frameId }) },
+          windowId: null
+        })
+      );
+
+      const { requests } = await readRequestSession();
+
+      expect(requests).toEqual({ 'req-1': openRow() });
+      expect('frameId' in (requests['req-1'] as object)).toBe(false);
+    }
+  );
+});
+
 describe('session-store — the sanitizer drops only the row it cannot vouch for', () => {
   const survivingRow = openRow({ seq: 9 });
 
@@ -277,6 +337,20 @@ describe('session-store — write path', () => {
     expect(sessionSet).toHaveBeenCalledWith({
       [REQUEST_SESSION_KEY]: {
         requests: { 'req-1': openRow() },
+        windowId: 3
+      }
+    });
+  });
+
+  it('round-trips frameId, including 0, through the write path', async () => {
+    await writeRequestSession({
+      requests: { 'req-1': openRow({ frameId: 0 }) as Request },
+      windowId: 3
+    });
+
+    expect(sessionSet).toHaveBeenCalledWith({
+      [REQUEST_SESSION_KEY]: {
+        requests: { 'req-1': openRow({ frameId: 0 }) },
         windowId: 3
       }
     });

--- a/src/background/redux/windowManagement/session-store.test.ts
+++ b/src/background/redux/windowManagement/session-store.test.ts
@@ -155,6 +155,23 @@ describe('session-store — read path', () => {
     });
   });
 
+  // `typeof record !== 'object' || record == null` is deletable and the VALUE
+  // above still passes: destructuring `null` without the guard throws, which
+  // the outer `catch` swallows into the same `emptyRecord()`. The only
+  // observable difference is the catch's side effect — it LOGS. (A string
+  // like 'nope' would not distinguish this: object-destructuring a primitive
+  // string does not throw, so its result is identical with or without the
+  // guard.)
+  it('returns the empty record for a null session record without logging', async () => {
+    sessionGet.mockResolvedValue(storedRecord(null));
+
+    await expect(readRequestSession()).resolves.toEqual({
+      requests: {},
+      windowId: null
+    });
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
   it('drops a non-object requests map to {} without touching windowId', async () => {
     sessionGet.mockResolvedValue(
       storedRecord({ requests: ['not', 'a', 'map'], windowId: 4 })
@@ -353,41 +370,11 @@ describe('session-store — the sanitizer drops only the row it cannot vouch for
   });
 });
 
-describe('session-store — sanitizer completeness pin', () => {
-  type OpenRow = Extract<Request, { status: 'open' }>;
-
-  // `sanitizeRequest`'s open-row return literal is checked against `Request`,
-  // but TS does not require an OPTIONAL field to appear in an object literal
-  // typed as a union member — `frameId` proved exactly this can go unnoticed
-  // for a while. This record must list every key of `OpenRow`; a field added
-  // there without a matching key here is a compile error, forcing the
-  // sanitizer's return literal in session-store.ts to be revisited too.
-  const OPEN_ROW_KEYS = {
-    status: true,
-    tabId: true,
-    frameId: true,
-    origin: true,
-    method: true,
-    windowIds: true,
-    awaitingDeviceConfirmation: true,
-    seq: true
-  } satisfies Record<keyof OpenRow, true>;
-
-  it('lists every OpenRow field', () => {
-    expect(Object.keys(OPEN_ROW_KEYS).sort()).toEqual(
-      [
-        'status',
-        'tabId',
-        'frameId',
-        'origin',
-        'method',
-        'windowIds',
-        'awaitingDeviceConfirmation',
-        'seq'
-      ].sort()
-    );
-  });
-});
+// The completeness pin moved to session-store.ts, colocated with
+// `sanitizeRequest`'s open-row literal it actually guards — a copy here was
+// satisfiable inside the test file alone (add a field to BOTH the pin and a
+// hand-maintained runtime list, and the build stays green while the
+// sanitizer itself still silently drops it).
 
 describe('session-store — write path', () => {
   it('writes the record under the session key', async () => {
@@ -483,6 +470,15 @@ describe('session-store — write path', () => {
     await Promise.resolve();
 
     const writeB = writeRequestSession({ requests: {}, windowId: 2 });
+    // One more tick: if B's flush were merely CHAINED but not yet started
+    // (the real, serialised behaviour), this changes nothing — it is still
+    // waiting on A's unresolved `set`. If `writeChain` were rebuilt from a
+    // fresh `Promise.resolve()` instead of chained onto the existing one
+    // (serialisation lost), B's flush would be a microtask away from running
+    // regardless of A — this tick is what lets that difference surface as a
+    // second `sessionSet` call, which asserting synchronously right after the
+    // `writeB` call cannot see.
+    await Promise.resolve();
     // The reset queue only lets B's flush get CHAINED after A's — A's `set`
     // promise is still pending, so B's flush cannot have started yet.
     expect(sessionSet).toHaveBeenCalledTimes(1);

--- a/src/background/redux/windowManagement/session-store.test.ts
+++ b/src/background/redux/windowManagement/session-store.test.ts
@@ -169,7 +169,8 @@ describe('session-store — read path', () => {
   it.each([
     ['a non-integer', 1.5],
     ['a string', '4'],
-    ['undefined', undefined]
+    ['undefined', undefined],
+    ['negative', -1]
   ])('nulls a windowId that is %s', async (_label, windowId) => {
     sessionGet.mockResolvedValue(storedRecord({ requests: {}, windowId }));
 
@@ -231,6 +232,7 @@ describe('session-store — frameId', () => {
   it.each([
     ['a stringified frameId', '1'],
     ['a fractional frameId', 1.5],
+    ['a negative frameId', -1],
     ['null', null]
   ])(
     'drops the frameId field but keeps the row for %s',

--- a/src/background/redux/windowManagement/session-store.test.ts
+++ b/src/background/redux/windowManagement/session-store.test.ts
@@ -1,0 +1,405 @@
+import { MAX_RESPONDED_TOMBSTONES } from './reducer';
+import {
+  REQUEST_SESSION_KEY,
+  SessionRecord,
+  readRequestSession,
+  writeRequestSession
+} from './session-store';
+import { Request } from './types';
+
+// `isEphemeralBackgroundBuild` is FALSE under jest: `npm test` sets no BROWSER
+// and DefinePlugin is webpack-only. Without this mock every case below would
+// exercise the disabled path and pass while asserting nothing.
+let mockIsEphemeralBackgroundBuild = true;
+
+jest.mock('@src/utils', () => ({
+  get isEphemeralBackgroundBuild() {
+    return mockIsEphemeralBackgroundBuild;
+  }
+}));
+
+const sessionGet = jest.fn<Promise<Record<string, unknown>>, [unknown]>();
+const sessionSet = jest.fn<Promise<void>, [unknown]>();
+const sessionRemove = jest.fn<Promise<void>, [unknown]>();
+
+// The area itself is swappable: `@types/webextension-polyfill` declares
+// `session` non-optional, so "the browser has no session area" is a state only
+// the runtime can be in.
+let mockSessionArea: unknown = {
+  get: (...args: unknown[]) => sessionGet(...(args as [unknown])),
+  set: (...args: unknown[]) => sessionSet(...(args as [unknown])),
+  remove: (...args: unknown[]) => sessionRemove(...(args as [unknown]))
+};
+
+jest.mock('webextension-polyfill', () => ({
+  storage: {
+    get session() {
+      return mockSessionArea;
+    }
+  }
+}));
+
+const openRow = (overrides: Record<string, unknown> = {}) => ({
+  status: 'open',
+  tabId: 7,
+  origin: 'https://dapp.example',
+  method: 'sign',
+  windowIds: [11],
+  awaitingDeviceConfirmation: false,
+  seq: 0,
+  ...overrides
+});
+
+const storedRecord = (record: unknown) => ({ [REQUEST_SESSION_KEY]: record });
+
+const lastWrittenRecord = (): SessionRecord => {
+  const [written] = sessionSet.mock.calls[sessionSet.mock.calls.length - 1];
+
+  return (written as Record<string, SessionRecord>)[REQUEST_SESSION_KEY];
+};
+
+let consoleErrorSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsEphemeralBackgroundBuild = true;
+  mockSessionArea = {
+    get: (...args: unknown[]) => sessionGet(...(args as [unknown])),
+    set: (...args: unknown[]) => sessionSet(...(args as [unknown])),
+    remove: (...args: unknown[]) => sessionRemove(...(args as [unknown]))
+  };
+  sessionGet.mockResolvedValue({});
+  sessionSet.mockResolvedValue(undefined);
+  sessionRemove.mockResolvedValue(undefined);
+  consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore();
+});
+
+describe('session-store — the gate', () => {
+  it('reads and writes nothing on a persistent-background build', async () => {
+    mockIsEphemeralBackgroundBuild = false;
+
+    await expect(readRequestSession()).resolves.toEqual({
+      requests: {},
+      windowId: null
+    });
+    await writeRequestSession({
+      requests: { a: openRow() as Request },
+      windowId: 3
+    });
+
+    expect(sessionGet).not.toHaveBeenCalled();
+    expect(sessionSet).not.toHaveBeenCalled();
+  });
+
+  it('reads and writes nothing when the runtime has no session area', async () => {
+    mockSessionArea = undefined;
+
+    await expect(readRequestSession()).resolves.toEqual({
+      requests: {},
+      windowId: null
+    });
+    await writeRequestSession({ requests: {}, windowId: 3 });
+
+    expect(sessionSet).not.toHaveBeenCalled();
+  });
+
+  it('reads and writes when the build is ephemeral and the area exists', async () => {
+    sessionGet.mockResolvedValue(
+      storedRecord({ requests: { 'req-1': openRow() }, windowId: 3 })
+    );
+
+    await expect(readRequestSession()).resolves.toEqual({
+      requests: { 'req-1': openRow() },
+      windowId: 3
+    });
+
+    await writeRequestSession({ requests: {}, windowId: 3 });
+
+    expect(sessionSet).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('session-store — read path', () => {
+  it('returns the empty record when the key is absent', async () => {
+    sessionGet.mockResolvedValue({});
+
+    await expect(readRequestSession()).resolves.toEqual({
+      requests: {},
+      windowId: null
+    });
+  });
+
+  it('returns the empty record, and never throws, when the read rejects', async () => {
+    sessionGet.mockRejectedValue('not an Error — the area is not polyfilled');
+
+    await expect(readRequestSession()).resolves.toEqual({
+      requests: {},
+      windowId: null
+    });
+  });
+
+  it.each([
+    ['a non-object payload', 'nope'],
+    ['null', null],
+    ['an array', ['a']]
+  ])('drops %s wholesale', async (_label, record) => {
+    sessionGet.mockResolvedValue(storedRecord(record));
+
+    await expect(readRequestSession()).resolves.toEqual({
+      requests: {},
+      windowId: null
+    });
+  });
+
+  it('drops a non-object requests map to {} without touching windowId', async () => {
+    sessionGet.mockResolvedValue(
+      storedRecord({ requests: ['not', 'a', 'map'], windowId: 4 })
+    );
+
+    await expect(readRequestSession()).resolves.toEqual({
+      requests: {},
+      windowId: 4
+    });
+  });
+
+  it.each([
+    ['a non-integer', 1.5],
+    ['a string', '4'],
+    ['undefined', undefined]
+  ])('nulls a windowId that is %s', async (_label, windowId) => {
+    sessionGet.mockResolvedValue(storedRecord({ requests: {}, windowId }));
+
+    expect((await readRequestSession()).windowId).toBeNull();
+  });
+
+  it('keeps a tombstone row', async () => {
+    sessionGet.mockResolvedValue(
+      storedRecord({
+        requests: { 'req-1': { status: 'responded', seq: 4 } },
+        windowId: null
+      })
+    );
+
+    expect((await readRequestSession()).requests).toEqual({
+      'req-1': { status: 'responded', seq: 4 }
+    });
+  });
+});
+
+describe('session-store — the sanitizer drops only the row it cannot vouch for', () => {
+  const survivingRow = openRow({ seq: 9 });
+
+  const cases: [string, Record<string, unknown>][] = [
+    ['a bogus status', openRow({ status: 'pending' })],
+    ['a missing seq', openRow({ seq: undefined })],
+    ['a fractional seq', openRow({ seq: 1.5 })],
+    ['a stringified seq', openRow({ seq: '1' })],
+    ['a negative tabId', openRow({ tabId: -1 })],
+    ['a fractional tabId', openRow({ tabId: 1.5 })],
+    ['a stringified tabId', openRow({ tabId: '7' })],
+    ['a null tabId', openRow({ tabId: null })],
+    ['a non-http origin', openRow({ origin: 'chrome-extension://abc/x.html' })],
+    // Interpolated so eslint's `no-script-url` does not flag the literal.
+    ['a script-url origin', openRow({ origin: `javascript:${'alert(1)'}` })],
+    ['an unparseable origin', openRow({ origin: 'not a url' })],
+    [
+      'an over-long origin',
+      openRow({ origin: `https://${'a'.repeat(300)}.example` })
+    ],
+    ['an unknown method', openRow({ method: 'transfer' })],
+    ['a non-array windowIds', openRow({ windowIds: 11 })],
+    ['a non-integer windowIds member', openRow({ windowIds: [11, '12'] })],
+    [
+      'an over-long windowIds',
+      openRow({ windowIds: Array.from({ length: 17 }, (_, i) => i) })
+    ],
+    [
+      'a truthy non-boolean awaitingDeviceConfirmation',
+      openRow({ awaitingDeviceConfirmation: 1 })
+    ],
+    ['a non-object row', 'nope' as unknown as Record<string, unknown>]
+  ];
+
+  it.each(cases)('drops a row with %s', async (_label, row) => {
+    sessionGet.mockResolvedValue(
+      storedRecord({
+        requests: { bad: row, good: survivingRow },
+        windowId: null
+      })
+    );
+
+    expect((await readRequestSession()).requests).toEqual({
+      good: survivingRow
+    });
+  });
+
+  it('drops a __proto__ key and an over-long key, keeping the rest', async () => {
+    sessionGet.mockResolvedValue(
+      storedRecord({
+        // Computed keys, so `__proto__` is an OWN property rather than the
+        // literal's prototype setter.
+        requests: {
+          ['__proto__']: openRow(),
+          ['x'.repeat(257)]: openRow(),
+          good: survivingRow
+        },
+        windowId: null
+      })
+    );
+
+    const { requests } = await readRequestSession();
+
+    expect(requests).toEqual({ good: survivingRow });
+    expect(Object.keys(requests)).toEqual(['good']);
+  });
+
+  it('keeps awaitingDeviceConfirmation: true and an empty windowIds', async () => {
+    const row = openRow({ awaitingDeviceConfirmation: true, windowIds: [] });
+    sessionGet.mockResolvedValue(
+      storedRecord({ requests: { 'req-1': row }, windowId: null })
+    );
+
+    expect((await readRequestSession()).requests).toEqual({ 'req-1': row });
+  });
+});
+
+describe('session-store — write path', () => {
+  it('writes the record under the session key', async () => {
+    await writeRequestSession({
+      requests: { 'req-1': openRow() as Request },
+      windowId: 3
+    });
+
+    expect(sessionSet).toHaveBeenCalledWith({
+      [REQUEST_SESSION_KEY]: {
+        requests: { 'req-1': openRow() },
+        windowId: 3
+      }
+    });
+  });
+
+  it('removes the key when the write rejects, so the mirror degrades to absent', async () => {
+    sessionSet.mockRejectedValue(new Error('QuotaExceeded'));
+
+    await writeRequestSession({ requests: {}, windowId: 1 });
+
+    expect(sessionRemove).toHaveBeenCalledWith(REQUEST_SESSION_KEY);
+  });
+
+  it('swallows a rejecting remove', async () => {
+    sessionSet.mockRejectedValue('context invalidated');
+    sessionRemove.mockRejectedValue('context invalidated');
+
+    await expect(
+      writeRequestSession({ requests: {}, windowId: 1 })
+    ).resolves.toBeUndefined();
+  });
+
+  it('still lands a write issued after a rejected one — the chain is never poisoned', async () => {
+    sessionSet.mockRejectedValueOnce(new Error('QuotaExceeded'));
+
+    await writeRequestSession({ requests: {}, windowId: 1 });
+    await writeRequestSession({ requests: {}, windowId: 2 });
+
+    expect(sessionSet).toHaveBeenCalledTimes(2);
+    expect(lastWrittenRecord()).toEqual({ requests: {}, windowId: 2 });
+  });
+
+  it('lands two rapid writes in order', async () => {
+    const first = writeRequestSession({ requests: {}, windowId: 1 });
+    await first;
+    const second = writeRequestSession({ requests: {}, windowId: 2 });
+    await second;
+
+    expect(
+      sessionSet.mock.calls.map(
+        ([written]) =>
+          (written as Record<string, SessionRecord>)[REQUEST_SESSION_KEY]
+            .windowId
+      )
+    ).toEqual([1, 2]);
+  });
+
+  it('coalesces same-tick writes onto the newest snapshot', async () => {
+    void writeRequestSession({ requests: {}, windowId: 1 });
+    await writeRequestSession({ requests: {}, windowId: 2 });
+
+    expect(sessionSet).toHaveBeenCalledTimes(1);
+    expect(lastWrittenRecord().windowId).toBe(2);
+  });
+
+  it('caps rows on the write side, dropping tombstones before open rows and oldest first', async () => {
+    const requests: Record<string, Request> = {};
+    // Two over the cap, with the two oldest tombstones expected to go.
+    const rowCount = MAX_RESPONDED_TOMBSTONES + 22;
+
+    for (let seq = 0; seq < rowCount; seq += 1) {
+      requests[`req-${seq}`] =
+        seq < 30
+          ? ({ status: 'responded', seq } as Request)
+          : (openRow({ seq }) as Request);
+    }
+
+    await writeRequestSession({ requests, windowId: null });
+
+    const written = lastWrittenRecord().requests;
+
+    expect(Object.keys(written)).toHaveLength(MAX_RESPONDED_TOMBSTONES + 20);
+    expect(written['req-0']).toBeUndefined();
+    expect(written['req-1']).toBeUndefined();
+    expect(written['req-2']).toBeDefined();
+    // Every open row survives: a dropped one is a live approval window.
+    for (let seq = 30; seq < rowCount; seq += 1) {
+      expect(written[`req-${seq}`]).toBeDefined();
+    }
+  });
+
+  it('ranks the write cap by seq, not by key hoisting', async () => {
+    const requests: Record<string, Request> = {};
+
+    for (let seq = 0; seq < MAX_RESPONDED_TOMBSTONES + 21; seq += 1) {
+      // `"42"` enumerates ahead of every string key; its ordinal is the newest.
+      const requestId =
+        seq === MAX_RESPONDED_TOMBSTONES + 20 ? '42' : `req-${seq}`;
+      requests[requestId] = { status: 'responded', seq } as Request;
+    }
+
+    await writeRequestSession({ requests, windowId: null });
+
+    const written = lastWrittenRecord().requests;
+
+    expect(written['42']).toBeDefined();
+    expect(written['req-0']).toBeUndefined();
+  });
+});
+
+describe('session-store — logging discipline', () => {
+  it('never logs a raw URL query or the sanitizer input', async () => {
+    sessionGet.mockRejectedValue(
+      new Error(
+        'chrome-extension://abc/signature-request.html?message=secret failed'
+      )
+    );
+    sessionSet.mockRejectedValue(
+      new Error(
+        'chrome-extension://abc/signature-request.html?signingPublicKeyHex=01ab failed'
+      )
+    );
+
+    await readRequestSession();
+    await writeRequestSession({
+      requests: { 'req-1': openRow() as Request },
+      windowId: 1
+    });
+
+    const logged = consoleErrorSpy.mock.calls.flat().join(' ');
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(logged).not.toContain('?');
+    expect(logged).not.toContain('dapp.example');
+  });
+});

--- a/src/background/redux/windowManagement/session-store.ts
+++ b/src/background/redux/windowManagement/session-store.ts
@@ -5,7 +5,7 @@ import { isEphemeralBackgroundBuild } from '@src/utils';
 import { redactUrlQuery } from '@background/redact-url-query';
 
 import { MAX_RESPONDED_TOMBSTONES } from './reducer';
-import { isStorableRequestId } from './request-map';
+import { MAX_REQUEST_ID_LENGTH, isStorableRequestId } from './request-map';
 import { CancellableMethod, Request, WindowManagementState } from './types';
 
 // Follows the obfuscated `storage.local` convention for consistency only. This
@@ -26,7 +26,6 @@ export type SessionRecord = {
 // has to be defined there and key hoisting can never decide which rows survive.
 const MAX_SESSION_ROWS = MAX_RESPONDED_TOMBSTONES + 20;
 
-const MAX_REQUEST_ID_LENGTH = 256;
 const MAX_ORIGIN_LENGTH = 256;
 const MAX_WINDOW_IDS = 16;
 

--- a/src/background/redux/windowManagement/session-store.ts
+++ b/src/background/redux/windowManagement/session-store.ts
@@ -5,7 +5,7 @@ import { isEphemeralBackgroundBuild } from '@src/utils';
 import { redactUrlQuery } from '@background/redact-url-query';
 
 import { MAX_RESPONDED_TOMBSTONES } from './reducer';
-import { MAX_REQUEST_ID_LENGTH, isStorableRequestId } from './request-map';
+import { isStorableRequestId } from './request-map';
 import { CancellableMethod, Request, WindowManagementState } from './types';
 
 // Follows the obfuscated `storage.local` convention for consistency only. This
@@ -86,6 +86,26 @@ const isDeliverableOrigin = (raw: unknown): raw is string => {
   }
 };
 
+// Completeness pin for the open-row return literal below, same idiom as
+// `CANCELLABLE_METHODS` above: every key of the 'open' variant of `Request`,
+// so a field added there without a matching key here is a compile error IN
+// THIS FILE. TS does not otherwise require an OPTIONAL field to appear in an
+// object literal typed as a union member — `frameId` proved exactly that can
+// go unnoticed. `void`d rather than exported: its only job is the type
+// check, and an unused export would earn its own knip complaint instead.
+type OpenRow = Extract<Request, { status: 'open' }>;
+const OPEN_ROW_KEYS: Record<keyof OpenRow, true> = {
+  status: true,
+  tabId: true,
+  frameId: true,
+  origin: true,
+  method: true,
+  windowIds: true,
+  awaitingDeviceConfirmation: true,
+  seq: true
+};
+void OPEN_ROW_KEYS;
+
 // Total: it drops what it cannot vouch for and never throws — a throw would
 // leave the background unable to start at all.
 function sanitizeRequest(raw: unknown): Request | undefined {
@@ -148,10 +168,9 @@ function sanitizeRequestMap(raw: unknown): WindowManagementState['requests'] {
   const requests: WindowManagementState['requests'] = {};
 
   for (const [requestId, value] of Object.entries(raw)) {
-    if (
-      !isStorableRequestId(requestId) ||
-      requestId.length > MAX_REQUEST_ID_LENGTH
-    ) {
+    // `isStorableRequestId` already rejects an over-long id (the length
+    // bound lives there, at the SDK entry) — no separate length check here.
+    if (!isStorableRequestId(requestId)) {
       continue;
     }
 

--- a/src/background/redux/windowManagement/session-store.ts
+++ b/src/background/redux/windowManagement/session-store.ts
@@ -125,9 +125,10 @@ function sanitizeRequest(raw: unknown): Request | undefined {
     return undefined;
   }
 
-  // `frameId` is kept only when `Number.isInteger` — so `0` (top frame, falsy)
-  // survives verbatim — and otherwise omitted, never defaulted, so an absent or
-  // malformed value degrades to today's unscoped send rather than dropping the row.
+  // `frameId` is kept only when `isNonNegativeInteger` — so `0` (top frame,
+  // falsy) survives verbatim — and otherwise omitted, never defaulted, so an
+  // absent or malformed (including negative) value degrades to today's
+  // unscoped send rather than dropping the row.
   return {
     status: 'open',
     tabId,
@@ -136,7 +137,7 @@ function sanitizeRequest(raw: unknown): Request | undefined {
     windowIds,
     awaitingDeviceConfirmation,
     seq,
-    ...(Number.isInteger(row.frameId) ? { frameId: row.frameId as number } : {})
+    ...(isNonNegativeInteger(row.frameId) ? { frameId: row.frameId } : {})
   };
 }
 
@@ -166,7 +167,7 @@ function sanitizeRequestMap(raw: unknown): WindowManagementState['requests'] {
 }
 
 const sanitizeWindowId = (raw: unknown): number | null =>
-  typeof raw === 'number' && Number.isInteger(raw) ? raw : null;
+  isNonNegativeInteger(raw) ? raw : null;
 
 // Tombstones go before open rows, oldest first by ordinal: a dropped open row
 // is a request whose window is on screen, a dropped tombstone only costs a dedup.

--- a/src/background/redux/windowManagement/session-store.ts
+++ b/src/background/redux/windowManagement/session-store.ts
@@ -125,9 +125,9 @@ function sanitizeRequest(raw: unknown): Request | undefined {
     return undefined;
   }
 
-  // `frameId` (PR #1484) is sanitized here once it lands, on `Number.isInteger`
-  // alone: `0` is the top frame and is falsy, so `raw.frameId || undefined`
-  // would erase it.
+  // `frameId` is kept only when `Number.isInteger` — so `0` (top frame, falsy)
+  // survives verbatim — and otherwise omitted, never defaulted, so an absent or
+  // malformed value degrades to today's unscoped send rather than dropping the row.
   return {
     status: 'open',
     tabId,
@@ -135,7 +135,8 @@ function sanitizeRequest(raw: unknown): Request | undefined {
     method,
     windowIds,
     awaitingDeviceConfirmation,
-    seq
+    seq,
+    ...(Number.isInteger(row.frameId) ? { frameId: row.frameId as number } : {})
   };
 }
 

--- a/src/background/redux/windowManagement/session-store.ts
+++ b/src/background/redux/windowManagement/session-store.ts
@@ -1,0 +1,286 @@
+import { Storage, storage } from 'webextension-polyfill';
+
+import { isEphemeralBackgroundBuild } from '@src/utils';
+
+import { redactUrlQuery } from '@background/redact-url-query';
+
+import { MAX_RESPONDED_TOMBSTONES } from './reducer';
+import { isStorableRequestId } from './request-map';
+import { CancellableMethod, Request, WindowManagementState } from './types';
+
+// Follows the obfuscated `storage.local` convention for consistency only. This
+// one is NOT immutable the way those are: `storage.session` is cleared on
+// extension reload and update, so no data ever crosses a version boundary and a
+// later rename would strand nothing.
+export const REQUEST_SESSION_KEY = 'q7Rk2vHs4nTbX';
+
+// What the mirror carries. `exportKeysWindowId` is excluded — a local flow with
+// no dapp waiting — and so is `ledger.windowId`, which is memory-only.
+export type SessionRecord = {
+  requests: WindowManagementState['requests'];
+  windowId: number | null;
+};
+
+// Write-side row cap: the reducer's tombstone bound plus headroom for the open
+// rows that can exist alongside them. The read stays uncapped, so no drop order
+// has to be defined there and key hoisting can never decide which rows survive.
+const MAX_SESSION_ROWS = MAX_RESPONDED_TOMBSTONES + 20;
+
+const MAX_REQUEST_ID_LENGTH = 256;
+const MAX_ORIGIN_LENGTH = 256;
+const MAX_WINDOW_IDS = 16;
+
+const emptyRecord = (): SessionRecord => ({ requests: {}, windowId: null });
+
+// The area must stay at Chrome's default `TRUSTED_CONTEXTS` — the map holds
+// every dapp origin with a pending or recently answered request, its tab ids
+// and live request ids. Nothing calls `setAccessLevel` and nothing should.
+//
+// Both halves of the gate are required. Firefox 115+ and Safari 16.4+ also have
+// the area, but their background pages are `"persistent": true` and lose
+// nothing, so a bare feature detect would enable an untested path there; and the
+// runtime half is still needed because `@types/webextension-polyfill` declares
+// `session` non-optional, so the type lies about availability.
+//
+// The polyfill exposes the area by pass-through, so this is the raw
+// `chrome.storage.session` and its rejections are not polyfill-normalised — a
+// catch here must not assume an `Error`.
+function sessionAreaOrNull(): Storage.StorageArea | null {
+  if (!isEphemeralBackgroundBuild) {
+    return null;
+  }
+
+  const area: Storage.StorageArea | undefined = storage.session;
+
+  return area ?? null;
+}
+
+const isNonNegativeInteger = (raw: unknown): raw is number =>
+  typeof raw === 'number' && Number.isInteger(raw) && raw >= 0;
+
+// A `Record` rather than a `Set` so adding a method to the union is a compile
+// error here rather than a row the sanitizer silently drops.
+const CANCELLABLE_METHODS: Record<CancellableMethod, true> = {
+  connect: true,
+  switchAccount: true,
+  sign: true,
+  signMessage: true,
+  signTypedData: true,
+  decryptMessage: true
+};
+
+const isCancellableMethod = (raw: unknown): raw is CancellableMethod =>
+  typeof raw === 'string' &&
+  Object.prototype.hasOwnProperty.call(CANCELLABLE_METHODS, raw);
+
+const isDeliverableOrigin = (raw: unknown): raw is string => {
+  if (typeof raw !== 'string' || raw.length > MAX_ORIGIN_LENGTH) {
+    return false;
+  }
+
+  try {
+    const { protocol } = new URL(raw);
+
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+// Total: it drops what it cannot vouch for and never throws — a throw would
+// leave the background unable to start at all.
+function sanitizeRequest(raw: unknown): Request | undefined {
+  if (typeof raw !== 'object' || raw == null) {
+    return undefined;
+  }
+
+  const row = raw as Record<string, unknown>;
+  const seq = row.seq;
+
+  // Required, not optional: the area is cleared on extension update and the
+  // ordinal shipped first, so a `seq`-less row cannot exist.
+  if (typeof seq !== 'number' || !Number.isInteger(seq)) {
+    return undefined;
+  }
+
+  if (row.status === 'responded') {
+    return { status: 'responded', seq };
+  }
+
+  if (row.status !== 'open') {
+    return undefined;
+  }
+
+  const { tabId, origin, method, windowIds, awaitingDeviceConfirmation } = row;
+
+  if (
+    !isNonNegativeInteger(tabId) ||
+    !isDeliverableOrigin(origin) ||
+    !isCancellableMethod(method) ||
+    !Array.isArray(windowIds) ||
+    windowIds.length > MAX_WINDOW_IDS ||
+    !windowIds.every(isNonNegativeInteger) ||
+    typeof awaitingDeviceConfirmation !== 'boolean'
+  ) {
+    return undefined;
+  }
+
+  // `frameId` (PR #1484) is sanitized here once it lands, on `Number.isInteger`
+  // alone: `0` is the top frame and is falsy, so `raw.frameId || undefined`
+  // would erase it.
+  return {
+    status: 'open',
+    tabId,
+    origin,
+    method,
+    windowIds,
+    awaitingDeviceConfirmation,
+    seq
+  };
+}
+
+function sanitizeRequestMap(raw: unknown): WindowManagementState['requests'] {
+  if (typeof raw !== 'object' || raw == null || Array.isArray(raw)) {
+    return {};
+  }
+
+  const requests: WindowManagementState['requests'] = {};
+
+  for (const [requestId, value] of Object.entries(raw)) {
+    if (
+      !isStorableRequestId(requestId) ||
+      requestId.length > MAX_REQUEST_ID_LENGTH
+    ) {
+      continue;
+    }
+
+    const request = sanitizeRequest(value);
+
+    if (request != null) {
+      requests[requestId] = request;
+    }
+  }
+
+  return requests;
+}
+
+const sanitizeWindowId = (raw: unknown): number | null =>
+  typeof raw === 'number' && Number.isInteger(raw) ? raw : null;
+
+// Tombstones go before open rows, oldest first by ordinal: a dropped open row
+// is a request whose window is on screen, a dropped tombstone only costs a dedup.
+function capRows(
+  requests: WindowManagementState['requests']
+): WindowManagementState['requests'] {
+  const rows = Object.entries(requests).flatMap(([requestId, request]) =>
+    request == null ? [] : [[requestId, request] as const]
+  );
+  const overflow = rows.length - MAX_SESSION_ROWS;
+
+  if (overflow <= 0) {
+    return requests;
+  }
+
+  const dropped = new Set(
+    [...rows]
+      .sort(
+        ([, a], [, b]) =>
+          Number(a.status === 'open') - Number(b.status === 'open') ||
+          a.seq - b.seq
+      )
+      .slice(0, overflow)
+      .map(([requestId]) => requestId)
+  );
+
+  return Object.fromEntries(
+    rows.filter(([requestId]) => !dropped.has(requestId))
+  );
+}
+
+/**
+ * The mirrored record, or the empty one on a missing area, a rejected read or
+ * unparseable content. Never throws.
+ */
+export async function readRequestSession(): Promise<SessionRecord> {
+  const area = sessionAreaOrNull();
+
+  if (area == null) {
+    return emptyRecord();
+  }
+
+  try {
+    const stored = await area.get(REQUEST_SESSION_KEY);
+    const record = stored?.[REQUEST_SESSION_KEY] as unknown;
+
+    if (typeof record !== 'object' || record == null) {
+      return emptyRecord();
+    }
+
+    const { requests, windowId } = record as Record<string, unknown>;
+
+    return {
+      requests: sanitizeRequestMap(requests),
+      windowId: sanitizeWindowId(windowId)
+    };
+  } catch (error) {
+    console.error('Read request mirror failed: ', redactUrlQuery(error));
+
+    return emptyRecord();
+  }
+}
+
+// Writes are serialised: two in-flight `set` calls have no documented landing
+// order, and an older one landing last leaves a STALE mirror — the unsafe
+// direction. The snapshot is taken at flush, so a superseded one is skipped.
+let pendingRecord: SessionRecord | null = null;
+let flushQueued = false;
+let writeChain: Promise<void> = Promise.resolve();
+
+// Must never reject: `writeChain.then(flush)` would skip every later flush
+// forever. Both catches therefore live inside it, never attached to the chain.
+async function flush(area: Storage.StorageArea): Promise<void> {
+  const record = pendingRecord;
+
+  pendingRecord = null;
+  flushQueued = false;
+
+  if (record == null) {
+    return;
+  }
+
+  try {
+    await area.set({
+      [REQUEST_SESSION_KEY]: {
+        requests: capRows(record.requests),
+        windowId: record.windowId
+      }
+    });
+  } catch (error) {
+    console.error('Persist request mirror failed: ', redactUrlQuery(error));
+
+    try {
+      // Degrade to absent, which behaves exactly like today. A stale mirror
+      // does not. `remove` can reject too, hence the second catch.
+      await area.remove(REQUEST_SESSION_KEY);
+    } catch {
+      // Nothing left to try.
+    }
+  }
+}
+
+export function writeRequestSession(record: SessionRecord): Promise<void> {
+  const area = sessionAreaOrNull();
+
+  if (area == null) {
+    return Promise.resolve();
+  }
+
+  pendingRecord = record;
+
+  if (!flushQueued) {
+    flushQueued = true;
+    writeChain = writeChain.then(() => flush(area));
+  }
+
+  return writeChain;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,6 +57,13 @@ export const isLedgerAvailable =
   process.env.BROWSER === Browser.Chrome ||
   process.env.BROWSER === Browser.Edge;
 
+// Named for the property rather than the vendor: `Browser.Edge` is Chromium
+// too, and an `isChromeBuild` gate would silently ship an Edge build without
+// the request mirror. Build-time, so DefinePlugin still eliminates dead code.
+export const isEphemeralBackgroundBuild =
+  process.env.BROWSER === Browser.Chrome ||
+  process.env.BROWSER === Browser.Edge;
+
 export const isValidU64 = (value?: string): boolean => {
   if (!value) {
     return false;


### PR DESCRIPTION
## Description

`windowManagement.requests` lived only in the MV3 service worker's memory. A worker restart destroyed every request descriptor while the approval windows they describe were still on screen and still signable.

Four things broke at once:

- **Cancel-on-close.** `cancelRequestsDisplacedBy` selects from `selectOpenRequests`; with no descriptor there is nothing to select, so closing the window told the dapp nothing and its promise hung to the SDK's own 30-minute timeout.
- **Response dedup.** `markRequestResponded` early-returns *before* dispatching when the descriptor is missing, so a genuine post-restart response left **no tombstone at all** — every later response for that id also passed the guard.
- **Supersede.** Two losses, not one: no descriptor to displace, and `windowManagement.windowId` is gone too, so `createOpenWindow` never enters its reuse branch and the next approval opens a *second* window.
- **`awaitingDeviceConfirmation`.** The WALLET-1394 guard that keeps a window out of reuse during a Ledger confirmation silently re-armed — the flag is announced once at bracket start and never re-sent.

### The fix

`{ requests, windowId }` is mirrored into `chrome.storage.session` and hydrated in the `get-main-store.ts` preload.

**Why `storage.session`.** It is in-memory, survives a worker restart, and is cleared when the browser closes or the extension reloads — exactly the lifetime a request descriptor wants. That is why there is no purge, no session marker and no TTL: nothing can outlive the session it belongs to. It also keeps dapp origins and tab ids off disk, and stops browser-session-scoped window/tab ids from ever being read back in a session that has reassigned them.

**Why the preload and not a saga.** The event that wakes a dead worker is often the approval window closing itself. `windows.onRemoved` awaits store init and then reads `selectOpenRequests` **synchronously**, so a saga's first `await` is already too late — and a window-URL rebuild is worse still, since the window whose close woke the worker is by then gone from `windows.getAll`. The preload reads the session area alongside the existing `storage.local.get`, so the map is present the moment the store exists and no handler can observe it empty.

### Details worth a reviewer's attention

- **The write is a separate call to a separate area with its own catch** — never a field in the twelve-key `storage.local.set`. That call also writes `VAULT_CIPHER_KEY`, and `requestId` is dapp-chosen with no length bound anywhere, so sharing the write would let a page fail the vault persist.
- **Rows are capped on the write side; the read is uncapped.** This leaves no read-side drop order for integer-key hoisting to decide.
- **A rejected write removes the key.** An absent mirror behaves exactly like today; a stale one can pin a request open for the whole browser session. Writes are serialised so an older snapshot cannot land after a newer one, and the flush never rejects — a rejection would poison the chain for every later write.
- **`createStore(preloadedState)` bypasses every case reducer**, so the restored map is validated by a *total* sanitizer that drops what it cannot vouch for rather than throwing. A throw here would leave the background unable to start at all.
- **The subscriber guard compares the `(requests, windowId)` pair, not the slice reference** — four case reducers return a fresh object for a value-equal write.
- **Chrome and Edge only**, behind a build-time predicate *and* a runtime detect. Firefox and Safari declare `"persistent": true`, so their background page never dies and the mirror would be a live untested path there. The runtime half is still needed because `@types/webextension-polyfill` declares `storage.session` **non-optional** even where it does not exist.
- `isEphemeralBackgroundBuild` is byte-identical in expression to `isLedgerAvailable`. Deliberate — two different concepts that happen to coincide today.
- The subscriber's `.catch` on the mirror write is unreachable by construction (the flush never rejects). It is there because the write must not be able to take anything else down with it; flagging it so it is not read as dead code.

### Verification

- `npx jest src/background/` — 62 suites, 786 tests pass. `npx tsc --noEmit` clean. `knip` clean.
- `windowManagement/reducer.ts` stays at 100% coverage; `src/background/handlers/` stays above its floor.
- **The jest trap was mutation-checked.** `isEphemeralBackgroundBuild` is `false` under jest (`npm test` sets no `BROWSER`, DefinePlugin is webpack-only), so an unmocked test would exercise the *disabled* path and pass while asserting nothing. Flipping the mock to `false` fails 31 of 42 session-store tests and 2 get-main-store tests — the tests really do run the enabled path.
- **A new e2e locks in the close-as-wake ordering** (second commit): the worker is stopped, the approval window is closed programmatically, and the dapp must settle with a cancel inside 15s. Verified to **fail** without the fix — with the gate off it times out on exactly that assertion, not on a setup step. It cannot live in the popup suite, which runs under `MOCK_STATE` and short-circuits the session read.

### Not in this PR

The startup sweep, the open-request cap, and the wallet-reset fix are deliberately separate — they are compensating mechanisms with their own risk, and this change stands on its own without them. `frameId` (#1484, since merged) is carried in the mirrored record and sanitized on hydration: `Number.isInteger` only, optional — `0` (the top frame) is preserved verbatim, a malformed value drops the field but keeps the row.

## Linked tickets

[WALLET-1419](https://make-software.atlassian.net/browse/WALLET-1419)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [x] If the PR adds any new text to the UI, make sure they are localized — no UI text added

- [x] Include a screenshot or recording if implementing significant UI or user flow change — background-only, no UI change

- [ ] When this PR affects architecture changes wait for review from Dmytro before merging


[WALLET-1419]: https://make-software.atlassian.net/browse/WALLET-1419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
