### PR TITLE
docs(background): reframe MV3-restart fallbacks as residual paths

### DIFF
--- a/src/background/handlers/close-windows-on-response.test.ts
+++ b/src/background/handlers/close-windows-on-response.test.ts
@@ -537,7 +537,7 @@ describe('handleSdkResponseToTab (WALLET-1416 wiring)', () => {
     expect(removeMock).not.toHaveBeenCalled();
   });
 
-  it('after an MV3 restart it delivers and closes nothing', async () => {
+  it('with no descriptor ever registered it delivers and closes nothing', async () => {
     const store = makeRealStore();
     store.dispatch(
       ledgerNewWindowIdChanged({

--- a/src/background/handlers/deliver-via-origin.ts
+++ b/src/background/handlers/deliver-via-origin.ts
@@ -23,7 +23,8 @@ export async function deliverViaOrigin(
   // wrong one is both a leak and a loss. Only frame 0 is the same frame in
   // every tab, and the origin match already established that tab's top
   // document belongs to the dapp — so a non-zero frameId must not broadcast.
-  // `undefined` (no descriptor — MV3-restart path) keeps broadcasting unscoped.
+  // `undefined` (no descriptor — one of the residual descriptor-less paths)
+  // keeps broadcasting unscoped.
   if (frameId != null && frameId !== 0) {
     console.error(
       'deliverViaOrigin: sub-frame response not broadcast — no other tab can be matched to it',

--- a/src/background/handlers/sdk-response-to-tab.test.ts
+++ b/src/background/handlers/sdk-response-to-tab.test.ts
@@ -686,11 +686,11 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
     expect(dispatch).not.toHaveBeenCalled();
   });
 
-  it('no descriptor (service worker restarted) → still delivers, dispatches nothing', async () => {
+  it('no descriptor (residual descriptor-less path) → still delivers, dispatches nothing', async () => {
     // Every approval-window url carries `?origin=` (all six flows build it), so
-    // a restart can still be verified against the live tab. `UI_SENDER` without
-    // one is a synthetic sender no page produces — the fail-closed case it now
-    // exercises has its own test above.
+    // a descriptor-less response can still be verified against the live tab.
+    // `UI_SENDER` without one is a synthetic sender no page produces — the
+    // fail-closed case it now exercises has its own test above.
     const { store, dispatch } = makeStore(undefined);
 
     const result = await handleSdkResponseToTab(
@@ -808,7 +808,8 @@ describe('handleSdkResponseToTab (background dedupe of SDK responses)', () => {
   });
 
   it('withholds the response when no origin can be established', async () => {
-    // No descriptor (MV3 restart) AND a sender url with no ?origin= param.
+    // No descriptor (a residual descriptor-less path) AND a sender url with
+    // no ?origin= param.
     const { store, dispatch } = makeStore();
 
     await handleSdkResponseToTab(makeMessage(), UI_SENDER, store);

--- a/src/background/handlers/sdk-response-to-tab.ts
+++ b/src/background/handlers/sdk-response-to-tab.ts
@@ -176,10 +176,10 @@ export async function handleSdkResponseToTab(
       ? selectOpenRequest(store.getState(), requestId)
       : undefined;
 
-  // An MV3 service-worker restart empties the requests map while the approval
-  // window lives on, so a legitimate response can arrive with no descriptor at
-  // all. The window url still carries `?origin=`, so fall back to that rather
-  // than dropping a signature the user just produced.
+  // The requests map is mirrored across an MV3 restart now, but residual
+  // paths (a lost mirror write, a sanitizer-dropped row) can still leave the
+  // approval window open with no descriptor. Fall back to the window url's
+  // `?origin=` rather than dropping a signature the user just produced.
   const expectedOrigin = request?.origin ?? recoverDappOrigin(sender.url);
   const frameId = request?.frameId;
 

--- a/src/background/redux/get-main-store.ts
+++ b/src/background/redux/get-main-store.ts
@@ -132,9 +132,11 @@ export async function getExistingMainStoreSingletonOrInit() {
             : undefined,
           trustedWasm,
           csprNameExpirations,
-          // Present before any handler can run: `windowManagement.requests`
-          // lives only in the worker's memory, and an MV3 restart destroys it
-          // while the approval windows it describes are still on screen.
+          // Present before any handler can run: on Chrome/Edge `requestSession`
+          // is the session mirror, rehydrating `windowManagement.requests`
+          // across an MV3 restart (residual paths aside — a lost mirror write,
+          // a sanitizer-dropped row); on Firefox/Safari's persistent background
+          // page it is always the empty record, since nothing there restarts.
           windowManagement: {
             windowId: requestSession.windowId,
             exportKeysWindowId: null,

--- a/src/background/redux/sagas/vault-sagas.test.ts
+++ b/src/background/redux/sagas/vault-sagas.test.ts
@@ -740,9 +740,9 @@ describe('reconcileStalePayloadsSaga', () => {
   const vaultOf = (storeState: unknown) =>
     (storeState as { vault: VaultState }).vault;
 
-  // The window half of the keep-set. `windowManagement.requests` is not
-  // persisted, so after a service-worker restart the descriptor is gone while
-  // the window is still on screen and still signable.
+  // The window half of the keep-set. On a residual descriptor-less path (a
+  // lost mirror write, a sanitizer-dropped row, etc.) the descriptor is gone
+  // while the window is still on screen and still signable.
   it('keeps a payload whose requestId appears in an open window tab URL, with no descriptor in the store', async () => {
     mockWindowsGetAll.mockResolvedValue([
       { id: 1, tabs: [{ url: approvalWindowUrl('live-1') }] }

--- a/src/background/redux/sagas/vault-sagas.ts
+++ b/src/background/redux/sagas/vault-sagas.ts
@@ -516,9 +516,10 @@ export function* reconcileStalePayloadsSaga() {
     const openRequests = yield* sagaSelect(selectOpenRequests);
     const vault = yield* sagaSelect(selectVault);
 
-    // Both halves are needed. After a service-worker restart the descriptors
-    // are gone while the window still shows its `?requestId=`; on window reuse
-    // a live window still reports the previous request's URL mid-navigation.
+    // Both halves are needed. On a residual descriptor-less path the
+    // descriptors are gone while the window still shows its `?requestId=`;
+    // on window reuse a live window still reports the previous request's
+    // URL mid-navigation.
     const keep = new Set(liveIdsFromWindows);
 
     for (const { requestId } of openRequests) {

--- a/src/background/redux/vault/reducer.ts
+++ b/src/background/redux/vault/reducer.ts
@@ -727,8 +727,9 @@ const slice = createSlice({
   // paths funnels through `windowRequestResponded`.
   //
   // Keyed off the ACTION, not off `windowManagement`'s resulting state: that
-  // reducer no-ops the transition unless the request is currently 'open', which
-  // is exactly the orphan case (an MV3 restart between registration and the
+  // reducer no-ops the transition unless the request is currently 'open',
+  // which is exactly one of the residual descriptor-less paths (a lost mirror
+  // write, a sanitizer-dropped row, etc., between registration and the
   // response) where a stale payload most needs dropping.
   extraReducers: builder => {
     builder.addCase(

--- a/src/background/redux/windowManagement/reducer.test.ts
+++ b/src/background/redux/windowManagement/reducer.test.ts
@@ -392,10 +392,10 @@ describe('windowManagement requests', () => {
     // Its two siblings refuse to act on a missing or wrong-status entry; this
     // one wrote unconditionally, so the union modelled ∅ → open → responded
     // while the reducer permitted ∅ → responded. Reachable whenever the UI
-    // forwards a response for an id the store no longer has — an MV3
-    // service-worker restart between registration and the response — and the
-    // orphan then consumes a slot in the tombstone cap and makes the SDK entry
-    // guard reject that id as a duplicate.
+    // forwards a response for an id the store no longer has — one of the
+    // residual descriptor-less paths — and the orphan then consumes a slot in
+    // the tombstone cap and makes the SDK entry guard reject that id as a
+    // duplicate.
     it('refuses to tombstone a requestId that was never registered', () => {
       const next = reducer(
         empty,
@@ -417,12 +417,13 @@ describe('windowManagement requests', () => {
 
   describe('tombstone eviction', () => {
     it('caps the responded entries instead of growing for the whole session', () => {
-      // Nothing ever deleted a key. On MV3 a service-worker restart eventually
-      // wiped the map, but `manifest.v2.json` and `manifest.v2.safari.json`
-      // both declare `"persistent": true` — on Firefox and Safari the
-      // background page is never torn down, so this grew by one permanent
-      // entry per request, keyed by a dapp-supplied string, for the entire
-      // browser session.
+      // Nothing ever deleted a key. Before the session mirror, an MV3
+      // service-worker restart eventually wiped the map; now Chrome/Edge
+      // tombstones survive it too (residual paths aside). But
+      // `manifest.v2.json` and `manifest.v2.safari.json` both declare
+      // `"persistent": true` — on Firefox and Safari the background page is
+      // never torn down, so this grows by one permanent entry per request,
+      // keyed by a dapp-supplied string, for the entire browser session.
       let state = empty;
       for (let i = 0; i < MAX_RESPONDED_TOMBSTONES + 10; i++) {
         state = reducer(state, opened(`r${i}`));

--- a/src/background/redux/windowManagement/reducer.ts
+++ b/src/background/redux/windowManagement/reducer.ts
@@ -170,16 +170,15 @@ const slice = createSlice({
     },
     // The tombstone is deliberately kept: `selectRequestStatus` reading back
     // 'responded' is what makes the background dedup drop a duplicate response.
-    // It is in-memory only, but "in-memory" bounds nothing by itself: on MV3 a
-    // service-worker restart wipes it (after which a late duplicate is no
-    // longer deduped), while `manifest.v2.json` and `manifest.v2.safari.json`
-    // both declare `"persistent": true`, so on Firefox and Safari the
-    // background page is never torn down. Nothing here deleted a key, so on
-    // those two targets the map grew by one permanent entry per request —
-    // keyed by a dapp-supplied string — for the whole browser session. Hence
-    // the FIFO cap below: the descriptor is dropped as before, and the oldest
-    // tombstones are evicted once there are more than a dedup could plausibly
-    // need. Open requests are never evicted.
+    // On Chrome/Edge the session mirror now survives a service-worker restart
+    // (residual paths aside), so "in-memory" no longer bounds it there either.
+    // `manifest.v2.json` and `manifest.v2.safari.json` both declare
+    // `"persistent": true`, so on Firefox and Safari the background page is
+    // never torn down and nothing here deletes a key — the map grows by one
+    // permanent entry per request, keyed by a dapp-supplied string, for the
+    // whole browser session. Hence the FIFO cap below: the descriptor is
+    // dropped as before, and the oldest tombstones are evicted once there are
+    // more than a dedup could plausibly need. Open requests are never evicted.
     windowRequestResponded: (
       state,
       action: PayloadAction<{ requestId: string }>
@@ -188,9 +187,9 @@ const slice = createSlice({
       // Only a request that is currently 'open' can become 'responded'; the
       // union models ∅ → open → responded and this is what stops the reducer
       // permitting ∅ → responded. Without it, a response the UI forwards for an
-      // id the store no longer holds (an MV3 restart between registration and
-      // the response) wrote an orphan tombstone that consumed a slot in the cap
-      // below and made the SDK entry guard reject that id as a duplicate.
+      // id the store no longer holds (one of the residual descriptor-less
+      // paths) wrote an orphan tombstone that consumed a slot in the cap below
+      // and made the SDK entry guard reject that id as a duplicate.
       const request = getRequest(state.requests, action.payload.requestId);
 
       if (request?.status !== 'open') {


### PR DESCRIPTION
## Description

Comment and test-name work only — `git diff` contains no executable-code changes.

The session mirror (previous PR in this stack) makes an MV3 service-worker restart no longer empty `windowManagement.requests` in the ordinary case on Chrome/Edge. Several comments still described that restart as the _primary_ reason a request descriptor can be missing while its approval window is on screen. After the mirror it is a residual reason: a mirror write lost in flight, a row the hydration sanitizer dropped, the deliberate remove-on-rejected-write, an open row dropped by the write cap during a burst, or an approval window surviving a wallet reset. (Firefox and Safari declare `"persistent": true` and never had the restart problem; the mirror is deliberately not active there.)

### What changed

- `sdk-response-to-tab.ts` — the comment above the `request?.origin ?? recoverDappOrigin(sender.url)` fallback now frames it as covering the residual descriptor-less paths. **The fallback itself is kept** — it is load-bearing for exactly those residues.
- `deliver-via-origin.ts` — same rewording for the unscoped-broadcast note.
- `windowManagement/reducer.ts` — two blocks: the tombstone-cap rationale (the Firefox/Safari growth story that justifies the FIFO cap is unchanged and stays; only the "a restart wipes the map" half is retired) and the `windowRequestResponded` transition-guard trigger.
- `vault-sagas.ts` — the saga-body justification for the window-URL half of `reconcileStalePayloadsSaga`'s keep set now rests on the residual paths, not on restarts. The `reconcileStalePayloadsSaga` doc block is deliberately untouched: its stranding story concerns the vault's own payload map (`jsonById`/`eip712ById`), which is not mirrored, and nothing in it became stale.
- Test comments/names that documented the old framing were re-framed onto the state they actually set up ("no descriptor registered"), in `sdk-response-to-tab.test.ts`, `reducer.test.ts`, and `close-windows-on-response.test.ts`. **Every assertion is unchanged.**

### Verification

- `npx jest src/background/handlers/ src/background/redux/windowManagement/ src/background/redux/sagas/` — 29 suites, 537 tests pass (count unchanged from base).
- `npx tsc --noEmit`, eslint and prettier clean on all touched files.
- Zero-behaviour-change reviewed hunk by hunk: every changed line is a comment line or a test-name string.

## Linked tickets

[WALLET-1419](https://make-software.atlassian.net/browse/WALLET-1419)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [x] If the PR adds any new text to the UI, make sure they are localized — no UI text added

- [x] Include a screenshot or recording if implementing significant UI or user flow change — comment-only, no UI change

- [ ] When this PR affects architecture changes wait for review from Dmytro before merging


[WALLET-1419]: https://make-software.atlassian.net/browse/WALLET-1419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ