### PR TITLE
test(e2e): match the Tokens tab exactly on the Activity path

### DIFF
--- a/e2e-tests/popup/common/home-tabs.spec.ts
+++ b/e2e-tests/popup/common/home-tabs.spec.ts
@@ -52,7 +52,9 @@ popup.describe('Popup UI: Home tabs', () => {
 
       await popupExpect(popupPage.getByTitle('Activity')).toBeVisible();
 
-      await popupPage.getByText('Tokens').click();
+      // Matched exactly: the Activity list this tab sits above renders deploy
+      // names like `swap_exact_cspr_for_tokens`, which a substring match hits.
+      await popupPage.getByText('Tokens', { exact: true }).click();
       await popupPage.getByText('Casper', { exact: true }).first().click();
       await popupExpect(
         popupPage.getByRole('heading', { name: 'Token' })


### PR DESCRIPTION
`e2e-popup-tests` fails deterministically on `develop` and on every branch cut from it:

```
Error: locator.click: Error: strict mode violation:
getByText('Tokens') resolved to 5 elements:
  1) <span type="captionRegular">Tokens</span>
  2) swap_exact_cspr_for_tokens
  3) swap_exact_tokens_for_cspr
  ...
at e2e-tests/popup/common/home-tabs.spec.ts:55
```

`getByText` with a plain string matches case-insensitive **substrings**. The failing click happens while the Activity tab is open, and the test account's deploy history on testnet now contains swap deploys whose names end in `_for_tokens` / `_tokens_for_`. The tab label and four deploy plates all match, so Playwright refuses the click.

No code change caused this — the on-chain data behind the test account changed. It reproduces on all three retries.

Matching the tab label exactly resolves it. Only this call site is affected: deploy plates render on the Activity tab alone, so the sibling tab clicks in this spec, which are reached from Tokens or NFTs, cannot collide with deploy names.

Worth noting separately: this spec asserts against live testnet activity, so it stays sensitive to whatever deploys land on that account.
