### PR TITLE
fix(background): treat about:blank as an unsettled tab url in the attach probe

### DIFF
--- a/src/background/handlers/attach-window-to-request.test.ts
+++ b/src/background/handlers/attach-window-to-request.test.ts
@@ -99,6 +99,20 @@ describe('a window that is not ours must not own a request', () => {
     expect(cancelMock).not.toHaveBeenCalled();
   });
 
+  it('does not undo the attach when the tab is still at about:blank', async () => {
+    // Firefox has no `pendingUrl` and reports a freshly created window's tab
+    // as `about:blank` until the navigation commits, so on a cold open there
+    // the probe lands on exactly this shape (WALLET-1439). Repairing on it
+    // cancelled the request whose window was on screen.
+    getMock.mockResolvedValue({ id: 7, tabs: [{ url: 'about:blank' }] });
+    const { store } = makeStore();
+
+    attachWindowToRequest(store, 'r1', 7);
+    await flush();
+
+    expect(cancelMock).not.toHaveBeenCalled();
+  });
+
   it('warns when our window carries no requestId at all', async () => {
     // Without this the ownership check establishes "one of our windows" and
     // says nothing about "the window showing THIS request" — and the two are

--- a/src/background/handlers/attach-window-to-request.ts
+++ b/src/background/handlers/attach-window-to-request.ts
@@ -67,7 +67,11 @@ export function attachWindowToRequest(
       const tab = browserWindow.tabs?.[0];
       const tabUrl = tab?.url ?? tab?.pendingUrl;
 
-      if (tabUrl == null || tabUrl === '') {
+      // Every not-yet-settled shape, per browser: Chrome reports a navigating
+      // tab as `url: ''` (the target in `pendingUrl`); Firefox has no
+      // `pendingUrl` and reports `about:blank` until the navigation commits,
+      // which is what a freshly created window's tab shows when probed.
+      if (tabUrl == null || tabUrl === '' || tabUrl === 'about:blank') {
         return;
       }
 


### PR DESCRIPTION
## Description

On Firefox the sign approval window opens but never renders the request — the page sits on its skeleton and the dapp waits forever ([WALLET-1439](https://make-software.atlassian.net/browse/WALLET-1439)). Chrome is unaffected.

The cause is the attach-time ownership probe in `attachWindowToRequest`. Once `windows.create` resolves, the probe reads the new window's first tab and repairs the attach — i.e. cancels the request — when the tab's URL provably is not an extension page. In front of that sits a guard whose whole job is to let inconclusive shapes pass untouched, because repairing on one cancels an approval that is on screen. That guard only knew Chrome's unsettled shape: a navigating tab reported as `url: ''` with the real target in `pendingUrl`.

Firefox has no `pendingUrl` at all, and reports a freshly created window's tab as `about:blank` until the navigation commits. On a cold popup load that commit loses the race with the probe, so `about:blank` fell through to `!tabUrl.startsWith(runtime.getURL(''))`, the wallet's own window was read as foreign, and the request it was about to display was cancelled. Cancelling deletes the stored signing payload — so the popup already on screen had nothing left to render, which is the stuck skeleton in the report.

### What changed

- `about:blank` joins `null` and `''` as an unsettled tab URL in the probe's guard, and the comment there now enumerates the shapes per browser instead of describing Chrome's as if it were universal.
- A regression test for the Firefox shape (`{ tabs: [{ url: 'about:blank' }] }`) asserting the probe does not cancel.

This only widens the *inconclusive* set, not the accept set — the file's existing asymmetry (a provable verdict repairs, anything inconclusive does not) is what makes that safe. Detection is not weakened: a window that genuinely is not ours settles on a non-extension URL, and the foreign-window case that this arm exists for is still caught. `about:blank` was never a verdict in the first place; it was being treated as one.

### Verification

- `npm run ci-check` — format:check, lint, tsc, knip and the full jest suite with coverage, all green (run by the `pre-push` hook).
- No UI verification: the change is background-only, and the symptom reproduces on Firefox, which the extension's `agent-browser` harness does not drive — the Chrome path this fix does not touch is the one it could exercise.

## Linked tickets

[WALLET-1439](https://make-software.atlassian.net/browse/WALLET-1439)

## Checklist

- [x] Make sure this PR title follows semantic release conventions: <https://semantic-release.gitbook.io/semantic-release/#commit-message-format>

- [x] If the PR adds any new text to the UI, make sure they are localized — no UI text added

- [x] Include a screenshot or recording if implementing significant UI or user flow change — background-only, no UI change

- [ ] When this PR affects architecture changes wait for review from Dmytro before merging


[WALLET-1439]: https://make-software.atlassian.net/browse/WALLET-1439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WALLET-1439]: https://make-software.atlassian.net/browse/WALLET-1439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ