### PR TITLE
ci(dependabot): weekly grouped updates with release cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,18 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+    # One combined PR for all minor+patch bumps; majors stay individual
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+    # Wait out the window in which compromised releases are typically
+    # detected and yanked. Security updates from Dependabot alerts bypass this.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
     target-branch: "develop"
     # Specify labels for npm pull requests
     labels:


### PR DESCRIPTION
Dependabot currently opens up to five single-package PRs every day. This changes the update policy for npm dependencies:

- Check weekly (Mondays) instead of daily
- Group all minor and patch bumps into one combined PR; majors stay individual
- Add a release cooldown (7 days default, 14 for majors) so freshly published versions are not proposed before the window in which compromised releases are typically detected and yanked. Security updates driven by Dependabot alerts bypass the cooldown.

Existing open single-package Dependabot PRs will not regroup themselves — the next scheduled run recreates them as one grouped PR, so the current stragglers can simply be closed.