### PR TITLE
fix(background): sweep orphaned request rows after a worker restart

### DIFF
--- a/src/background/create-open-window.ts
+++ b/src/background/create-open-window.ts
@@ -14,7 +14,7 @@ export enum WindowApp {
 
 export type WindowSearchParams = Record<string, string>;
 
-function getUrlByWindowApp(
+export function getUrlByWindowApp(
   windowApp: WindowApp,
   searchParams?: WindowSearchParams
 ) {

--- a/src/background/handlers/cancel-requests.ts
+++ b/src/background/handlers/cancel-requests.ts
@@ -202,8 +202,11 @@ export async function cancelRequestsDisplacedBy(
 // (spec §8.1). Without this the dapp promise hangs until its own timeout
 // (30 min by default).
 //
-// `source` defaults to the original trigger so every existing call site keeps
-// its behaviour unchanged. It doubles as the banner policy: only
+// `source` defaults to the original trigger so the `open-window-failed` call
+// site keeps its BANNER policy unchanged — its delivery does not: #1484's
+// stale-tab check below applies to every source alike, so that call site's
+// delivery is deliberately narrowed too, same as the sweep's. `source` doubles
+// as the banner policy: only
 // `'open-window-failed'` dispatches `sagaError` (a `windows.create` failure is
 // the wallet's own doing, with nothing else to tell the user). Every other
 // source — today just the sweep — is dapp-triggerable and console-only,
@@ -238,14 +241,21 @@ export async function failRequestOnWindowError(
   // the TOP document's origin, so only a top-frame request (no `frameId`, or
   // `0`) is checkable this way; a sub-frame request goes straight to the
   // frame-targeted send, same as today.
-  const staleOrigin =
-    (frameId == null || frameId === 0) &&
-    (await getLiveTabOrigin(tabId)) !== origin;
+  const isTopFrame = frameId == null || frameId === 0;
+  const liveOrigin = isTopFrame ? await getLiveTabOrigin(tabId) : undefined;
+  const staleOrigin = isTopFrame && liveOrigin !== origin;
 
   let delivered = 1;
 
   if (staleOrigin) {
     delivered = await deliverViaOrigin(origin, action, frameId);
+
+    // Identifiers and origins only, matching sdk-response-to-tab's withheld-
+    // response log — never a URL.
+    console.error(
+      `${source}: target tab no longer hosts the requesting origin; response withheld`,
+      { requestId, tabId, expectedOrigin: origin, liveOrigin, delivered }
+    );
   } else {
     try {
       await (frameId == null
@@ -265,6 +275,9 @@ export async function failRequestOnWindowError(
     }
   }
 
+  // The sweep (source === 'sweep-orphaned-requests') knowingly shares this
+  // same tombstone-before-delivery ordering — an accepted residual, not an
+  // oversight specific to the sweep.
   if (source !== 'open-window-failed') {
     console[delivered > 0 ? 'warn' : 'error'](
       `${source}: cancelled an orphaned request`,

--- a/src/background/handlers/cancel-requests.ts
+++ b/src/background/handlers/cancel-requests.ts
@@ -1,8 +1,9 @@
 import { tabs } from 'webextension-polyfill';
 
+import { redactUrlQuery } from '@background/redact-url-query';
 import { sagaError } from '@background/redux/app-events/actions';
 import { SagaErrorSource } from '@background/redux/app-events/types';
-import { MainStore } from '@background/redux/get-main-store';
+import type { MainStore } from '@background/redux/get-main-store';
 import {
   windowDetachedFromRequests,
   windowRequestResponded
@@ -16,6 +17,7 @@ import {
 import { SdkMethod, sdkMethod } from '@content/sdk-method';
 
 import { deliverViaOrigin } from './deliver-via-origin';
+import { getLiveTabOrigin } from './tab-origin';
 
 // Grace before cancelling an abandoned request: lets an in-flight genuine
 // response (a button response, or a Ledger success cleanup that closes this
@@ -28,9 +30,10 @@ const delay = (ms: number) =>
 // The window-driven cancel paths only. Derived from `SagaErrorSource` rather
 // than spelled out again, so the two can never drift — a `source` this module
 // dispatches is by construction one the banner reader knows.
-// `'open-window-failed'` is deliberately NOT here: it is produced by
-// `failRequestOnWindowError`, which is a separate trigger with no grace and no
-// window event behind it.
+// Neither `'open-window-failed'` nor `'sweep-orphaned-requests'` is here: both
+// are produced by `failRequestOnWindowError`, a separate trigger with no
+// window event behind it — and only the first of the two banners at all (see
+// its `source` parameter below).
 export type CancelSource = Extract<
   SagaErrorSource,
   'cancel-on-close' | 'cancel-on-supersede'
@@ -193,12 +196,26 @@ export async function cancelRequestsDisplacedBy(
   await cancelRequests(store, candidates, source, windowId, afterMark);
 }
 
-// `windows.create` rejected, so no window will ever display this request and no
-// `windows.onRemoved` will ever fire for it. Without this the dapp promise hangs
-// until its own timeout (30 min by default).
+// The trigger with no window event behind it — either `windows.create`
+// rejected (no `windows.onRemoved` will ever fire for a window that never
+// existed) or the startup sweep decided a hydrated 'open' row is orphaned
+// (spec §8.1). Without this the dapp promise hangs until its own timeout
+// (30 min by default).
+//
+// `source` defaults to the original trigger so every existing call site keeps
+// its behaviour unchanged. It doubles as the banner policy: only
+// `'open-window-failed'` dispatches `sagaError` (a `windows.create` failure is
+// the wallet's own doing, with nothing else to tell the user). Every other
+// source — today just the sweep — is dapp-triggerable and console-only,
+// matching the precedent in `sdk-methods.ts`'s `reportCapacityRefusal`: a
+// banner mounted route-independently over every approval screen must not
+// fire for a request the user cannot act on, and in close-as-wake the sweep's
+// enumeration resolves inside another cancel's own grace, so it would often
+// paint over an ordinary close or a live signing prompt.
 export async function failRequestOnWindowError(
   store: MainStore,
-  requestId: string
+  requestId: string,
+  source: SagaErrorSource = 'open-window-failed'
 ): Promise<void> {
   const request = selectOpenRequests(store.getState()).find(
     openRequest => openRequest.requestId === requestId
@@ -210,17 +227,50 @@ export async function failRequestOnWindowError(
 
   store.dispatch(windowRequestResponded({ requestId }));
 
-  const action = buildCancelResponse(request.method, requestId);
+  const { tabId, origin, method, frameId } = request;
+  const action = buildCancelResponse(method, requestId);
+
+  // #1484: verify the tab still hosts the requesting origin BEFORE sending.
+  // On a navigated-away tab `tabs.sendMessage` SUCCEEDS (the content script is
+  // injected on every http(s) page), so the catch → `deliverViaOrigin`
+  // fallback below would never fire — a swept row can be arbitrarily old, so
+  // navigated-away is the expected case, not the exception. `tabs.get` reports
+  // the TOP document's origin, so only a top-frame request (no `frameId`, or
+  // `0`) is checkable this way; a sub-frame request goes straight to the
+  // frame-targeted send, same as today.
+  const staleOrigin =
+    (frameId == null || frameId === 0) &&
+    (await getLiveTabOrigin(tabId)) !== origin;
+
   let delivered = 1;
-  try {
-    await tabs.sendMessage(request.tabId, action);
-  } catch (error) {
-    console.error(
-      'open-window-failed: cancel delivery failed',
-      { requestId, method: request.method, tabId: request.tabId },
-      error
+
+  if (staleOrigin) {
+    delivered = await deliverViaOrigin(origin, action, frameId);
+  } else {
+    try {
+      await (frameId == null
+        ? tabs.sendMessage(tabId, action)
+        : tabs.sendMessage(tabId, action, { frameId }));
+    } catch (error) {
+      // Never the raw error: a `tabs.sendMessage` rejection can echo back a
+      // navigated-away tab's URL, and one of this window's own URLs carries a
+      // signMessage request's plaintext message as a query param.
+      console.error(`${source}: cancel delivery failed`, {
+        requestId,
+        method,
+        tabId,
+        error: redactUrlQuery(error)
+      });
+      delivered = await deliverViaOrigin(origin, action, frameId);
+    }
+  }
+
+  if (source !== 'open-window-failed') {
+    console[delivered > 0 ? 'warn' : 'error'](
+      `${source}: cancelled an orphaned request`,
+      { requestId, tabId, delivered }
     );
-    delivered = await deliverViaOrigin(request.origin, action);
+    return;
   }
 
   // Dispatched AFTER the delivery attempt so the message can tell the truth.
@@ -230,7 +280,7 @@ export async function failRequestOnWindowError(
   // request was cancelled" there would be a lie the user cannot act on.
   store.dispatch(
     sagaError({
-      source: 'open-window-failed',
+      source,
       message:
         delivered > 0
           ? 'Approval window could not be opened; the request was cancelled'

--- a/src/background/handlers/fail-request-on-window-error.test.ts
+++ b/src/background/handlers/fail-request-on-window-error.test.ts
@@ -6,16 +6,17 @@ import { failRequestOnWindowError } from './cancel-requests';
 import { deliverViaOrigin } from './deliver-via-origin';
 
 jest.mock('webextension-polyfill', () => ({
-  tabs: { sendMessage: jest.fn() }
+  tabs: { sendMessage: jest.fn(), get: jest.fn() }
 }));
 jest.mock('./deliver-via-origin', () => ({ deliverViaOrigin: jest.fn() }));
 
-const open = (tabId: number, method = 'sign') => ({
+const open = (tabId: number, method = 'sign', frameId?: number) => ({
   status: 'open',
   tabId,
   origin: 'https://dapp',
   method,
-  windowIds: []
+  windowIds: [],
+  ...(frameId === undefined ? {} : { frameId })
 });
 
 const state = (requests: any) => ({
@@ -25,6 +26,9 @@ const state = (requests: any) => ({
 beforeEach(() => {
   jest.clearAllMocks();
   (tabs.sendMessage as jest.Mock).mockResolvedValue(undefined);
+  // Origin matches `open()`'s by default, so the direct-send branch runs
+  // unless a test deliberately makes the tab look navigated-away.
+  (tabs.get as jest.Mock).mockResolvedValue({ url: 'https://dapp/page' });
   (deliverViaOrigin as jest.Mock).mockResolvedValue(0);
 });
 
@@ -79,7 +83,8 @@ it('tabs.sendMessage rejects → falls back to deliverViaOrigin', async () => {
 
   expect(deliverViaOrigin).toHaveBeenCalledWith(
     'https://dapp',
-    sdkMethod.signResponse({ cancelled: true }, { requestId: 'r1' })
+    sdkMethod.signResponse({ cancelled: true }, { requestId: 'r1' }),
+    undefined
   );
 });
 
@@ -127,4 +132,182 @@ it('already-answered requestId (tombstoned) → clean no-op, nothing dispatched,
   expect(dispatch).not.toHaveBeenCalled();
   expect(tabs.sendMessage).not.toHaveBeenCalled();
   expect(deliverViaOrigin).not.toHaveBeenCalled();
+});
+
+describe('#1484 origin check (inside the vehicle)', () => {
+  it('a navigated-away tab gets deliverViaOrigin, not a direct send', async () => {
+    (tabs.get as jest.Mock).mockResolvedValue({
+      url: 'https://elsewhere/page'
+    });
+    const dispatch = jest.fn();
+    const getState = jest.fn().mockReturnValue(state({ r1: open(3, 'sign') }));
+
+    await failRequestOnWindowError({ dispatch, getState } as any, 'r1');
+
+    expect(tabs.sendMessage).not.toHaveBeenCalled();
+    expect(deliverViaOrigin).toHaveBeenCalledWith(
+      'https://dapp',
+      sdkMethod.signResponse({ cancelled: true }, { requestId: 'r1' }),
+      undefined
+    );
+  });
+
+  it('an unresolvable live origin (tab gone) also routes via deliverViaOrigin', async () => {
+    (tabs.get as jest.Mock).mockRejectedValue(new Error('No tab'));
+    const dispatch = jest.fn();
+    const getState = jest.fn().mockReturnValue(state({ r1: open(3, 'sign') }));
+
+    await failRequestOnWindowError({ dispatch, getState } as any, 'r1');
+
+    expect(tabs.sendMessage).not.toHaveBeenCalled();
+    expect(deliverViaOrigin).toHaveBeenCalled();
+  });
+
+  it('a sub-frame request skips the origin check and sends frame-targeted, even on a mismatched top origin', async () => {
+    (tabs.get as jest.Mock).mockResolvedValue({
+      url: 'https://elsewhere/page'
+    });
+    const dispatch = jest.fn();
+    const getState = jest
+      .fn()
+      .mockReturnValue(state({ r1: open(3, 'sign', 5) }));
+
+    await failRequestOnWindowError({ dispatch, getState } as any, 'r1');
+
+    expect(tabs.get).not.toHaveBeenCalled();
+    expect(tabs.sendMessage).toHaveBeenCalledWith(
+      3,
+      sdkMethod.signResponse({ cancelled: true }, { requestId: 'r1' }),
+      { frameId: 5 }
+    );
+  });
+
+  it('a top-frame request (frameId 0) is still origin-checked', async () => {
+    (tabs.get as jest.Mock).mockResolvedValue({
+      url: 'https://elsewhere/page'
+    });
+    const dispatch = jest.fn();
+    const getState = jest
+      .fn()
+      .mockReturnValue(state({ r1: open(3, 'sign', 0) }));
+
+    await failRequestOnWindowError({ dispatch, getState } as any, 'r1');
+
+    expect(tabs.sendMessage).not.toHaveBeenCalled();
+    expect(deliverViaOrigin).toHaveBeenCalledWith(
+      'https://dapp',
+      sdkMethod.signResponse({ cancelled: true }, { requestId: 'r1' }),
+      0
+    );
+  });
+});
+
+describe('policy parameter (source)', () => {
+  it('explicit "open-window-failed" source matches the implicit default', async () => {
+    (tabs.sendMessage as jest.Mock).mockRejectedValue(new Error('tab gone'));
+    (deliverViaOrigin as jest.Mock).mockResolvedValue(0);
+    const dispatch = jest.fn();
+    const getState = jest.fn().mockReturnValue(state({ r1: open(3, 'sign') }));
+
+    await failRequestOnWindowError(
+      { dispatch, getState } as any,
+      'r1',
+      'open-window-failed'
+    );
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'appEvents/sagaError',
+        payload: expect.objectContaining({ source: 'open-window-failed' })
+      })
+    );
+  });
+
+  it('banner is suppressed for a non-open-window-failed source (console-only)', async () => {
+    const consoleWarn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+    const dispatch = jest.fn();
+    const getState = jest.fn().mockReturnValue(state({ r1: open(3, 'sign') }));
+
+    await failRequestOnWindowError(
+      { dispatch, getState } as any,
+      'r1',
+      'sweep-orphaned-requests'
+    );
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'windowManagement/windowRequestResponded'
+      })
+    );
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'appEvents/sagaError' })
+    );
+    expect(consoleWarn).toHaveBeenCalled();
+    consoleWarn.mockRestore();
+  });
+
+  it('a suppressed-source delivery failure logs at error level, not warn', async () => {
+    (tabs.sendMessage as jest.Mock).mockRejectedValue(new Error('tab gone'));
+    (deliverViaOrigin as jest.Mock).mockResolvedValue(0);
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const dispatch = jest.fn();
+    const getState = jest.fn().mockReturnValue(state({ r1: open(3, 'sign') }));
+
+    await failRequestOnWindowError(
+      { dispatch, getState } as any,
+      'r1',
+      'sweep-orphaned-requests'
+    );
+
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'appEvents/sagaError' })
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('sweep-orphaned-requests'),
+      expect.anything()
+    );
+    consoleError.mockRestore();
+  });
+});
+
+it('never logs a raw URL or a raw Error — only redacted identifiers appear across any log line', async () => {
+  // The rejection itself echoes the URL back, the way a real `tabs.sendMessage`
+  // rejection can (`Could not establish connection` etc. sometimes quote the
+  // target). If the vehicle ever logs this Error object directly instead of
+  // `redactUrlQuery(error)`, `JSON.stringify` on a bare Error argument would
+  // render `{}` and hide the leak from a whole-array serialization — so this
+  // walks each logged argument individually instead.
+  (tabs.sendMessage as jest.Mock).mockRejectedValue(
+    new Error('tab gone: https://dapp/page?message=super-secret&x=1')
+  );
+  (deliverViaOrigin as jest.Mock).mockResolvedValue(0);
+  (tabs.get as jest.Mock).mockResolvedValue({
+    url: 'https://dapp/page?message=super-secret&x=1'
+  });
+  const consoleError = jest
+    .spyOn(console, 'error')
+    .mockImplementation(() => {});
+  const dispatch = jest.fn();
+  const getState = jest.fn().mockReturnValue(state({ r1: open(3, 'sign') }));
+
+  await failRequestOnWindowError({ dispatch, getState } as any, 'r1');
+
+  expect(consoleError).toHaveBeenCalled();
+
+  for (const call of consoleError.mock.calls) {
+    for (const arg of call) {
+      // A raw Error instance is refused outright: it would carry whatever the
+      // rejection embedded, un-redacted, past this check entirely.
+      expect(arg).not.toBeInstanceOf(Error);
+
+      const text = typeof arg === 'string' ? arg : JSON.stringify(arg);
+      expect(text).not.toContain('super-secret');
+      expect(text).not.toMatch(/\?[^"]*=/);
+    }
+  }
+  consoleError.mockRestore();
 });

--- a/src/background/handlers/fail-request-on-window-error.test.ts
+++ b/src/background/handlers/fail-request-on-window-error.test.ts
@@ -304,6 +304,18 @@ it('never logs a raw URL or a raw Error — only redacted identifiers appear acr
       // rejection embedded, un-redacted, past this check entirely.
       expect(arg).not.toBeInstanceOf(Error);
 
+      // `JSON.stringify` alone would miss a surgical revert of
+      // `error: redactUrlQuery(error)` back to `error: error` inside the
+      // object argument: `Error#message` is a non-enumerable own property, so
+      // stringifying a raw Error renders `{}` and the secret text check below
+      // would pass right past it. Walk every object argument's own values
+      // directly instead of trusting the serialization to surface them.
+      if (typeof arg === 'object' && arg != null) {
+        for (const value of Object.values(arg)) {
+          expect(value).not.toBeInstanceOf(Error);
+        }
+      }
+
       const text = typeof arg === 'string' ? arg : JSON.stringify(arg);
       expect(text).not.toContain('super-secret');
       expect(text).not.toMatch(/\?[^"]*=/);

--- a/src/background/handlers/fail-request-on-window-error.test.ts
+++ b/src/background/handlers/fail-request-on-window-error.test.ts
@@ -135,10 +135,14 @@ it('already-answered requestId (tombstoned) → clean no-op, nothing dispatched,
 });
 
 describe('#1484 origin check (inside the vehicle)', () => {
-  it('a navigated-away tab gets deliverViaOrigin, not a direct send', async () => {
+  it('a navigated-away tab gets deliverViaOrigin, not a direct send, and logs identifiers + origins only', async () => {
     (tabs.get as jest.Mock).mockResolvedValue({
       url: 'https://elsewhere/page'
     });
+    (deliverViaOrigin as jest.Mock).mockResolvedValue(1);
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
     const dispatch = jest.fn();
     const getState = jest.fn().mockReturnValue(state({ r1: open(3, 'sign') }));
 
@@ -150,6 +154,20 @@ describe('#1484 origin check (inside the vehicle)', () => {
       sdkMethod.signResponse({ cancelled: true }, { requestId: 'r1' }),
       undefined
     );
+    // Identifiers and origins only — never the tab's URL (`https://elsewhere/page`).
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('response withheld'),
+      {
+        requestId: 'r1',
+        tabId: 3,
+        expectedOrigin: 'https://dapp',
+        liveOrigin: 'https://elsewhere',
+        delivered: 1
+      }
+    );
+    const logged = JSON.stringify(consoleError.mock.calls);
+    expect(logged).not.toContain('/page');
+    consoleError.mockRestore();
   });
 
   it('an unresolvable live origin (tab gone) also routes via deliverViaOrigin', async () => {
@@ -227,6 +245,9 @@ describe('policy parameter (source)', () => {
     const consoleWarn = jest
       .spyOn(console, 'warn')
       .mockImplementation(() => {});
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
     const dispatch = jest.fn();
     const getState = jest.fn().mockReturnValue(state({ r1: open(3, 'sign') }));
 
@@ -245,7 +266,11 @@ describe('policy parameter (source)', () => {
       expect.objectContaining({ type: 'appEvents/sagaError' })
     );
     expect(consoleWarn).toHaveBeenCalled();
+    // The other collapse direction: a delivered response must not ALSO log at
+    // error level.
+    expect(consoleError).not.toHaveBeenCalled();
     consoleWarn.mockRestore();
+    consoleError.mockRestore();
   });
 
   it('a suppressed-source delivery failure logs at error level, not warn', async () => {
@@ -253,6 +278,9 @@ describe('policy parameter (source)', () => {
     (deliverViaOrigin as jest.Mock).mockResolvedValue(0);
     const consoleError = jest
       .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const consoleWarn = jest
+      .spyOn(console, 'warn')
       .mockImplementation(() => {});
     const dispatch = jest.fn();
     const getState = jest.fn().mockReturnValue(state({ r1: open(3, 'sign') }));
@@ -266,11 +294,19 @@ describe('policy parameter (source)', () => {
     expect(dispatch).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'appEvents/sagaError' })
     );
+    // The `sendMessage` rejection above also logs its OWN unconditional
+    // `${source}: cancel delivery failed` at error level, before the
+    // delivered-ternary log this test is actually about — a loose
+    // `stringContaining(source)` match is satisfied by that first, unrelated
+    // call and stays blind to the ternary collapsing to unconditional `warn`.
+    // Pin the exact message the ternary produces, and that `warn` is untouched.
     expect(consoleError).toHaveBeenCalledWith(
-      expect.stringContaining('sweep-orphaned-requests'),
+      expect.stringContaining('cancelled an orphaned request'),
       expect.anything()
     );
+    expect(consoleWarn).not.toHaveBeenCalled();
     consoleError.mockRestore();
+    consoleWarn.mockRestore();
   });
 });
 

--- a/src/background/handlers/sweep-orphaned-requests.test.ts
+++ b/src/background/handlers/sweep-orphaned-requests.test.ts
@@ -124,7 +124,9 @@ it('a row a window still claims is untouched — including when its windowIds is
 
 it('a Ledger row with two dead windows is cancelled', async () => {
   (collectRequestIdsFromOpenWindows as jest.Mock).mockResolvedValue(new Set());
-  const requests = { r1: openRow(3, 0, [7, 9]) };
+  const requests = {
+    r1: { ...openRow(3, 0, [7, 9]), awaitingDeviceConfirmation: true }
+  };
   const store = makeStore(requests);
 
   const promise = sweepOrphanedRequests(store, requests);

--- a/src/background/handlers/sweep-orphaned-requests.test.ts
+++ b/src/background/handlers/sweep-orphaned-requests.test.ts
@@ -1,0 +1,253 @@
+import { tabs } from 'webextension-polyfill';
+
+import { collectRequestIdsFromOpenWindows } from '@background/open-request-windows';
+import { windowRequestResponded } from '@background/redux/windowManagement/actions';
+import { reducer } from '@background/redux/windowManagement/reducer';
+import { MAX_SESSION_ROWS } from '@background/redux/windowManagement/session-store';
+import {
+  Request,
+  WindowManagementState
+} from '@background/redux/windowManagement/types';
+
+import { sdkMethod } from '@content/sdk-method';
+
+import { cancelOpenRequestsForClosedWindow } from './cancel-open-requests-on-close';
+import { CANCEL_GRACE_MS } from './cancel-requests';
+import { deliverViaOrigin } from './deliver-via-origin';
+import { sweepOrphanedRequests } from './sweep-orphaned-requests';
+
+jest.mock('webextension-polyfill', () => ({
+  tabs: { sendMessage: jest.fn(), get: jest.fn() }
+}));
+jest.mock('./deliver-via-origin', () => ({ deliverViaOrigin: jest.fn() }));
+jest.mock('@background/open-request-windows', () => ({
+  collectRequestIdsFromOpenWindows: jest.fn()
+}));
+
+const openRow = (
+  tabId: number,
+  seq: number,
+  windowIds: number[] = []
+): Request => ({
+  status: 'open',
+  tabId,
+  origin: 'https://dapp',
+  method: 'sign',
+  windowIds,
+  awaitingDeviceConfirmation: false,
+  seq
+});
+
+// A tiny real store: dispatch runs the REAL reducer, so the vehicle's own
+// live re-check (the property this whole suite is about) is exercised
+// against genuine transition guards, not a hand-rolled stand-in for them.
+function makeStore(requests: WindowManagementState['requests']) {
+  let windowManagement: WindowManagementState = {
+    windowId: null,
+    exportKeysWindowId: null,
+    requests
+  };
+  const dispatch = jest.fn((action: any) => {
+    windowManagement = reducer(windowManagement, action);
+  });
+  const getState = jest.fn(() => ({ windowManagement }));
+  return { dispatch, getState } as any;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  (tabs.sendMessage as jest.Mock).mockResolvedValue(undefined);
+  (tabs.get as jest.Mock).mockResolvedValue({ url: 'https://dapp/page' });
+  (deliverViaOrigin as jest.Mock).mockResolvedValue(0);
+  jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+it('an empty hydrated map calls no getAll', async () => {
+  const store = makeStore({});
+
+  await sweepOrphanedRequests(store, {});
+
+  expect(collectRequestIdsFromOpenWindows).not.toHaveBeenCalled();
+});
+
+it('ignores tombstoned and empty entries in the hydrated snapshot', async () => {
+  (collectRequestIdsFromOpenWindows as jest.Mock).mockResolvedValue(new Set());
+  const requests: WindowManagementState['requests'] = {
+    r1: { status: 'responded', seq: 0 },
+    r2: undefined
+  };
+  const store = makeStore(requests);
+
+  await sweepOrphanedRequests(store, requests);
+
+  expect(collectRequestIdsFromOpenWindows).not.toHaveBeenCalled();
+  expect(store.dispatch).not.toHaveBeenCalled();
+});
+
+it('a hydrated row no window claims is cancelled', async () => {
+  (collectRequestIdsFromOpenWindows as jest.Mock).mockResolvedValue(new Set());
+  const requests = { r1: openRow(3, 0) };
+  const store = makeStore(requests);
+
+  const promise = sweepOrphanedRequests(store, requests);
+  await jest.advanceTimersByTimeAsync(CANCEL_GRACE_MS);
+  await promise;
+
+  expect(tabs.sendMessage).toHaveBeenCalledWith(
+    3,
+    sdkMethod.signResponse({ cancelled: true }, { requestId: 'r1' })
+  );
+  expect(store.getState().windowManagement.requests.r1.status).toBe(
+    'responded'
+  );
+});
+
+it('a row a window still claims is untouched — including when its windowIds is empty', async () => {
+  (collectRequestIdsFromOpenWindows as jest.Mock).mockResolvedValue(
+    new Set(['r1'])
+  );
+  const requests = { r1: openRow(3, 0, []) };
+  const store = makeStore(requests);
+
+  await sweepOrphanedRequests(store, requests);
+
+  expect(tabs.sendMessage).not.toHaveBeenCalled();
+  expect(store.getState().windowManagement.requests.r1.status).toBe('open');
+});
+
+it('a Ledger row with two dead windows is cancelled', async () => {
+  (collectRequestIdsFromOpenWindows as jest.Mock).mockResolvedValue(new Set());
+  const requests = { r1: openRow(3, 0, [7, 9]) };
+  const store = makeStore(requests);
+
+  const promise = sweepOrphanedRequests(store, requests);
+  await jest.advanceTimersByTimeAsync(CANCEL_GRACE_MS);
+  await promise;
+
+  expect(tabs.sendMessage).toHaveBeenCalled();
+  expect(store.getState().windowManagement.requests.r1.status).toBe(
+    'responded'
+  );
+});
+
+it('a row registered after init is untouched', async () => {
+  (collectRequestIdsFromOpenWindows as jest.Mock).mockResolvedValue(new Set());
+  const hydrated = { r1: openRow(3, 0) };
+  // r2 is live (present in the store) but was registered AFTER the hydrated
+  // snapshot was taken, so it must never be considered.
+  const store = makeStore({ ...hydrated, r2: openRow(4, 1) });
+
+  const promise = sweepOrphanedRequests(store, hydrated);
+  await jest.advanceTimersByTimeAsync(CANCEL_GRACE_MS);
+  await promise;
+
+  expect(tabs.sendMessage).not.toHaveBeenCalledWith(4, expect.anything());
+  expect(store.getState().windowManagement.requests.r2.status).toBe('open');
+});
+
+it('a failed getAll cancels nothing', async () => {
+  (collectRequestIdsFromOpenWindows as jest.Mock).mockResolvedValue(null);
+  const requests = { r1: openRow(3, 0) };
+  const store = makeStore(requests);
+
+  await sweepOrphanedRequests(store, requests);
+
+  expect(tabs.sendMessage).not.toHaveBeenCalled();
+  expect(store.dispatch).not.toHaveBeenCalled();
+});
+
+it('a genuine response arriving during the grace wins and no cancel is sent', async () => {
+  (collectRequestIdsFromOpenWindows as jest.Mock).mockResolvedValue(new Set());
+  const hydrated = { r1: openRow(3, 0) };
+  const store = makeStore(hydrated);
+
+  const promise = sweepOrphanedRequests(store, hydrated);
+  await jest.advanceTimersByTimeAsync(CANCEL_GRACE_MS - 1);
+  // The genuine response landing mid-grace — e.g. a Ledger success arriving
+  // via `sdk-response-to-tab`'s `markRequestResponded`.
+  store.dispatch(windowRequestResponded({ requestId: 'r1' }));
+  await jest.advanceTimersByTimeAsync(1);
+  await promise;
+
+  expect(tabs.sendMessage).not.toHaveBeenCalled();
+  expect(store.getState().windowManagement.requests.r1.status).toBe(
+    'responded'
+  );
+});
+
+it('a navigated-away tab gets deliverViaOrigin, not a direct send', async () => {
+  (collectRequestIdsFromOpenWindows as jest.Mock).mockResolvedValue(new Set());
+  (tabs.get as jest.Mock).mockResolvedValue({ url: 'https://elsewhere/page' });
+  const requests = { r1: openRow(3, 0) };
+  const store = makeStore(requests);
+
+  const promise = sweepOrphanedRequests(store, requests);
+  await jest.advanceTimersByTimeAsync(CANCEL_GRACE_MS);
+  await promise;
+
+  expect(tabs.sendMessage).not.toHaveBeenCalled();
+  expect(deliverViaOrigin).toHaveBeenCalledWith(
+    'https://dapp',
+    sdkMethod.signResponse({ cancelled: true }, { requestId: 'r1' }),
+    undefined
+  );
+});
+
+it('concurrent sweep + window-removed for the same row delivers exactly one cancel', async () => {
+  (collectRequestIdsFromOpenWindows as jest.Mock).mockResolvedValue(new Set());
+  const requests = { r1: openRow(3, 0, [7]) };
+  const store = makeStore(requests);
+
+  const sweepPromise = sweepOrphanedRequests(store, requests);
+  const removedPromise = cancelOpenRequestsForClosedWindow(store, 7);
+
+  await jest.advanceTimersByTimeAsync(CANCEL_GRACE_MS);
+  await Promise.all([sweepPromise, removedPromise]);
+
+  expect(tabs.sendMessage).toHaveBeenCalledTimes(1);
+  expect(store.getState().windowManagement.requests.r1.status).toBe(
+    'responded'
+  );
+});
+
+it('bounds cancellation work per wake to the session write cap', async () => {
+  (collectRequestIdsFromOpenWindows as jest.Mock).mockResolvedValue(new Set());
+  const requests: WindowManagementState['requests'] = {};
+  for (let i = 0; i < MAX_SESSION_ROWS + 5; i++) {
+    requests[`r${i}`] = openRow(i, i);
+  }
+  const store = makeStore(requests);
+
+  const promise = sweepOrphanedRequests(store, requests);
+  await jest.advanceTimersByTimeAsync(CANCEL_GRACE_MS);
+  await promise;
+
+  expect(tabs.sendMessage).toHaveBeenCalledTimes(MAX_SESSION_ROWS);
+});
+
+it('a per-row cancel failure is logged with identifiers only, never a raw URL', async () => {
+  (collectRequestIdsFromOpenWindows as jest.Mock).mockResolvedValue(new Set());
+  const requests = { r1: openRow(3, 0) };
+  const store = makeStore(requests);
+  const secretBearingError = new Error(
+    'dispatch failed https://dapp/page?message=super-secret'
+  );
+  (store.dispatch as jest.Mock).mockImplementationOnce(() => {
+    throw secretBearingError;
+  });
+
+  const promise = sweepOrphanedRequests(store, requests);
+  await jest.advanceTimersByTimeAsync(CANCEL_GRACE_MS);
+  await promise;
+
+  const serialized = JSON.stringify((console.error as jest.Mock).mock.calls);
+  expect(serialized).not.toContain('super-secret');
+  expect(serialized).not.toMatch(/\?[^"]*=/);
+});

--- a/src/background/handlers/sweep-orphaned-requests.test.ts
+++ b/src/background/handlers/sweep-orphaned-requests.test.ts
@@ -234,7 +234,14 @@ it('bounds cancellation work per wake to the session write cap', async () => {
   expect(tabs.sendMessage).toHaveBeenCalledTimes(MAX_SESSION_ROWS);
 });
 
-it('a per-row cancel failure is logged with identifiers only, never a raw URL', async () => {
+it('a per-row cancel failure is logged with identifiers only, never a raw URL or a raw Error', async () => {
+  // `JSON.stringify` on a whole log-call array is blind to a surgical revert
+  // of `error: redactUrlQuery(error)` back to `error: error`: `Error#message`
+  // is a non-enumerable own property, so a raw Error renders `{}` and the
+  // secret-text checks below would pass right past it — same trap as
+  // `fail-request-on-window-error.test.ts`'s equivalent test. Walk every
+  // logged argument's own values directly instead of trusting serialization
+  // to surface them.
   (collectRequestIdsFromOpenWindows as jest.Mock).mockResolvedValue(new Set());
   const requests = { r1: openRow(3, 0) };
   const store = makeStore(requests);
@@ -249,7 +256,22 @@ it('a per-row cancel failure is logged with identifiers only, never a raw URL', 
   await jest.advanceTimersByTimeAsync(CANCEL_GRACE_MS);
   await promise;
 
-  const serialized = JSON.stringify((console.error as jest.Mock).mock.calls);
-  expect(serialized).not.toContain('super-secret');
-  expect(serialized).not.toMatch(/\?[^"]*=/);
+  const calls = (console.error as jest.Mock).mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+
+  for (const call of calls) {
+    for (const arg of call) {
+      expect(arg).not.toBeInstanceOf(Error);
+
+      if (typeof arg === 'object' && arg != null) {
+        for (const value of Object.values(arg)) {
+          expect(value).not.toBeInstanceOf(Error);
+        }
+      }
+
+      const text = typeof arg === 'string' ? arg : JSON.stringify(arg);
+      expect(text).not.toContain('super-secret');
+      expect(text).not.toMatch(/\?[^"]*=/);
+    }
+  }
 });

--- a/src/background/handlers/sweep-orphaned-requests.ts
+++ b/src/background/handlers/sweep-orphaned-requests.ts
@@ -68,10 +68,11 @@ export async function sweepOrphanedRequests(
     return;
   }
 
-  // Bound the work per wake to the session write cap. The hydrated snapshot
-  // can never hold more open rows than this anyway (`capRows` keeps open rows
-  // over tombstones), but a row past the cut stays 'open' and is re-swept on
-  // the next wake regardless.
+  // Bound the work per wake to the session write cap (`MAX_SESSION_ROWS`,
+  // currently 70). The reducer's own `MAX_OPEN_REQUESTS` cap (20) is the real
+  // bound on how many open rows a hydrated snapshot can hold; this slice is
+  // the outer guard for whatever a stale or pre-cap mirror still carries. A
+  // row past the cut stays 'open' and is re-swept on the next wake regardless.
   const toSweep = orphaned
     .slice()
     .sort((a, b) => a.seq - b.seq)

--- a/src/background/handlers/sweep-orphaned-requests.ts
+++ b/src/background/handlers/sweep-orphaned-requests.ts
@@ -1,0 +1,105 @@
+import { collectRequestIdsFromOpenWindows } from '@background/open-request-windows';
+import { redactUrlQuery } from '@background/redact-url-query';
+import type { MainStore } from '@background/redux/get-main-store';
+import { MAX_SESSION_ROWS } from '@background/redux/windowManagement/session-store';
+import { WindowManagementState } from '@background/redux/windowManagement/types';
+
+import { CANCEL_GRACE_MS, failRequestOnWindowError } from './cancel-requests';
+
+const delay = (ms: number) =>
+  new Promise<void>(resolve => setTimeout(resolve, ms));
+
+/**
+ * Cancels every hydrated 'open' row no window still displays (spec §8.1) — the
+ * two durable-state freezes `windows.onRemoved` alone can never recover from:
+ * an init failure that consumed the only cancelling event, and a crash between
+ * a detach and its tombstone that durably persists `{status:'open',
+ * windowIds:[]}`. Left uncancelled, the row permanently occupies one of ten
+ * `MAX_STORED_PAYLOADS` slots (`vault-sagas.ts`), reopening the leak
+ * WALLET-1418 closed.
+ *
+ * `hydratedRequests` is the snapshot taken at init — NEVER read from
+ * `store.getState()` after an await, or a request registered moments ago,
+ * still waiting for its window to attach, could be cancelled during its own
+ * legitimate registration→attach gap.
+ */
+export async function sweepOrphanedRequests(
+  store: MainStore,
+  hydratedRequests: WindowManagementState['requests']
+): Promise<void> {
+  const openRows = Object.entries(hydratedRequests).flatMap(
+    ([requestId, request]) =>
+      request != null && request.status === 'open'
+        ? [{ requestId, seq: request.seq }]
+        : []
+  );
+
+  // A user who never touches a dapp hits this on every wake — `init` runs on
+  // every wake and `windows.onRemoved` fires for any browser window — so a
+  // full tab enumeration must not run when there is nothing to sweep.
+  if (openRows.length === 0) {
+    return;
+  }
+
+  // Unchanged, on purpose: a read-only second caller cannot narrow the Set
+  // `reconcileStalePayloadsSaga` consumes, and a second copy would have to
+  // independently re-earn its piecewise URL compare, `REQUEST_BEARING_PATHNAMES`,
+  // `tab.url || tab.pendingUrl`, the per-tab catch and the `Set | null`
+  // contract — then split-brain the moment a new approval page is added. See
+  // spec §8.1.
+  const liveRequestIds = await collectRequestIdsFromOpenWindows();
+
+  // `null` is a failed enumeration, not "no window displays anything" — fail
+  // closed, same as `reconcileStalePayloadsSaga`.
+  if (liveRequestIds == null) {
+    return;
+  }
+
+  // Liveness is a window-URL question, never a `windowIds` question: a row
+  // can read `windowIds: []` while its approval window is genuinely on
+  // screen (the worker can die between `windowRequestOpened` and the attach
+  // that follows `windows.create`), so `windowIds` is never consulted here —
+  // only whether some window's URL still names this requestId.
+  const orphaned = openRows.filter(
+    ({ requestId }) => !liveRequestIds.has(requestId)
+  );
+
+  if (orphaned.length === 0) {
+    return;
+  }
+
+  // Bound the work per wake to the session write cap. The hydrated snapshot
+  // can never hold more open rows than this anyway (`capRows` keeps open rows
+  // over tombstones), but a row past the cut stays 'open' and is re-swept on
+  // the next wake regardless.
+  const toSweep = orphaned
+    .slice()
+    .sort((a, b) => a.seq - b.seq)
+    .slice(0, MAX_SESSION_ROWS);
+
+  // The vehicle's premise — "no window will ever display this request" — does
+  // not transfer from the `windows.create`-rejection trigger to the sweep: a
+  // Ledger confirmation runs in the window's document, not the worker, so a
+  // genuine signed response can be in flight. The grace lets it land and mark
+  // the row 'responded' first; `failRequestOnWindowError` re-reads the store
+  // fresh, so it sees that and no-ops.
+  await delay(CANCEL_GRACE_MS);
+
+  await Promise.allSettled(
+    toSweep.map(({ requestId }) =>
+      failRequestOnWindowError(
+        store,
+        requestId,
+        'sweep-orphaned-requests'
+      ).catch(error =>
+        // Identifiers + `redactUrlQuery` only — never the raw error, in case
+        // it wraps a rejection that echoes a signMessage window's plaintext
+        // query string.
+        console.error('sweep-orphaned-requests: cancel failed', {
+          requestId,
+          error: redactUrlQuery(error)
+        })
+      )
+    )
+  );
+}

--- a/src/background/open-request-windows.test.ts
+++ b/src/background/open-request-windows.test.ts
@@ -1,6 +1,10 @@
 import { windows } from 'webextension-polyfill';
 
-import { collectRequestIdsFromOpenWindows } from './open-request-windows';
+import { WindowApp, getUrlByWindowApp } from './create-open-window';
+import {
+  REQUEST_BEARING_PATHNAMES,
+  collectRequestIdsFromOpenWindows
+} from './open-request-windows';
 
 jest.mock('webextension-polyfill', () => ({
   windows: { getAll: jest.fn().mockResolvedValue([]) },
@@ -265,5 +269,41 @@ describe('collectRequestIdsFromOpenWindows', () => {
     const logged = JSON.stringify(consoleError.mock.calls);
     expect(logged).not.toContain('my-secret-message');
     expect(logged).not.toContain('?');
+  });
+});
+
+// Oracle: nothing else ties `REQUEST_BEARING_PATHNAMES` to the URLs approval
+// windows actually open at — the two lists could drift silently. Derived from
+// `getUrlByWindowApp`, not restated as literals, so a pathname change on
+// either side fails here instead of only in production.
+describe('REQUEST_BEARING_PATHNAMES tracks every approval WindowApp', () => {
+  const APPROVAL_WINDOW_APPS = [
+    WindowApp.ConnectToApp,
+    WindowApp.SwitchAccount,
+    WindowApp.SignatureRequestDeploy,
+    WindowApp.SignatureRequestMessage,
+    WindowApp.SignatureRequestEip712,
+    WindowApp.DecryptMessageRequest
+  ];
+
+  const pathnameFor = (windowApp: WindowApp) =>
+    new URL(
+      getUrlByWindowApp(windowApp),
+      'chrome-extension://abcdefghijklmnop/'
+    ).pathname;
+
+  it.each(APPROVAL_WINDOW_APPS)(
+    'covers the pathname %s opens at',
+    windowApp => {
+      expect(REQUEST_BEARING_PATHNAMES.has(pathnameFor(windowApp))).toBe(true);
+    }
+  );
+
+  // Deliberately excluded: `import-account-with-file.html` is a separate
+  // window, never displays a `?requestId=`.
+  it('does not cover ImportAccount', () => {
+    expect(
+      REQUEST_BEARING_PATHNAMES.has(pathnameFor(WindowApp.ImportAccount))
+    ).toBe(false);
   });
 });

--- a/src/background/open-request-windows.ts
+++ b/src/background/open-request-windows.ts
@@ -5,7 +5,7 @@ import { redactUrlQuery } from '@background/redact-url-query';
 // Every page a `?requestId=` can legitimately reach. `popup.html` never carries
 // one today, but it is `use-ledger.ts`'s default `domain` and none of these is
 // web-accessible, so listing it costs nothing and fails toward keeping.
-const REQUEST_BEARING_PATHNAMES = new Set([
+export const REQUEST_BEARING_PATHNAMES = new Set([
   '/signature-request.html',
   '/connect-to-app.html',
   '/popup.html'

--- a/src/background/redux/app-events/types.ts
+++ b/src/background/redux/app-events/types.ts
@@ -25,7 +25,10 @@ export type SagaErrorSource =
   | 'cancel-on-close'
   | 'cancel-on-supersede'
   | 'open-window-failed'
-  | 'sdk-response-to-tab';
+  | 'sdk-response-to-tab'
+  // Startup sweep of a hydrated 'open' row no window still claims (spec
+  // §8.1) — a second, console-only trigger for `failRequestOnWindowError`.
+  | 'sweep-orphaned-requests';
 
 export interface SagaError {
   id: number;

--- a/src/background/redux/get-main-store.test.ts
+++ b/src/background/redux/get-main-store.test.ts
@@ -18,6 +18,26 @@ const storageRemove = jest.fn().mockResolvedValue(undefined);
 const runtimeSendMessage = jest.fn().mockResolvedValue(undefined);
 const sessionGet = jest.fn<Promise<Record<string, unknown>>, [unknown]>();
 const sessionSet = jest.fn().mockResolvedValue(undefined);
+// Absent until now, so the fire-and-forget `sweepOrphanedRequests(...).catch`
+// in `getExistingMainStoreSingletonOrInit` silently swallowed a
+// `windows.getAll is not a function` TypeError in every test here — the sweep
+// call was wired but never actually observed to run.
+//
+// Defaults to reporting `mirroredRequest`'s own requestId ('req-1') as still
+// LIVE. Every hydration test below seeds that same row, and the sweep only
+// short-circuits (no `delay(CANCEL_GRACE_MS)`, no cancel/log side effects)
+// when it finds a hydrated open row's id among the live ones — anything else
+// would race a real 250ms timer against whichever test runs next.
+const windowsGetAll = jest.fn().mockResolvedValue([
+  {
+    id: 1,
+    tabs: [
+      {
+        url: 'chrome-extension://test-extension-id/signature-request.html?requestId=req-1'
+      }
+    ]
+  }
+]);
 
 jest.mock('webextension-polyfill', () => ({
   storage: {
@@ -33,9 +53,13 @@ jest.mock('webextension-polyfill', () => ({
     }
   },
   runtime: {
-    sendMessage: (...args: unknown[]) => runtimeSendMessage(...args)
+    sendMessage: (...args: unknown[]) => runtimeSendMessage(...args),
+    getURL: (path: string) => `chrome-extension://test-extension-id/${path}`
   },
-  tabs: { query: jest.fn().mockResolvedValue([]) }
+  tabs: { query: jest.fn().mockResolvedValue([]) },
+  windows: {
+    getAll: (...args: unknown[]) => windowsGetAll(...args)
+  }
 }));
 
 // The mirror is gated on a build-time flag that is FALSE under jest, so without
@@ -306,6 +330,23 @@ describe('preload hydration — the session mirror', () => {
     await new Promise(resolve => setImmediate(resolve as () => void));
 
     expect(sessionSet).not.toHaveBeenCalled();
+  });
+
+  it('actually runs the sweep on the hydration-enabled path, not just calls it', async () => {
+    // A non-empty hydrated OPEN row is required: `sweepOrphanedRequests`
+    // returns before enumerating windows when there is nothing to sweep, so
+    // an empty map would pass even with a totally disconnected sweep call.
+    sessionGet.mockResolvedValue({
+      [REQUEST_SESSION_KEY]: {
+        requests: { 'req-1': mirroredRequest },
+        windowId: 3
+      }
+    });
+
+    await initWithKeysSnapshot(undefined);
+    await new Promise(resolve => setImmediate(resolve as () => void));
+
+    expect(windowsGetAll).toHaveBeenCalledWith({ populate: true });
   });
 
   it('yields ONE store for two interleaved first callers', async () => {

--- a/src/background/redux/get-main-store.ts
+++ b/src/background/redux/get-main-store.ts
@@ -1,5 +1,6 @@
 import { storage } from 'webextension-polyfill';
 
+import { sweepOrphanedRequests } from '@background/handlers/sweep-orphaned-requests';
 import { redactUrlQuery } from '@background/redact-url-query';
 import { AppEventsState } from '@background/redux/app-events/types';
 import { broadcastPopupState } from '@background/redux/broadcast-popup-state';
@@ -208,6 +209,19 @@ export async function getExistingMainStoreSingletonOrInit() {
           });
         }
       });
+
+      // Fire-and-forget hardening pass (spec §8.1): catches the two durable-
+      // state freezes no window event can ever recover from. Passed the
+      // hydrated snapshot rather than reading `getState()` itself — a request
+      // registered moments after this line is not in it, and so cannot be
+      // cancelled during its own registration→attach gap.
+      void sweepOrphanedRequests(storeSingleton, requestSession.requests).catch(
+        e =>
+          console.error(
+            'sweep-orphaned-requests: sweep failed',
+            redactUrlQuery(e)
+          )
+      );
     }
   } catch (e) {
     console.error('Failed to retrieve data from local storage: ', e);

--- a/src/background/redux/windowManagement/session-store.ts
+++ b/src/background/redux/windowManagement/session-store.ts
@@ -24,7 +24,10 @@ export type SessionRecord = {
 // Write-side row cap: the reducer's tombstone bound plus headroom for the open
 // rows that can exist alongside them. The read stays uncapped, so no drop order
 // has to be defined there and key hoisting can never decide which rows survive.
-const MAX_SESSION_ROWS = MAX_RESPONDED_TOMBSTONES + 20;
+// Exported so the startup sweep can bound its own per-wake work to the same
+// figure (see sweep-orphaned-requests.ts) — the hydrated snapshot it reads can
+// never hold more open rows than this in the first place.
+export const MAX_SESSION_ROWS = MAX_RESPONDED_TOMBSTONES + 20;
 
 const MAX_ORIGIN_LENGTH = 256;
 const MAX_WINDOW_IDS = 16;


### PR DESCRIPTION
## Description

Hardening on top of the session mirror. Durable state is not a durable event: `windows.onRemoved` fires once per window, and two states can freeze into the mirror with no event left to advance them — an init failure consumes the only `onRemoved` while the mirror re-hydrates the row, and a crash inside the 250 ms cancel grace durably persists `{status: 'open', windowIds: []}`, the one shape no window event can ever cancel. A pinned row's id is rejected by the SDK entry guard forever and holds one of the ten `MAX_STORED_PAYLOADS` slots — reopening the leak WALLET-1418 closed.

### The sweep

New module `src/background/handlers/sweep-orphaned-requests.ts`, called fire-and-forget from `getExistingMainStoreSingletonOrInit` after the subscriber attaches (no new `await` between the singleton's null check and assignment). It takes the hydrated snapshot as an argument — never `getState()` after an await — so a request registered after init can never be swept during its own registration→attach gap.

- **Liveness is a window-URL question, never a `windowIds` question.** A hydrated `'open'` row is orphaned iff the enumeration succeeded and no open window's URL claims its id. Empty `windowIds` is the registration→attach shape — the window is on screen — and is never treated as proof of death. A failed enumeration cancels nothing.
- `collectRequestIdsFromOpenWindows` is called **unchanged** — same superset-of-live, fail-toward-keeping polarity `reconcileStalePayloadsSaga` depends on.
- Short-circuits before `windows.getAll` when the snapshot has no `'open'` rows — init runs on every wake, and a user who never touches a dapp must not pay a tab enumeration per wake. Work per wake is bounded to the mirror's write cap.
- `await delay(CANCEL_GRACE_MS)` before cancelling: a Ledger confirmation runs in the window's document, not the worker, so a genuine signed response can be in flight; the vehicle's live re-check then sees `'responded'` and the sweep sends nothing.

### The vehicle, parameterised

`failRequestOnWindowError` gains a `source: SagaErrorSource` parameter (new `'sweep-orphaned-requests'` member of the closed union; `CancelSource`'s comment rewritten):

- **No banner for swept rows.** The `sagaError` dispatch fires only for the `open-window-failed` caller. In close-as-wake the sweep's enumeration resolves inside the grace and delivers the flagship cancel — without this, every ordinary close-after-idle would paint an untranslated error banner, possibly over a live signing prompt. The sweep's policy is console-only, matching the codebase precedent for dapp-triggerable paths.
- **#1484's origin check moved inside the vehicle.** On a navigated-away tab `tabs.sendMessage` _succeeds_ (the content script is on every http(s) page), so a catch-fallback never fires — and a swept row can be arbitrarily old, so navigated-away is the expected state. The check carries #1484's frameId semantics: the origin comparison is gated on `frameId == null || frameId === 0` (`tabs.get` reports the top document's origin) and the send is frame-targeted. **This intentionally changes the existing `open-window-failed` call site's delivery too** — its cancels now get the same navigated-away protection. The cost, stated honestly: the tombstone and the send are now separated by one extra `tabs.get` round-trip for both sources, slightly widening the spec's acknowledged "crash between tombstone and delivery loses that cancel" residual.

### Idempotence

The `getState → filter open → dispatch tombstone` sequence stays one synchronous block — the new origin `await` sits _after_ the tombstone dispatch — so concurrent sweep + window-removed cancels for the same row deliver exactly one cancel in every interleaving (pinned by a test running the real reducer, asserting a single `tabs.sendMessage`).

### What it does not close

A crash between the tombstone write and delivery still loses that cancel permanently: the next wake hydrates `'responded'`, the sweep skips it, and nothing retries. Bounded-staleness by design.

### Verification

- `npx jest src/background/` — 69 suites, 911 tests pass; `npx tsc --noEmit` clean; eslint/prettier clean (the type-only `MainStore` imports use `import type`, so no `import/no-cycle` warnings).
- New-module coverage 100/100/100/100; `src/background/handlers/` floors (85/100/95/95) hold.
- The nine sweep scenarios from the spec are all pinned, including: still-claimed row with empty `windowIds` untouched; genuine response during the grace wins; concurrent sweep + close delivers one cancel; navigated-away tab routed through `deliverViaOrigin`.
- Logging: new logs pass through `redactUrlQuery` only; tests assert no `?…=` substring survives any log the new code emits.

**Manual smoke still owed before merge** (needs a live extension): kill the worker inside the 250 ms grace after closing an approval window, wake it, confirm the pinned row is cancelled and its payload slot reclaimed.

## Linked tickets

[WALLET-1419](https://make-software.atlassian.net/browse/WALLET-1419)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [x] If the PR adds any new text to the UI, make sure they are localized — no UI text added

- [x] Include a screenshot or recording if implementing significant UI or user flow change — background-only, no UI change

- [ ] When this PR affects architecture changes wait for review from Dmytro before merging


[WALLET-1419]: https://make-software.atlassian.net/browse/WALLET-1419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ