### PR TITLE
fix(background): cap concurrently open requests

### DIFF
--- a/src/background/handlers/sdk-methods.test.ts
+++ b/src/background/handlers/sdk-methods.test.ts
@@ -439,6 +439,9 @@ describe('connectRequest', () => {
       handled: true,
       response: sdkMethod.connectResponse(false, META)
     });
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: windowRequestOpened.type })
+    );
     expect(openWindowMock).not.toHaveBeenCalled();
   });
 });
@@ -533,6 +536,9 @@ describe('switchAccountRequest', () => {
       handled: true,
       response: sdkMethod.switchAccountResponse(false, META)
     });
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: windowRequestOpened.type })
+    );
     expect(openWindowMock).not.toHaveBeenCalled();
   });
 });
@@ -787,6 +793,59 @@ describe('signRequest', () => {
       expect.objectContaining({ requestId: 'req-1' })
     );
   });
+
+  it('refused at the open-request cap → the payload-cap-style cancelled response, no window', async () => {
+    // Payload cap has room (default mock), only the open-request cap refuses —
+    // so, unlike the payload-cap refusal above, the payload dispatch DOES land
+    // and only the descriptor dispatch is refused: the accepted deploy payload
+    // is left stranded for `reconcileStalePayloadsSaga` to reclaim.
+    isEqualCIMock.mockReturnValue(false);
+    const { store, dispatch } = makeStore();
+    dispatch.mockImplementation(() => {});
+
+    const result = await handleSdkMethod(
+      sdkMethod.signRequest({ deployJson, signingPublicKeyHex: 'PK-1' }, META),
+      SENDER,
+      store
+    );
+
+    expect(result).toEqual({
+      handled: true,
+      response: sdkMethod.signResponse(
+        {
+          cancelled: true,
+          message: 'Too many pending signature requests',
+          errorCode: SdkErrorCode.tooManyPendingRequests
+        },
+        { requestId: 'req-1' }
+      )
+    });
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: windowRequestOpened.type })
+    );
+    expect(openWindowMock).not.toHaveBeenCalled();
+  });
+
+  it('an open-request-cap refusal is logged, distinct from the payload-cap message, identifiers only', async () => {
+    isEqualCIMock.mockReturnValue(false);
+    const { store, dispatch } = makeStore();
+    dispatch.mockImplementation(() => {});
+
+    await handleSdkMethod(
+      sdkMethod.signRequest({ deployJson, signingPublicKeyHex: 'PK-1' }, META),
+      SENDER,
+      store
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('open-request map at capacity'),
+      { requestId: 'req-1', method: sdkMethod.signRequest.type }
+    );
+    const logged = JSON.stringify(consoleErrorSpy.mock.calls);
+    expect(logged).not.toContain('PK-1');
+    expect(logged).not.toContain(ORIGIN);
+  });
 });
 
 describe('signMessageRequest', () => {
@@ -879,6 +938,9 @@ describe('signMessageRequest', () => {
       handled: true,
       response: sdkMethod.signMessageResponse({ cancelled: true }, META)
     });
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: windowRequestOpened.type })
+    );
     expect(openWindowMock).not.toHaveBeenCalled();
   });
 });
@@ -1108,6 +1170,74 @@ describe('signTypedDataRequest', () => {
       })
     );
   });
+
+  it('refused at the open-request cap → the payload-cap-style cancelled response, no window', async () => {
+    // Payload cap has room (default mock), only the open-request cap refuses —
+    // so, unlike the payload-cap refusal above, the payload dispatch DOES land
+    // and only the descriptor dispatch is refused: the accepted eip712 payload
+    // is left stranded for `reconcileStalePayloadsSaga` to reclaim.
+    const { store, dispatch } = makeStore();
+    dispatch.mockImplementation(() => {});
+
+    const result = await handleSdkMethod(
+      sdkMethod.signTypedDataRequest(
+        {
+          typedData: { foo: 'bar' } as any,
+          options: undefined,
+          signingPublicKeyHex: 'PK-1'
+        },
+        META
+      ),
+      SENDER,
+      store
+    );
+
+    expect(result).toEqual({
+      handled: true,
+      response: sdkMethod.signTypedDataResponse(
+        {
+          cancelled: true,
+          signature: null,
+          digest: null,
+          publicKey: null,
+          error: 'Too many pending signature requests',
+          errorCode: SdkErrorCode.tooManyPendingRequests
+        },
+        { requestId: 'req-1' }
+      )
+    });
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: windowRequestOpened.type })
+    );
+    expect(openWindowMock).not.toHaveBeenCalled();
+  });
+
+  it('an open-request-cap refusal is logged, distinct from the payload-cap message, identifiers only', async () => {
+    const { store, dispatch } = makeStore();
+    dispatch.mockImplementation(() => {});
+
+    await handleSdkMethod(
+      sdkMethod.signTypedDataRequest(
+        {
+          typedData: { foo: 'secret' } as any,
+          options: undefined,
+          signingPublicKeyHex: 'PK-1'
+        },
+        META
+      ),
+      SENDER,
+      store
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('open-request map at capacity'),
+      { requestId: 'req-1', method: sdkMethod.signTypedDataRequest.type }
+    );
+    const logged = JSON.stringify(consoleErrorSpy.mock.calls);
+    expect(logged).not.toContain('secret');
+    expect(logged).not.toContain(ORIGIN);
+  });
 });
 
 describe('decryptMessageRequest', () => {
@@ -1200,6 +1330,9 @@ describe('decryptMessageRequest', () => {
       handled: true,
       response: sdkMethod.decryptMessageResponse({ cancelled: true }, META)
     });
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: windowRequestOpened.type })
+    );
     expect(openWindowMock).not.toHaveBeenCalled();
   });
 });

--- a/src/background/handlers/sdk-methods.test.ts
+++ b/src/background/handlers/sdk-methods.test.ts
@@ -109,12 +109,27 @@ const selectEip712JsonByIdMock = selectEip712JsonById as jest.MockedFunction<
 const ORIGIN = 'https://dapp.example';
 const META = { requestId: 'req-1' };
 
+// `dispatch` records a `windowRequestOpened` into a mutable backing map, mimicking
+// the real reducer's accept path closely enough that the handler's post-dispatch
+// re-read (`selectRequestStatus`) sees the row. A test asserting the open-request
+// cap overrides `dispatch` to a no-op instead, standing in for the reducer's
+// refusal — the row then never appears, exactly like the real cap.
 function makeStore(requests: Record<string, unknown> = {}) {
-  const dispatch = jest.fn();
+  const state = { ...requests };
+  const dispatch = jest.fn((action: { type: string; payload?: unknown }) => {
+    if (action.type === windowRequestOpened.type) {
+      const { requestId } = action.payload as { requestId: string };
+      state[requestId] = { status: 'open' };
+    }
+  });
   const store = {
     dispatch,
     getState: () => ({
-      windowManagement: { windowId: null, exportKeysWindowId: null, requests }
+      windowManagement: {
+        windowId: null,
+        exportKeysWindowId: null,
+        requests: state
+      }
     })
   } as unknown as MainStore;
   return { store, dispatch };
@@ -407,6 +422,25 @@ describe('connectRequest', () => {
       })
     );
   });
+
+  it('refused at the open-request cap → connectResponse(false), no window', async () => {
+    selectIsConnectedMock.mockReturnValue(false);
+    const { store, dispatch } = makeStore();
+    // Stand in for the reducer's cap refusal: the descriptor never lands.
+    dispatch.mockImplementation(() => {});
+
+    const result = await handleSdkMethod(
+      sdkMethod.connectRequest({ title: 't' }, META),
+      SENDER,
+      store
+    );
+
+    expect(result).toEqual({
+      handled: true,
+      response: sdkMethod.connectResponse(false, META)
+    });
+    expect(openWindowMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('switchAccountRequest', () => {
@@ -483,6 +517,23 @@ describe('switchAccountRequest', () => {
         }
       })
     );
+  });
+
+  it('refused at the open-request cap → switchAccountResponse(false), no window', async () => {
+    const { store, dispatch } = makeStore();
+    dispatch.mockImplementation(() => {});
+
+    const result = await handleSdkMethod(
+      sdkMethod.switchAccountRequest({ title: 't' }, META),
+      SENDER,
+      store
+    );
+
+    expect(result).toEqual({
+      handled: true,
+      response: sdkMethod.switchAccountResponse(false, META)
+    });
+    expect(openWindowMock).not.toHaveBeenCalled();
   });
 });
 
@@ -810,6 +861,26 @@ describe('signMessageRequest', () => {
       })
     );
   });
+
+  it('refused at the open-request cap → signMessageResponse(cancelled), no window', async () => {
+    const { store, dispatch } = makeStore();
+    dispatch.mockImplementation(() => {});
+
+    const result = await handleSdkMethod(
+      sdkMethod.signMessageRequest(
+        { message: 'hi', signingPublicKeyHex: 'PK-1' },
+        META
+      ),
+      SENDER,
+      store
+    );
+
+    expect(result).toEqual({
+      handled: true,
+      response: sdkMethod.signMessageResponse({ cancelled: true }, META)
+    });
+    expect(openWindowMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('signTypedDataRequest', () => {
@@ -1110,6 +1181,26 @@ describe('decryptMessageRequest', () => {
         }
       })
     );
+  });
+
+  it('refused at the open-request cap → decryptMessageResponse(cancelled), no window', async () => {
+    const { store, dispatch } = makeStore();
+    dispatch.mockImplementation(() => {});
+
+    const result = await handleSdkMethod(
+      sdkMethod.decryptMessageRequest(
+        { message: 'enc', signingPublicKeyHex: 'PK-1' },
+        META
+      ),
+      SENDER,
+      store
+    );
+
+    expect(result).toEqual({
+      handled: true,
+      response: sdkMethod.decryptMessageResponse({ cancelled: true }, META)
+    });
+    expect(openWindowMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/background/handlers/sdk-methods.test.ts
+++ b/src/background/handlers/sdk-methods.test.ts
@@ -22,7 +22,10 @@ import {
   selectIsAccountConnected,
   selectVaultActiveAccount
 } from '@background/redux/vault/selectors';
-import { windowRequestOpened } from '@background/redux/windowManagement/actions';
+import {
+  windowRequestOpened,
+  windowRequestResponded
+} from '@background/redux/windowManagement/actions';
 import { emitSdkEventToActiveTabsWithOrigin } from '@background/utils';
 
 import { sdkMethod } from '@content/sdk-method';
@@ -820,9 +823,18 @@ describe('signRequest', () => {
         { requestId: 'req-1' }
       )
     });
-    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch).toHaveBeenCalledTimes(3);
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ type: windowRequestOpened.type })
+    );
+    // Reclaims the stranded payload immediately, rather than waiting on
+    // `reconcileStalePayloadsSaga`: the vault reducer deletes the payload
+    // keyed off exactly this action.
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: windowRequestResponded.type,
+        payload: { requestId: 'req-1' }
+      })
     );
     expect(openWindowMock).not.toHaveBeenCalled();
   });
@@ -840,7 +852,11 @@ describe('signRequest', () => {
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining('open-request map at capacity'),
-      { requestId: 'req-1', method: sdkMethod.signRequest.type }
+      {
+        requestId: 'req-1',
+        method: sdkMethod.signRequest.type,
+        openCount: 0
+      }
     );
     const logged = JSON.stringify(consoleErrorSpy.mock.calls);
     expect(logged).not.toContain('PK-1');
@@ -1206,9 +1222,17 @@ describe('signTypedDataRequest', () => {
         { requestId: 'req-1' }
       )
     });
-    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch).toHaveBeenCalledTimes(3);
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ type: windowRequestOpened.type })
+    );
+    // Reclaims the stranded eip712 payload immediately — same mechanism as
+    // the `sign` branch's equivalent assertion.
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: windowRequestResponded.type,
+        payload: { requestId: 'req-1' }
+      })
     );
     expect(openWindowMock).not.toHaveBeenCalled();
   });
@@ -1232,7 +1256,11 @@ describe('signTypedDataRequest', () => {
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining('open-request map at capacity'),
-      { requestId: 'req-1', method: sdkMethod.signTypedDataRequest.type }
+      {
+        requestId: 'req-1',
+        method: sdkMethod.signTypedDataRequest.type,
+        openCount: 0
+      }
     );
     const logged = JSON.stringify(consoleErrorSpy.mock.calls);
     expect(logged).not.toContain('secret');

--- a/src/background/handlers/sdk-methods.ts
+++ b/src/background/handlers/sdk-methods.ts
@@ -306,6 +306,28 @@ export async function handleSdkMethod(
         method: 'sign'
       })
     );
+
+    // At `MAX_OPEN_REQUESTS` the reducer refused the write silently, same as
+    // the four capless methods above — but the payload above has ALREADY been
+    // accepted into the map, so it is stranded here rather than refused; it is
+    // reclaimed by `reconcileStalePayloadsSaga` since no descriptor and no
+    // window will ever claim it.
+    if (selectRequestStatus(store.getState(), action.meta.requestId) == null) {
+      reportOpenRequestCapacityRefusal(action);
+
+      return {
+        handled: true,
+        response: sdkMethod.signResponse(
+          {
+            cancelled: true,
+            message: CAPACITY_REFUSAL_MESSAGE,
+            errorCode: SdkErrorCode.tooManyPendingRequests
+          },
+          { requestId: action.meta.requestId }
+        )
+      };
+    }
+
     openWindow(store, {
       windowApp: WindowApp.SignatureRequestDeploy,
       searchParams: {
@@ -423,6 +445,29 @@ export async function handleSdkMethod(
         method: 'signTypedData'
       })
     );
+
+    // Same residual as the deploy branch: the payload above is already
+    // accepted, so a refusal here strands it for `reconcileStalePayloadsSaga`
+    // to reclaim rather than refusing the payload write itself.
+    if (selectRequestStatus(store.getState(), action.meta.requestId) == null) {
+      reportOpenRequestCapacityRefusal(action);
+
+      return {
+        handled: true,
+        response: sdkMethod.signTypedDataResponse(
+          {
+            cancelled: true,
+            signature: null,
+            digest: null,
+            publicKey: null,
+            error: CAPACITY_REFUSAL_MESSAGE,
+            errorCode: SdkErrorCode.tooManyPendingRequests
+          },
+          { requestId: action.meta.requestId }
+        )
+      };
+    }
+
     openWindow(store, {
       windowApp: WindowApp.SignatureRequestEip712,
       searchParams: {

--- a/src/background/handlers/sdk-methods.ts
+++ b/src/background/handlers/sdk-methods.ts
@@ -69,6 +69,15 @@ function reportCapacityRefusal(action: SdkMethod) {
   );
 }
 
+// Same rationale as `reportCapacityRefusal`, for `MAX_OPEN_REQUESTS` rather
+// than the payload maps.
+function reportOpenRequestCapacityRefusal(action: SdkMethod) {
+  console.error('sdk-methods: open-request map at capacity, request refused', {
+    requestId: action.meta.requestId,
+    method: action.type
+  });
+}
+
 export async function handleSdkMethod(
   action: SdkMethod,
   sender: Runtime.MessageSender,
@@ -140,6 +149,21 @@ export async function handleSdkMethod(
           method: 'connect'
         })
       );
+
+      // At `MAX_OPEN_REQUESTS` the reducer refused the write silently; this is
+      // the analogue of the `getPayload(...) == null` check above, for a method
+      // with no capacity map of its own to read back.
+      if (
+        selectRequestStatus(store.getState(), action.meta.requestId) == null
+      ) {
+        reportOpenRequestCapacityRefusal(action);
+
+        return {
+          handled: true,
+          response: sdkMethod.connectResponse(false, action.meta)
+        };
+      }
+
       openWindow(store, {
         windowApp: WindowApp.ConnectToApp,
         searchParams: query,
@@ -178,6 +202,16 @@ export async function handleSdkMethod(
         method: 'switchAccount'
       })
     );
+
+    if (selectRequestStatus(store.getState(), action.meta.requestId) == null) {
+      reportOpenRequestCapacityRefusal(action);
+
+      return {
+        handled: true,
+        response: sdkMethod.switchAccountResponse(false, action.meta)
+      };
+    }
+
     openWindow(store, {
       windowApp: WindowApp.SwitchAccount,
       searchParams: query,
@@ -307,6 +341,19 @@ export async function handleSdkMethod(
         method: 'signMessage'
       })
     );
+
+    if (selectRequestStatus(store.getState(), action.meta.requestId) == null) {
+      reportOpenRequestCapacityRefusal(action);
+
+      return {
+        handled: true,
+        response: sdkMethod.signMessageResponse(
+          { cancelled: true },
+          action.meta
+        )
+      };
+    }
+
     openWindow(store, {
       windowApp: WindowApp.SignatureRequestMessage,
       searchParams: {
@@ -412,6 +459,19 @@ export async function handleSdkMethod(
         method: 'decryptMessage'
       })
     );
+
+    if (selectRequestStatus(store.getState(), action.meta.requestId) == null) {
+      reportOpenRequestCapacityRefusal(action);
+
+      return {
+        handled: true,
+        response: sdkMethod.decryptMessageResponse(
+          { cancelled: true },
+          action.meta
+        )
+      };
+    }
+
     openWindow(store, {
       windowApp: WindowApp.DecryptMessageRequest,
       searchParams: {

--- a/src/background/handlers/sdk-methods.ts
+++ b/src/background/handlers/sdk-methods.ts
@@ -28,9 +28,15 @@ import {
   selectIsAccountConnected,
   selectVaultActiveAccount
 } from '@background/redux/vault/selectors';
-import { windowRequestOpened } from '@background/redux/windowManagement/actions';
+import {
+  windowRequestOpened,
+  windowRequestResponded
+} from '@background/redux/windowManagement/actions';
 import { isStorableRequestId } from '@background/redux/windowManagement/request-map';
-import { selectRequestStatus } from '@background/redux/windowManagement/selectors';
+import {
+  selectOpenRequests,
+  selectRequestStatus
+} from '@background/redux/windowManagement/selectors';
 import { emitSdkEventToActiveTabsWithOrigin } from '@background/utils';
 
 import { SiteNotConnectedError, WalletLockedError } from '@content/sdk-errors';
@@ -69,12 +75,21 @@ function reportCapacityRefusal(action: SdkMethod) {
   );
 }
 
-// Same rationale as `reportCapacityRefusal`, for `MAX_OPEN_REQUESTS` rather
-// than the payload maps.
-function reportOpenRequestCapacityRefusal(action: SdkMethod) {
+// Same LOGGING rationale as `reportCapacityRefusal` (this side is not
+// invisible to the wallet even when refused silently) — but not the same dapp
+// half: only the two payload-bearing refusals (`sign`, `signTypedData`) carry
+// `errorCode`. For the four capless methods the refusal is indistinguishable
+// from an ordinary user decline on the dapp side until WALLET-1436 gives it
+// one too. `openCount` is the count AFTER the refused write — it names how
+// full the map the refusal fired against actually was.
+function reportOpenRequestCapacityRefusal(
+  action: SdkMethod,
+  openCount: number
+) {
   console.error('sdk-methods: open-request map at capacity, request refused', {
     requestId: action.meta.requestId,
-    method: action.type
+    method: action.type,
+    openCount
   });
 }
 
@@ -156,7 +171,10 @@ export async function handleSdkMethod(
       if (
         selectRequestStatus(store.getState(), action.meta.requestId) == null
       ) {
-        reportOpenRequestCapacityRefusal(action);
+        reportOpenRequestCapacityRefusal(
+          action,
+          selectOpenRequests(store.getState()).length
+        );
 
         return {
           handled: true,
@@ -204,7 +222,10 @@ export async function handleSdkMethod(
     );
 
     if (selectRequestStatus(store.getState(), action.meta.requestId) == null) {
-      reportOpenRequestCapacityRefusal(action);
+      reportOpenRequestCapacityRefusal(
+        action,
+        selectOpenRequests(store.getState()).length
+      );
 
       return {
         handled: true,
@@ -311,9 +332,19 @@ export async function handleSdkMethod(
     // the four capless methods above — but the payload above has ALREADY been
     // accepted into the map, so it is stranded here rather than refused; it is
     // reclaimed by `reconcileStalePayloadsSaga` since no descriptor and no
-    // window will ever claim it.
+    // window will ever claim it. `windowRequestResponded` reclaims it
+    // immediately instead: the vault reducer deletes the payload keyed off
+    // this exact action (the WALLET-1418 orphan mechanism, and it is in the
+    // re-encrypt debounce list so the deletion reaches the cipher), and the
+    // windowManagement case no-ops for an id with no open row.
     if (selectRequestStatus(store.getState(), action.meta.requestId) == null) {
-      reportOpenRequestCapacityRefusal(action);
+      reportOpenRequestCapacityRefusal(
+        action,
+        selectOpenRequests(store.getState()).length
+      );
+      store.dispatch(
+        windowRequestResponded({ requestId: action.meta.requestId })
+      );
 
       return {
         handled: true,
@@ -365,7 +396,10 @@ export async function handleSdkMethod(
     );
 
     if (selectRequestStatus(store.getState(), action.meta.requestId) == null) {
-      reportOpenRequestCapacityRefusal(action);
+      reportOpenRequestCapacityRefusal(
+        action,
+        selectOpenRequests(store.getState()).length
+      );
 
       return {
         handled: true,
@@ -449,8 +483,16 @@ export async function handleSdkMethod(
     // Same residual as the deploy branch: the payload above is already
     // accepted, so a refusal here strands it for `reconcileStalePayloadsSaga`
     // to reclaim rather than refusing the payload write itself.
+    // `windowRequestResponded` reclaims it immediately instead — same
+    // mechanism as the `sign` branch above.
     if (selectRequestStatus(store.getState(), action.meta.requestId) == null) {
-      reportOpenRequestCapacityRefusal(action);
+      reportOpenRequestCapacityRefusal(
+        action,
+        selectOpenRequests(store.getState()).length
+      );
+      store.dispatch(
+        windowRequestResponded({ requestId: action.meta.requestId })
+      );
 
       return {
         handled: true,
@@ -506,7 +548,10 @@ export async function handleSdkMethod(
     );
 
     if (selectRequestStatus(store.getState(), action.meta.requestId) == null) {
-      reportOpenRequestCapacityRefusal(action);
+      reportOpenRequestCapacityRefusal(
+        action,
+        selectOpenRequests(store.getState()).length
+      );
 
       return {
         handled: true,

--- a/src/background/redux/windowManagement/reducer.test.ts
+++ b/src/background/redux/windowManagement/reducer.test.ts
@@ -584,11 +584,13 @@ describe('windowManagement requests', () => {
       state = reducer(state, opened('over-cap'));
       state = reducer(state, windowRequestResponded({ requestId: 'r0' }));
 
-      // If the refused write had consumed an ordinal, the next accepted one
-      // would be stamped one past where it should be.
+      // If the refused 'over-cap' write had ALSO consumed an ordinal, the next
+      // accepted one would be stamped one past where it should be. The
+      // `windowRequestResponded` restamp above is the one ordinal genuinely
+      // spent between the loop (0..MAX_OPEN_REQUESTS-1) and this request.
       const accepted = reducer(state, opened('under-cap'));
       expect(accepted.requests['under-cap']).toMatchObject({
-        seq: MAX_OPEN_REQUESTS
+        seq: MAX_OPEN_REQUESTS + 1
       });
     });
 

--- a/src/background/redux/windowManagement/reducer.test.ts
+++ b/src/background/redux/windowManagement/reducer.test.ts
@@ -15,7 +15,11 @@ import {
   windowRequestResponded,
   windowRequestWindowAttached
 } from './actions';
-import { MAX_RESPONDED_TOMBSTONES, reducer } from './reducer';
+import {
+  MAX_OPEN_REQUESTS,
+  MAX_RESPONDED_TOMBSTONES,
+  reducer
+} from './reducer';
 import { WindowManagementState } from './types';
 
 const empty: WindowManagementState = {
@@ -556,6 +560,73 @@ describe('windowManagement requests', () => {
       }
 
       expect(state.requests['still-open']).toMatchObject({ status: 'open' });
+    });
+  });
+
+  describe('the open-request cap', () => {
+    it('refuses a write at the cap and returns state unchanged (same reference)', () => {
+      let state = empty;
+      for (let i = 0; i < MAX_OPEN_REQUESTS; i++) {
+        state = reducer(state, opened(`r${i}`));
+      }
+
+      const next = reducer(state, opened('over-cap'));
+
+      expect(next).toBe(state);
+      expect(next.requests['over-cap']).toBeUndefined();
+    });
+
+    it('consumes no ordinal for a write refused at the cap', () => {
+      let state = empty;
+      for (let i = 0; i < MAX_OPEN_REQUESTS; i++) {
+        state = reducer(state, opened(`r${i}`));
+      }
+      state = reducer(state, opened('over-cap'));
+      state = reducer(state, windowRequestResponded({ requestId: 'r0' }));
+
+      // If the refused write had consumed an ordinal, the next accepted one
+      // would be stamped one past where it should be.
+      const accepted = reducer(state, opened('under-cap'));
+      expect(accepted.requests['under-cap']).toMatchObject({
+        seq: MAX_OPEN_REQUESTS
+      });
+    });
+
+    it('never evicts an open request to make room at the cap either', () => {
+      let state = empty;
+      for (let i = 0; i < MAX_OPEN_REQUESTS; i++) {
+        state = reducer(state, opened(`r${i}`));
+      }
+
+      const next = reducer(state, opened('over-cap'));
+
+      for (let i = 0; i < MAX_OPEN_REQUESTS; i++) {
+        expect(next.requests[`r${i}`]).toMatchObject({ status: 'open' });
+      }
+    });
+
+    it('a completed request frees a slot for a new one', () => {
+      let state = empty;
+      for (let i = 0; i < MAX_OPEN_REQUESTS; i++) {
+        state = reducer(state, opened(`r${i}`));
+      }
+      state = reducer(state, windowRequestResponded({ requestId: 'r0' }));
+
+      const next = reducer(state, opened('fresh'));
+
+      expect(next.requests.fresh).toMatchObject({ status: 'open' });
+    });
+
+    it('tombstones do not count against the open-request cap', () => {
+      let state = empty;
+      for (let i = 0; i < MAX_OPEN_REQUESTS + 10; i++) {
+        state = reducer(state, opened(`t${i}`));
+        state = reducer(state, windowRequestResponded({ requestId: `t${i}` }));
+      }
+
+      const next = reducer(state, opened('still-fits'));
+
+      expect(next.requests['still-fits']).toMatchObject({ status: 'open' });
     });
   });
 });

--- a/src/background/redux/windowManagement/reducer.ts
+++ b/src/background/redux/windowManagement/reducer.ts
@@ -11,7 +11,10 @@ export const MAX_RESPONDED_TOMBSTONES = 50;
 
 // One shared approval window plus the Ledger second window keeps steady-state
 // open-request concurrency at ~1-2; this only needs to bound the 250 ms
-// `CANCEL_GRACE_MS` burst, not any sustained load.
+// `CANCEL_GRACE_MS` burst, not any sustained load. Binding floor: this must
+// stay >= 2 * `MAX_STORED_PAYLOADS` (vault/reducer.ts) — below that, this cap
+// would fire before either payload cap on the sign/signTypedData paths, and
+// the payload already accepted by then is stranded with no window to show it.
 export const MAX_OPEN_REQUESTS = 20;
 
 // Derived from the map rather than kept in a counter field: a counter is state

--- a/src/background/redux/windowManagement/reducer.ts
+++ b/src/background/redux/windowManagement/reducer.ts
@@ -11,10 +11,15 @@ export const MAX_RESPONDED_TOMBSTONES = 50;
 
 // One shared approval window plus the Ledger second window keeps steady-state
 // open-request concurrency at ~1-2; this only needs to bound the 250 ms
-// `CANCEL_GRACE_MS` burst, not any sustained load. Binding floor: this must
+// `CANCEL_GRACE_MS` burst, not any sustained load. Binding floor, scoped to
+// the two payload-bearing methods (`sign`, `signTypedData`) only: this must
 // stay >= 2 * `MAX_STORED_PAYLOADS` (vault/reducer.ts) — below that, this cap
-// would fire before either payload cap on the sign/signTypedData paths, and
-// the payload already accepted by then is stranded with no window to show it.
+// would fire before either payload cap on those two paths, and the payload
+// already accepted by then is stranded with no window to show it. The four
+// capless methods (`connect`, `switchAccount`, `signMessage`,
+// `decryptMessage`) consume open slots from this SAME cap too, but have no
+// payload map of their own to strand — this floor's quantifier says nothing
+// about them.
 export const MAX_OPEN_REQUESTS = 20;
 
 // Derived from the map rather than kept in a counter field: a counter is state

--- a/src/background/redux/windowManagement/reducer.ts
+++ b/src/background/redux/windowManagement/reducer.ts
@@ -9,6 +9,11 @@ import { CancellableMethod, WindowManagementState } from './types';
 // background page never restarts.
 export const MAX_RESPONDED_TOMBSTONES = 50;
 
+// One shared approval window plus the Ledger second window keeps steady-state
+// open-request concurrency at ~1-2; this only needs to bound the 250 ms
+// `CANCEL_GRACE_MS` burst, not any sustained load.
+export const MAX_OPEN_REQUESTS = 20;
+
 // Derived from the map rather than kept in a counter field: a counter is state
 // the session record does not carry, so after a service-worker restart it would
 // resume at zero and re-issue ordinals the restored map still holds.
@@ -65,6 +70,17 @@ const slice = createSlice({
         !isStorableRequestId(action.payload.requestId) ||
         getRequest(state.requests, action.payload.requestId) != null
       ) {
+        return state;
+      }
+
+      // At the cap, refuse the write rather than evict — "open requests are
+      // never evicted" is the standing invariant, and a refused write must
+      // consume no ordinal (below `nextSeq` is never reached).
+      const openCount = Object.values(state.requests).filter(
+        request => request?.status === 'open'
+      ).length;
+
+      if (openCount >= MAX_OPEN_REQUESTS) {
         return state;
       }
 

--- a/src/background/redux/windowManagement/session-store.test.ts
+++ b/src/background/redux/windowManagement/session-store.test.ts
@@ -1,5 +1,6 @@
-import { MAX_RESPONDED_TOMBSTONES } from './reducer';
+import { MAX_OPEN_REQUESTS, MAX_RESPONDED_TOMBSTONES } from './reducer';
 import {
+  MAX_SESSION_ROWS,
   REQUEST_SESSION_KEY,
   SessionRecord,
   clearRequestSession,
@@ -490,6 +491,13 @@ describe('session-store — write path', () => {
 
     expect(sessionSet).toHaveBeenCalledTimes(2);
     expect(lastWrittenRecord().windowId).toBe(2);
+  });
+
+  it('bounds the write cap to exactly what the two request states can hold', () => {
+    // A row is either a tombstone or an open request — no third state — so the
+    // sum of their individual caps is the only correct figure, not headroom
+    // picked separately from the reducer's own open-request bound.
+    expect(MAX_SESSION_ROWS).toBe(MAX_RESPONDED_TOMBSTONES + MAX_OPEN_REQUESTS);
   });
 
   it('caps rows on the write side, dropping tombstones before open rows and oldest first', async () => {

--- a/src/background/redux/windowManagement/session-store.test.ts
+++ b/src/background/redux/windowManagement/session-store.test.ts
@@ -1,3 +1,5 @@
+import { MAX_STORED_PAYLOADS } from '@background/redux/vault/reducer';
+
 import { MAX_OPEN_REQUESTS, MAX_RESPONDED_TOMBSTONES } from './reducer';
 import {
   MAX_SESSION_ROWS,
@@ -498,6 +500,13 @@ describe('session-store — write path', () => {
     // sum of their individual caps is the only correct figure, not headroom
     // picked separately from the reducer's own open-request bound.
     expect(MAX_SESSION_ROWS).toBe(MAX_RESPONDED_TOMBSTONES + MAX_OPEN_REQUESTS);
+  });
+
+  it('keeps the open-request cap above the binding floor set by the payload caps', () => {
+    // Below `2 * MAX_STORED_PAYLOADS` the open-request cap would fire before
+    // either payload cap on the sign/signTypedData paths, stranding an already
+    // -accepted payload with no window ever opened for it.
+    expect(MAX_OPEN_REQUESTS).toBeGreaterThanOrEqual(2 * MAX_STORED_PAYLOADS);
   });
 
   it('caps rows on the write side, dropping tombstones before open rows and oldest first', async () => {

--- a/src/background/redux/windowManagement/session-store.test.ts
+++ b/src/background/redux/windowManagement/session-store.test.ts
@@ -2,7 +2,6 @@ import { MAX_STORED_PAYLOADS } from '@background/redux/vault/reducer';
 
 import { MAX_OPEN_REQUESTS, MAX_RESPONDED_TOMBSTONES } from './reducer';
 import {
-  MAX_SESSION_ROWS,
   REQUEST_SESSION_KEY,
   SessionRecord,
   clearRequestSession,
@@ -495,17 +494,33 @@ describe('session-store — write path', () => {
     expect(lastWrittenRecord().windowId).toBe(2);
   });
 
-  it('bounds the write cap to exactly what the two request states can hold', () => {
-    // A row is either a tombstone or an open request — no third state — so the
-    // sum of their individual caps is the only correct figure, not headroom
-    // picked separately from the reducer's own open-request bound.
-    expect(MAX_SESSION_ROWS).toBe(MAX_RESPONDED_TOMBSTONES + MAX_OPEN_REQUESTS);
+  it('drops nothing at exactly the combined cap: MAX_RESPONDED_TOMBSTONES tombstones plus MAX_OPEN_REQUESTS open rows', async () => {
+    // The identity `MAX_SESSION_ROWS === MAX_RESPONDED_TOMBSTONES +
+    // MAX_OPEN_REQUESTS` restates the definition character-for-character and
+    // proves nothing about the write-side cap itself. This instead builds
+    // the actual boundary case — a row is either a tombstone or an open
+    // request, no third state — and asserts the write path keeps every one
+    // of them, exactly at the cap.
+    const requests: Record<string, Request> = {};
+    for (let seq = 0; seq < MAX_RESPONDED_TOMBSTONES; seq += 1) {
+      requests[`tombstone-${seq}`] = { status: 'responded', seq } as Request;
+    }
+    for (let seq = 0; seq < MAX_OPEN_REQUESTS; seq += 1) {
+      requests[`open-${seq}`] = openRow({ seq }) as Request;
+    }
+
+    await writeRequestSession({ requests, windowId: null });
+
+    expect(lastWrittenRecord().requests).toEqual(requests);
   });
 
-  it('keeps the open-request cap above the binding floor set by the payload caps', () => {
+  it('keeps the open-request cap above the binding floor set by the payload caps (sign/signTypedData only)', () => {
     // Below `2 * MAX_STORED_PAYLOADS` the open-request cap would fire before
-    // either payload cap on the sign/signTypedData paths, stranding an already
-    // -accepted payload with no window ever opened for it.
+    // either payload cap on the sign/signTypedData paths specifically,
+    // stranding an already-accepted payload with no window ever opened for
+    // it. The four capless methods share this same cap but have no payload
+    // map to strand, so this floor says nothing about them — kept as a
+    // tripwire for the two methods it actually bounds.
     expect(MAX_OPEN_REQUESTS).toBeGreaterThanOrEqual(2 * MAX_STORED_PAYLOADS);
   });
 

--- a/src/background/redux/windowManagement/session-store.ts
+++ b/src/background/redux/windowManagement/session-store.ts
@@ -4,7 +4,7 @@ import { isEphemeralBackgroundBuild } from '@src/utils';
 
 import { redactUrlQuery } from '@background/redact-url-query';
 
-import { MAX_RESPONDED_TOMBSTONES } from './reducer';
+import { MAX_OPEN_REQUESTS, MAX_RESPONDED_TOMBSTONES } from './reducer';
 import { isStorableRequestId } from './request-map';
 import { CancellableMethod, Request, WindowManagementState } from './types';
 
@@ -21,13 +21,14 @@ export type SessionRecord = {
   windowId: number | null;
 };
 
-// Write-side row cap: the reducer's tombstone bound plus headroom for the open
-// rows that can exist alongside them. The read stays uncapped, so no drop order
-// has to be defined there and key hoisting can never decide which rows survive.
-// Exported so the startup sweep can bound its own per-wake work to the same
-// figure (see sweep-orphaned-requests.ts) — the hydrated snapshot it reads can
-// never hold more open rows than this in the first place.
-export const MAX_SESSION_ROWS = MAX_RESPONDED_TOMBSTONES + 20;
+// Write-side row cap: the reducer's tombstone bound plus its open-request bound
+// — the two are the only ways a row can exist, so their sum is the only correct
+// figure, not headroom picked separately. The read stays uncapped, so no drop
+// order has to be defined there and key hoisting can never decide which rows
+// survive. Exported so the startup sweep can bound its own per-wake work to the
+// same figure (see sweep-orphaned-requests.ts) — the hydrated snapshot it reads
+// can never hold more open rows than this in the first place.
+export const MAX_SESSION_ROWS = MAX_RESPONDED_TOMBSTONES + MAX_OPEN_REQUESTS;
 
 const MAX_ORIGIN_LENGTH = 256;
 const MAX_WINDOW_IDS = 16;

--- a/src/content/sdk.ts
+++ b/src/content/sdk.ts
@@ -169,7 +169,7 @@ export const CasperWalletProvider = (options?: CasperWalletProviderOptions) => {
   return {
     /**
      * Request the connect interface with the Casper Wallet extension. Will not show UI for already connected accounts and return true immediately.
-     * @returns `true` value when connection request is accepted by the user or when account is already connected, `false` otherwise.
+     * @returns `true` value when connection request is accepted by the user or when account is already connected, `false` otherwise — including when the wallet refused for its own open-request capacity, currently indistinguishable from a user decline (WALLET-1436 will make it explicit).
      */
     requestConnection(): Promise<boolean> {
       return fetchFromBackground<
@@ -186,7 +186,7 @@ export const CasperWalletProvider = (options?: CasperWalletProviderOptions) => {
     },
     /**
      * Request the switch account interface with the Casper Wallet extension
-     * @returns `true` value when successfully switched account, `false` otherwise.
+     * @returns `true` value when successfully switched account, `false` otherwise — including when the wallet refused for its own open-request capacity, currently indistinguishable from a user decline (WALLET-1436 will make it explicit).
      */
     requestSwitchAccount(): Promise<boolean> {
       return fetchFromBackground<


### PR DESCRIPTION
## Description

Hardening on top of the sweep. `sign` and `signTypedData` already refuse at `MAX_STORED_PAYLOADS = 10` before registering a request; `connect`, `switchAccount`, `signMessage` and `decryptMessage` had **no cap at all** — supersede was the only brake, and `CANCEL_GRACE_MS = 250` lets a burst register everything first. With the mirror persisting open rows, an unbounded burst would also be a session-storage write-amplification vector.

The sweep (previous PR) is the prerequisite that makes a cap safe: without it, a pinned-open row would consume a cap slot for the whole browser session, turning frozen states into a slow denial-of-approvals.

### What changed

- `MAX_OPEN_REQUESTS` beside `MAX_RESPONDED_TOMBSTONES` in `windowManagement/reducer.ts`. Steady-state concurrency is ~1–2 (one shared approval window plus the Ledger second window) — the cap only bounds the 250 ms burst.
- `windowRequestOpened` refuses the write at the cap and returns `state` unchanged (reference-identical). Open requests are never evicted, and a refused write consumes no ordinal.
- A silent reducer refusal produces no response by itself, so each of the four capless handlers gets an explicit post-dispatch re-read — the analogue of the existing `getPayload(...) == null` check. On refusal the dapp receives that method's **existing negative shape** and `openWindow` is never called.
- **Cap only — no `errorCode`.** Four of the six response shapes cannot carry one (`connectResponse`/`switchAccountResponse` are bare booleans; `signMessageResponse`/`decryptMessageResponse` are `{cancelled} | {…}`), and their `*Error` creators lack `error: true`, so the SDK would _resolve_ the dapp promise instead of rejecting (the WALLET-1346 masking defect). Widening the wire shapes is a separate ticket.
- The mirror's write cap is tightened from an undocumented headroom to the enforced relation `MAX_SESSION_ROWS = MAX_RESPONDED_TOMBSTONES + MAX_OPEN_REQUESTS`, with a test asserting it.
- `sign`/`signTypedData` (second commit): the same post-dispatch re-read applies to them too — at the cap they refuse with their own `MAX_STORED_PAYLOADS`-style response (`errorCode: tooManyPendingRequests`, a real error channel) and never open a window. Their payload actions are dispatched before `windowRequestOpened`, so on refusal the branch also dispatches `windowRequestResponded({requestId})` — the WALLET-1418 orphan mechanism the vault reducer already keys off — reclaiming the stored payload immediately (the `windowManagement` case no-ops for an id with no open row). Without this, ~20 capless opens plus 10 refused signs would pin every payload slot and kill signing for **all** origins until the next unlock (review finding). The `MAX_STORED_PAYLOADS` refusal itself fires earlier and is byte-unchanged.
- The four capless methods still answer a cap refusal with their negative shapes only — an explicit `errorCode` for them is [WALLET-1436](https://make-software.atlassian.net/browse/WALLET-1436) (wire-shape change + the WALLET-1346 masking fix).

  On the number itself: `MAX_OPEN_REQUESTS = 20` is not arbitrary — the vault already admits `2 × MAX_STORED_PAYLOADS` (deploys + EIP-712 maps, 10 each) concurrently open sign-family requests, so any smaller cap would fire _before_ the payload caps in the all-sign-family case. That floor is necessary, not sufficient — the four capless methods consume open slots outside its quantifier (review finding; the comment and test are scoped accordingly).

### Verification

- `npx jest src/background/` — 936 tests pass; `npx tsc --noEmit` clean; eslint/prettier clean.
- `windowManagement/reducer.ts` stays at 100/100/100/100; handlers/sagas floors hold.
- Pinned by tests: at the cap the write is refused and state returns reference-identical; each refusal produces the method's negative response and no `openWindow` call; a completed request frees a slot; `sign`'s existing refusal still fires first; the `MAX_SESSION_ROWS` relation.

## Linked tickets

[WALLET-1419](https://make-software.atlassian.net/browse/WALLET-1419)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [x] If the PR adds any new text to the UI, make sure they are localized — no UI text added

- [x] Include a screenshot or recording if implementing significant UI or user flow change — background-only, no UI change

- [ ] When this PR affects architecture changes wait for review from Dmytro before merging


[WALLET-1419]: https://make-software.atlassian.net/browse/WALLET-1419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[WALLET-1436]: https://make-software.atlassian.net/browse/WALLET-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
